### PR TITLE
Update GCP staging configuration: add a step to set the termination g…

### DIFF
--- a/.github/workflows/staging-gcp.yaml
+++ b/.github/workflows/staging-gcp.yaml
@@ -67,5 +67,11 @@ jobs:
             --max-instances=10
             --concurrency=3
             --timeout=3600
-            --termination-grace-period=300
             --set-env-vars=ENV=staging,INFISICAL_TOKEN=${{ secrets.INFISICAL_TOKEN }},INFISICAL_PROJECT_ID=${{ secrets.INFISICAL_PROJECT_ID }}
+
+      - name: Set termination grace period
+        run: |
+          gcloud beta run services update ${{ env.SERVICE_NAME }} \
+            --region=${{ env.GCP_REGION }} \
+            --termination-grace-period=300 || \
+          echo "Warning: Could not set termination grace period (beta feature)"


### PR DESCRIPTION
…race period to 300 seconds, ensuring proper resource cleanup during service updates.