### PR TITLE
Use Geist Sans app-wide; clean stale MUI references in docs

### DIFF
--- a/frontend/.claude/skills/create-component/SKILL.md
+++ b/frontend/.claude/skills/create-component/SKILL.md
@@ -104,7 +104,7 @@ If any of the above checks fail, read and follow the setup guide:
 - Installing className utilities (`clsx`, `tailwind-merge`, `class-variance-authority`)
 - Creating the `cn()` utility in `src/lib/utils.ts` (clsx + tailwind-merge)
 - Initializing shadcn/ui with the project's theme colors
-- Configuring CSS variables that match the existing MUI theme
+- Configuring CSS variables that match the project's design tokens
 - Updating `globals.css` with theme tokens
 
 After running setup, re-verify all checks in 2a–2d pass.
@@ -121,8 +121,8 @@ Read ALL reference files before generating any component. Do not skip any.
 
 Also read the project theme files to ensure consistency:
 
-- `src/lib/theme.ts` — centralized theme constants (colors, semantic aliases, presets)
-- `src/utils/theme.ts` — MUI theme with custom tokens (source of truth for color values)
+- `src/constants/theme.ts` — centralized theme constants (semantic color aliases, component presets)
+- `src/app/globals.css` — Tailwind theme tokens and CSS variables (source of truth for color values)
 
 ---
 
@@ -318,7 +318,7 @@ className = 'rounded-2xl'; // 12px (--radius-2xl)
 
 ```typescript
 className = 'shadow-xs'; // Subtle — inputs
-className = 'shadow-sm'; // Cards (MUI Card default)
+className = 'shadow-sm'; // Cards (default elevation)
 className = 'shadow-md'; // Elevated panels
 className = 'shadow-lg'; // Dialogs, dropdowns
 ```
@@ -326,7 +326,7 @@ className = 'shadow-lg'; // Dialogs, dropdowns
 **Spacing follows Tailwind defaults** (4px base unit):
 
 ```typescript
-className = 'p-2'; // 8px  (MUI button padding)
+className = 'p-2'; // 8px  (default button padding)
 className = 'px-4'; // 16px
 className = 'gap-2'; // 8px
 className = 'h-[42px]'; // 42px (project button height)
@@ -335,11 +335,11 @@ className = 'h-[42px]'; // 42px (project button height)
 ### 6d. Styling rules
 
 1. **Use `cn()` for ALL className composition** — combines `clsx` + `tailwind-merge`
-2. **Use Tailwind utility classes** — not inline styles or `sx` prop
+2. **Use Tailwind utility classes** — not inline styles
 3. **Use CSS variables for theme colors** — not hardcoded hex values
 4. **Support `className` prop on every component** — allows consumer overrides
 5. **Use `cva` (class-variance-authority)** for components with multiple variants
-6. **Never mix MUI `sx` prop with Tailwind** — pick one per component (Tailwind for new components)
+6. **No CSS-in-JS** — the project is Tailwind/shadcn only; do not introduce `@emotion`, `styled-components`, or `@mui/*`
 
 ### 6d-1. `cn()` usage patterns (MUST follow)
 
@@ -641,10 +641,10 @@ After presenting the summary, ask:
 - **Shared components docs**: After creating or changing any shared component, update `frontend/docs/shared-components.md` (props table + example + exports list). This doc is the single reference for shared UI and reduces token usage.
 - **Exports**: Both named and default export on every component
 - **TypeScript**: Use `interface` over `type` for props. Use `React.FC<Props>` pattern
-- **No MUI mixing**: New shared components use shadcn/Tailwind exclusively. Do not import from `@mui/material`
-- **Theme imports**: Always import `presets` and `semantic` from `@/lib/theme` — use presets for standard patterns (buttons, inputs, cards, badges) and semantic for intent-based one-off styling
-- **Theme consistency**: Always use palette Tailwind classes that reference CSS variables (`bg-purple-500`, `text-gray-800`, `border-slate-200`) — never hardcode hex colors
+- **shadcn/Tailwind only**: All shared components use shadcn/Tailwind exclusively. Do not introduce `@mui/*`, `@emotion/*`, or `styled-components`
+- **Theme imports**: Always import `presets` and `semantic` from `@/constants/theme` — use presets for standard patterns (buttons, inputs, cards, badges) and semantic for intent-based one-off styling
+- **Theme consistency**: Always use semantic Tailwind classes that reference CSS variables (`bg-primary`, `text-foreground`, `border-border`) — never hardcode hex colors
 - **Accessibility**: Every interactive element must be keyboard-accessible with proper ARIA attributes
-- **Icons**: Use `lucide-react` — do not use `@mui/icons-material` in shadcn components
+- **Icons**: Use `lucide-react` for everything; `src/components/icons/` is reserved for brand marks
 - **Responsive**: Use Tailwind responsive prefixes (`sm:`, `md:`, `lg:`) for responsive behavior
 - **Dark mode ready**: All colors flow through CSS variables in `globals.css` — to add dark mode, add a `.dark` variant in globals and the entire app updates automatically

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -311,13 +311,13 @@ Applies **performance-checklist.md** in full across all eight sub-areas:
 | Sub-area                | Key signals for this project                                                                                                                       |
 | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | React Rendering         | Jotai `useAtom` subscriptions — subscribe only to the atom slice needed; avoid subscribing to large atoms just to read one field                   |
-| Next.js & SSR           | ThemeRegistry uses Emotion SSR — do not add additional style injection that conflicts; keep Server Components free of `useTheme()`                 |
-| Bundle & Code Splitting | MUI is tree-shaken by default — always import from `@mui/material/Button` not `@mui/material`; use `next/dynamic` for heavy form tabs              |
+| Next.js & SSR           | Keep Server Components free of client-only hooks; use `'use client'` at the lowest level needed                                                    |
+| Bundle & Code Splitting | Prefer shadcn/Tailwind primitives over heavy component libraries; use `next/dynamic` for heavy form tabs                                           |
 | Network & API           | All API calls go through `src/services/` → `src/utils/axios.ts`; verify no N+1 patterns in Jotai write atoms that loop over IDs                    |
 | Core Web Vitals         | LCP, INP, CLS — check `next/image` usage, font loading via `next/font`, and that Jotai atom loads do not cause layout shifts                       |
 | Memory Management       | Write atoms that start polling or timers must expose a cleanup; `useEffect` in components must clean up axios calls with `AbortController`         |
 | State Management        | Jotai `loadable` is used for async atoms — ensure loading/error/data states are all handled in UI; do not access `.data` without checking `.state` |
-| Asset & CSS             | MUI `sx` prop with object literals creates new references each render — extract static `sx` objects outside the component or use `styled()`        |
+| Asset & CSS             | Prefer Tailwind utility classes over inline style objects; extract shared variants with `cva` or shared component presets                          |
 
 #### 7. Code Quality
 
@@ -333,8 +333,8 @@ Applies **code-quality-checklist.md** in full — error handling, TypeScript qua
 - Interactive `div`/`span` with `onClick` → use `<button>` or add `role` + keyboard handler
 - `<img>` without `alt`; form inputs without `<label>` or `aria-label`
 - Heading hierarchy skipped; missing `aria-live` on toasts / alerts
-- Focus not trapped in MUI `Dialog` / `Drawer` (MUI handles this by default — verify it is not disabled)
-- **This project**: MUI components are accessible by default — flag any prop that overrides this (e.g., `disablePortal`, `disableEnforceFocus` on dialogs)
+- Focus not trapped in dialog/drawer components — Radix primitives (used by shadcn) handle this by default; verify any custom modal traps focus and restores it on close
+- **This project**: prefer Radix/shadcn primitives for any new dialog, drawer, popover, or menu — they ship correct ARIA, keyboard, and focus behavior out of the box
 
 #### 9. Dead Code / Removal Candidates
 
@@ -411,7 +411,7 @@ Write-only atoms (e.g., `atom(null, async (_get, set, payload) => {...})`) are t
 
 **Authentication**: Firebase is used alongside JWT. Auth state is persisted in cookies (`tone_access_token`, `org_tenant_id`, `login_data`). Constants for cookie key names are in `src/constants/index.ts`.
 
-**UI**: Material UI v6 with a custom theme defined in `src/utils/theme.ts`. Primary color is `#8b5cf6` (purple). The theme is provided via `src/components/ThemeRegistry.tsx` which handles MUI + Emotion SSR setup for Next.js. Use `useTheme()` to access theme values in components. **Direction**: Prefer **shadcn** (`src/components/ui/`) and **Tailwind** for new UI; use **lucide-react** or `src/components/icons/` (e.g. brand icons) instead of `@mui/icons-material`. MUI removal is planned; see `.claude/rules.md` §5.
+**UI**: shadcn/ui primitives in `src/components/ui/` styled with Tailwind v4 and theme tokens from `src/app/globals.css` (CSS variables for color, radius, etc.). The root font is **Geist Sans** (loaded via `next/font` in `src/app/layout.tsx`, exposed as `--font-geist-sans` and bound to Tailwind's `font-sans`); `font-mono` resolves to Geist Mono. Dark mode is handled by `next-themes`. Use **lucide-react** for icons (or `src/components/icons/` for brand marks). The codebase is MUI-free — do not introduce `@mui/*` or `@emotion/*` packages.
 
 **Shared components**: `src/components/shared/` holds reusable form/UI pieces (TextInput, CustomButton, Form, CheckboxField, RadioGroupField, SelectInput, TextAreaField, CustomLink). Each form component is **unified** — passing a `control` prop activates RHF `Controller` integration automatically (no separate `Form*` wrapper needed). Component prop types are defined in `src/types/components.ts`. To understand or use them without reading each file, read **`docs/shared-components.md`** (single reference, lower token usage). When adding or changing a shared component, update that doc.
 

--- a/frontend/src/app/(auth)/forgot-password/page.tsx
+++ b/frontend/src/app/(auth)/forgot-password/page.tsx
@@ -47,7 +47,7 @@ export default function ForgotPasswordPage() {
 
   return (
     <div className="animate-page">
-      <h2 className="font-display text-[28px] font-semibold tracking-tight">Reset password</h2>
+      <h2 className="text-[28px] font-semibold tracking-tight">Reset password</h2>
       <p className="mt-2 text-sm text-muted-foreground">
         Enter your email and we&apos;ll send you a reset link
       </p>

--- a/frontend/src/app/(auth)/layout.tsx
+++ b/frontend/src/app/(auth)/layout.tsx
@@ -121,7 +121,7 @@ function BrandedPanel() {
           visible: { transition: { staggerChildren: 0.12, delayChildren: 0.3 } },
         }}
       >
-        <h1 className="font-display text-[clamp(2rem,4vw,3.25rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white">
+        <h1 className="text-[clamp(2rem,4vw,3.25rem)] font-semibold leading-[1.05] tracking-[-0.02em] text-white">
           <motion.span
             className="block text-white"
             variants={{
@@ -357,7 +357,7 @@ function StatCard({ stat }: { stat: (typeof STATS)[number] }) {
         <stat.icon className="h-3.5 w-3.5 text-violet-200" />
       </div>
       <span
-        className="font-display text-[22px] font-semibold leading-none tracking-tight text-white"
+        className="text-[22px] font-semibold leading-none tracking-tight text-white"
         style={{ transform: 'translateZ(30px)' }}
       >
         {stat.value}

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -66,7 +66,7 @@ function LoginPageInner() {
   return (
     <>
       <motion.div className="mb-8" variants={fadeUp}>
-        <h2 className="font-display text-[28px] font-semibold tracking-tight">Welcome back</h2>
+        <h2 className="text-[28px] font-semibold tracking-tight">Welcome back</h2>
         <p className="mt-2 text-sm text-muted-foreground">
           Enter your credentials to access your account
         </p>

--- a/frontend/src/app/(auth)/reset-password/page.tsx
+++ b/frontend/src/app/(auth)/reset-password/page.tsx
@@ -61,7 +61,7 @@ function ResetPasswordContent() {
 
   return (
     <div className="animate-page">
-      <h2 className="font-display text-[28px] font-semibold tracking-tight">Set new password</h2>
+      <h2 className="text-[28px] font-semibold tracking-tight">Set new password</h2>
       <p className="mt-2 text-sm text-muted-foreground">Enter your new password below</p>
       <Form handleSubmit={handleSubmit} onSubmit={onSubmit} className="mt-6">
         <TextInput

--- a/frontend/src/app/(auth)/signup/page.tsx
+++ b/frontend/src/app/(auth)/signup/page.tsx
@@ -61,9 +61,7 @@ export default function SignupPage() {
   return (
     <div className="animate-page">
       <div className="mb-8">
-        <h2 className="font-display text-[28px] font-semibold tracking-tight">
-          Create your account
-        </h2>
+        <h2 className="text-[28px] font-semibold tracking-tight">Create your account</h2>
         <p className="mt-2 text-sm text-muted-foreground">
           Start building AI voice agents in minutes
         </p>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3,7 +3,6 @@
 @theme inline {
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-  --font-display: var(--font-display);
 
   --color-background: hsl(var(--background));
   --color-foreground: hsl(var(--foreground));

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,15 +1,8 @@
 import type { Metadata } from 'next';
 import { GeistSans } from 'geist/font/sans';
 import { GeistMono } from 'geist/font/mono';
-import { Bricolage_Grotesque } from 'next/font/google';
 import './globals.css';
 import { Providers } from './providers';
-
-const bricolage = Bricolage_Grotesque({
-  subsets: ['latin'],
-  variable: '--font-display',
-  display: 'swap',
-});
 
 export const metadata: Metadata = {
   title: 'Tone — AI Voice Agent Builder',
@@ -26,9 +19,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body
-        className={`${GeistSans.variable} ${GeistMono.variable} ${bricolage.variable} font-sans antialiased`}
-      >
+      <body className={`${GeistSans.variable} ${GeistMono.variable} font-sans antialiased`}>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/frontend/src/components/organizations/OrganizationListPage.tsx
+++ b/frontend/src/components/organizations/OrganizationListPage.tsx
@@ -44,7 +44,7 @@ function StatChip({ label, value, icon: Icon, accent }: StatChipProps) {
         <Icon className="h-4 w-4" />
       </div>
       <div className="leading-tight">
-        <p className="font-display text-[20px] font-semibold tracking-tight">{value}</p>
+        <p className="text-[20px] font-semibold tracking-tight">{value}</p>
         <p className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">{label}</p>
       </div>
     </div>
@@ -171,9 +171,7 @@ const OrganizationListPage: React.FC = () => {
         transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
       >
         <div>
-          <h1 className="font-display text-2xl font-semibold tracking-tight text-foreground">
-            Organizations
-          </h1>
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground">Organizations</h1>
           <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">
             Manage your workspaces and team collaboration
           </p>

--- a/frontend/src/components/settings/Members.tsx
+++ b/frontend/src/components/settings/Members.tsx
@@ -182,9 +182,7 @@ export default function Members() {
     <div className="w-full">
       <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <h1 className="font-display text-2xl font-semibold tracking-tight text-foreground">
-            Members
-          </h1>
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground">Members</h1>
           <p className="mt-1 text-sm text-muted-foreground">
             Manage your team and invite new members
           </p>


### PR DESCRIPTION
## Summary

- Geist Sans is now the only font in the app: dropped Bricolage Grotesque (`--font-display`) from `layout.tsx`/`globals.css` and removed the `font-display` class from all 9 headings (auth pages, organizations, settings/Members), which now inherit the body's Geist Sans without changing size/weight/tracking.
- Updated `frontend/CLAUDE.md` and the `create-component` skill to describe the actual shadcn/Tailwind + Geist setup; removed stale guidance that still referenced the long-removed MUI theme, `ThemeRegistry`, `sx` prop, and `@mui/icons-material`.

## Test plan

- [ ] Visit each auth page (`/auth/login`, `/auth/signup`, `/auth/forgot-password`, `/auth/reset-password`), the organizations page, and the settings/members page; confirm headings render in Geist Sans with the same size and weight.
- [ ] DevTools → Computed font-family on `body` and on a heading both report Geist Sans (no Bricolage download in the Network tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)