### PR TITLE
Dashboard /stats: v2 Call port, EE mount, home polish

### DIFF
--- a/core/api/v1/dashboard.py
+++ b/core/api/v1/dashboard.py
@@ -1,18 +1,17 @@
-from uuid import UUID
-
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from core.database.session import get_db
 from core.middleware.auth import JWTClaims, require_org_member
 from core.services.dashboard_service import DashboardService
-from shared.config import settings
+from core.utils.org import resolve_org_id
 
 router = APIRouter()
 
 
-def _resolve_org_id(claims: JWTClaims) -> UUID:
-    return UUID(str(claims.org_id)) if claims.org_id else UUID(settings.DEFAULT_ORG_ID)
+def get_dashboard_stats_handler(claims: JWTClaims, db: Session) -> dict:
+    """Shared handler used by both Core and EE dashboard routers."""
+    return DashboardService(db, org_id=resolve_org_id(claims)).get_stats()
 
 
 @router.get("/stats")
@@ -20,4 +19,4 @@ def get_dashboard_stats(
     claims: JWTClaims = Depends(require_org_member),
     db: Session = Depends(get_db),
 ):
-    return DashboardService(db, org_id=_resolve_org_id(claims)).get_stats()
+    return get_dashboard_stats_handler(claims, db)

--- a/core/api/v1/dashboard.py
+++ b/core/api/v1/dashboard.py
@@ -1,11 +1,18 @@
+from uuid import UUID
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from core.database.session import get_db
 from core.middleware.auth import JWTClaims, require_org_member
 from core.services.dashboard_service import DashboardService
+from shared.config import settings
 
 router = APIRouter()
+
+
+def _resolve_org_id(claims: JWTClaims) -> UUID:
+    return UUID(str(claims.org_id)) if claims.org_id else UUID(settings.DEFAULT_ORG_ID)
 
 
 @router.get("/stats")
@@ -13,4 +20,4 @@ def get_dashboard_stats(
     claims: JWTClaims = Depends(require_org_member),
     db: Session = Depends(get_db),
 ):
-    return DashboardService(db).get_stats()
+    return DashboardService(db, org_id=_resolve_org_id(claims)).get_stats()

--- a/core/services/dashboard_service.py
+++ b/core/services/dashboard_service.py
@@ -1,59 +1,53 @@
-import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import func
-from sqlalchemy.orm import Session
 
 from core.models.agent import Agent
-from core.models.call_log import CallLog
+from core.models.call import Call
 from core.services.base import BaseService
 
 
 class DashboardService(BaseService):
-    def __init__(self, db: Session, user_id=None, org_id=None):
-        super().__init__(db, user_id, org_id)
+    """Aggregate per-org metrics for the home dashboard. Uses the v2 ``calls``
+    table (no ``status`` column) — "active" = call not yet ended, "successful"
+    = call ended with non-zero duration."""
 
     def get_stats(self) -> dict:
-        total_agents = self.query(Agent).count()
-
-        active_calls = (
-            self.query(CallLog)
-            .filter(CallLog.status == "in_progress")
-            .count()
-        )
-
-        # Minutes used this month
         now = datetime.now(timezone.utc)
-        start_of_month = int(
-            datetime(now.year, now.month, 1, tzinfo=timezone.utc).timestamp()
-        )
-        total_seconds = (
-            self.query(CallLog)
-            .with_entities(func.coalesce(func.sum(CallLog.duration_seconds), 0))
-            .filter(CallLog.started_at >= start_of_month)
-            .scalar()
-        )
-        minutes_used = round(total_seconds / 60, 1)
+        start_of_month = datetime(now.year, now.month, 1, tzinfo=timezone.utc)
+        thirty_days_ago = now - timedelta(days=30)
 
-        # Success rate over last 30 days
-        thirty_days_ago = int(time.time()) - (30 * 24 * 60 * 60)
+        total_agents = (
+            self.query(Agent).filter(Agent.deleted_at.is_(None)).count()
+        )
+
+        active_calls = self.query(Call).filter(Call.ended_at.is_(None)).count()
+
+        total_seconds = (
+            self.query(Call)
+            .with_entities(func.coalesce(func.sum(Call.duration_seconds), 0))
+            .filter(Call.started_at >= start_of_month)
+            .scalar()
+            or 0
+        )
+        minutes_used = round(int(total_seconds) / 60, 1)
+
         total_calls_30d = (
-            self.query(CallLog)
-            .filter(CallLog.started_at >= thirty_days_ago)
-            .count()
+            self.query(Call).filter(Call.started_at >= thirty_days_ago).count()
         )
         if total_calls_30d > 0:
             completed_calls_30d = (
-                self.query(CallLog)
+                self.query(Call)
                 .filter(
-                    CallLog.started_at >= thirty_days_ago,
-                    CallLog.status == "completed",
+                    Call.started_at >= thirty_days_ago,
+                    Call.ended_at.isnot(None),
+                    Call.duration_seconds > 0,
                 )
                 .count()
             )
             success_rate = round((completed_calls_30d / total_calls_30d) * 100, 1)
         else:
-            success_rate = 0
+            success_rate = 0.0
 
         return {
             "total_agents": total_agents,

--- a/core/services/dashboard_service.py
+++ b/core/services/dashboard_service.py
@@ -6,37 +6,57 @@ from core.models.agent import Agent
 from core.models.call import Call
 from core.services.base import BaseService
 
+# Bound "active" to a recent window so a single stuck row (crash, missed
+# hangup event) can't inflate the metric forever. Anything older than this
+# with a NULL ended_at is treated as orphaned, not in-flight.
+ACTIVE_CALL_WINDOW = timedelta(hours=1)
+
 
 class DashboardService(BaseService):
-    """Aggregate per-org metrics for the home dashboard. Uses the v2 ``calls``
-    table (no ``status`` column) — "active" = call not yet ended, "successful"
-    = call ended with non-zero duration."""
+    """Aggregate per-org metrics for the home dashboard.
+
+    Uses the v2 ``calls`` table (no ``status`` column):
+      - "active"     = started within ``ACTIVE_CALL_WINDOW`` and not yet ended
+      - "successful" = ended with non-zero duration
+
+    NOTE: the live voice pipeline does not yet write to ``calls``; these
+    metrics will report 0 until the pipeline cut-over lands.
+    """
 
     def get_stats(self) -> dict:
         now = datetime.now(timezone.utc)
         start_of_month = datetime(now.year, now.month, 1, tzinfo=timezone.utc)
         thirty_days_ago = now - timedelta(days=30)
+        active_since = now - ACTIVE_CALL_WINDOW
 
         total_agents = (
             self.query(Agent).filter(Agent.deleted_at.is_(None)).count()
         )
 
-        active_calls = self.query(Call).filter(Call.ended_at.is_(None)).count()
+        active_calls = (
+            self.query(Call)
+            .filter(Call.ended_at.is_(None), Call.started_at >= active_since)
+            .count()
+        )
 
         total_seconds = (
             self.query(Call)
             .with_entities(func.coalesce(func.sum(Call.duration_seconds), 0))
             .filter(Call.started_at >= start_of_month)
             .scalar()
-            or 0
         )
-        minutes_used = round(int(total_seconds) / 60, 1)
+        minutes_used = round(total_seconds / 60, 1)
 
-        total_calls_30d = (
-            self.query(Call).filter(Call.started_at >= thirty_days_ago).count()
+        finished_calls_30d = (
+            self.query(Call)
+            .filter(
+                Call.started_at >= thirty_days_ago,
+                Call.ended_at.isnot(None),
+            )
+            .count()
         )
-        if total_calls_30d > 0:
-            completed_calls_30d = (
+        if finished_calls_30d > 0:
+            successful_calls_30d = (
                 self.query(Call)
                 .filter(
                     Call.started_at >= thirty_days_ago,
@@ -45,7 +65,7 @@ class DashboardService(BaseService):
                 )
                 .count()
             )
-            success_rate = round((completed_calls_30d / total_calls_30d) * 100, 1)
+            success_rate = round((successful_calls_30d / finished_calls_30d) * 100, 1)
         else:
             success_rate = 0.0
 

--- a/core/utils/org.py
+++ b/core/utils/org.py
@@ -1,0 +1,12 @@
+from uuid import UUID
+
+from core.middleware.auth import JWTClaims
+from shared.config import settings
+
+
+def resolve_org_id(claims: JWTClaims) -> UUID:
+    """Resolve the effective org_id for a request. Falls back to
+    ``settings.DEFAULT_ORG_ID`` for single-tenant Core when no org_id is
+    present on the claims. EE middleware already enforces a valid org_id, so
+    the fallback is unused there."""
+    return UUID(str(claims.org_id)) if claims.org_id else UUID(settings.DEFAULT_ORG_ID)

--- a/ee/api/v1/dashboard.py
+++ b/ee/api/v1/dashboard.py
@@ -1,0 +1,18 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from core.database.session import get_db
+from core.services.dashboard_service import DashboardService
+from ee.middleware.auth import EEJWTClaims, require_ee_org_member
+
+router = APIRouter()
+
+
+@router.get("/stats")
+def get_dashboard_stats(
+    claims: EEJWTClaims = Depends(require_ee_org_member),
+    db: Session = Depends(get_db),
+):
+    return DashboardService(db, org_id=UUID(claims.org_id)).get_stats()

--- a/ee/api/v1/dashboard.py
+++ b/ee/api/v1/dashboard.py
@@ -1,10 +1,8 @@
-from uuid import UUID
-
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
+from core.api.v1.dashboard import get_dashboard_stats_handler
 from core.database.session import get_db
-from core.services.dashboard_service import DashboardService
 from ee.middleware.auth import EEJWTClaims, require_ee_org_member
 
 router = APIRouter()
@@ -15,4 +13,4 @@ def get_dashboard_stats(
     claims: EEJWTClaims = Depends(require_ee_org_member),
     db: Session = Depends(get_db),
 ):
-    return DashboardService(db, org_id=UUID(claims.org_id)).get_stats()
+    return get_dashboard_stats_handler(claims, db)

--- a/frontend/src/app/(dashboard)/home/page.tsx
+++ b/frontend/src/app/(dashboard)/home/page.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import dashboardAtom, { fetchDashboardStatsAtom } from '@/atoms/DashboardAtom';
-import { Card, CardContent } from '@/components/ui/card';
+import { Card } from '@/components/ui/card';
 import { cn } from '@/utils/cn';
 import { useAtomValue, useSetAtom } from 'jotai';
 import {
   Activity,
   ArrowUpRight,
-  BarChart3,
   Bot,
   CheckCircle2,
   Clock,
@@ -15,73 +14,85 @@ import {
   Plus,
   Settings,
   Users,
-  Zap,
 } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect } from 'react';
 
 /* ── Stat card config ────────────────────────────────────────────────────── */
 
-const statCards = [
+interface StatCardConfig {
+  label: string;
+  key: 'total_agents' | 'active_calls' | 'minutes_used' | 'success_rate';
+  suffix: string;
+  subtitle: string;
+  icon: typeof Bot;
+  iconBg: string;
+  iconColor: string;
+  accent: string;
+}
+
+const statCards: StatCardConfig[] = [
   {
     label: 'Total Agents',
-    key: 'total_agents' as const,
+    key: 'total_agents',
     suffix: '',
     subtitle: 'All agents',
     icon: Bot,
-    accent: 'from-primary/20 to-primary/5',
-    accentBorder: 'border-t-primary',
-    iconColor: 'text-primary',
+    iconBg: 'bg-violet-500/10',
+    iconColor: 'text-violet-600 dark:text-violet-400',
+    accent: 'from-violet-500/10 via-transparent to-transparent',
   },
   {
     label: 'Active Calls',
-    key: 'active_calls' as const,
+    key: 'active_calls',
     suffix: '',
     subtitle: 'Real-time',
     icon: Activity,
-    accent: 'from-emerald-500/20 to-emerald-500/5',
-    accentBorder: 'border-t-emerald-500',
-    iconColor: 'text-emerald-500',
+    iconBg: 'bg-emerald-500/10',
+    iconColor: 'text-emerald-600 dark:text-emerald-400',
+    accent: 'from-emerald-500/10 via-transparent to-transparent',
   },
   {
     label: 'Minutes Used',
-    key: 'minutes_used' as const,
+    key: 'minutes_used',
     suffix: '',
     subtitle: 'This month',
     icon: Clock,
-    accent: 'from-blue-500/20 to-blue-500/5',
-    accentBorder: 'border-t-blue-500',
-    iconColor: 'text-blue-500',
+    iconBg: 'bg-sky-500/10',
+    iconColor: 'text-sky-600 dark:text-sky-400',
+    accent: 'from-sky-500/10 via-transparent to-transparent',
   },
   {
     label: 'Success Rate',
-    key: 'success_rate' as const,
+    key: 'success_rate',
     suffix: '%',
     subtitle: 'Last 30 days',
     icon: CheckCircle2,
-    accent: 'from-amber-500/20 to-amber-500/5',
-    accentBorder: 'border-t-amber-500',
-    iconColor: 'text-amber-500',
+    iconBg: 'bg-amber-500/10',
+    iconColor: 'text-amber-600 dark:text-amber-400',
+    accent: 'from-amber-500/10 via-transparent to-transparent',
   },
 ];
 
-const quickActions = [
-  {
-    label: 'Create Agent',
-    href: '/agents',
-    icon: Plus,
-    color: 'bg-primary text-primary-foreground hover:bg-primary/90',
-  },
-];
+interface QuickLinkConfig {
+  title: string;
+  description: string;
+  icon: typeof Bot;
+  href: string;
+  iconBg: string;
+  iconColor: string;
+  hoverRing: string;
+}
 
-const quickLinks = [
+const quickLinks: QuickLinkConfig[] = [
   {
     title: 'Agents',
     description: 'Create and manage your AI voice agents',
     icon: Bot,
     href: '/agents',
-    iconBg: 'bg-primary/10',
-    iconColor: 'text-primary',
+    iconBg: 'bg-violet-500/10',
+    iconColor: 'text-violet-600 dark:text-violet-400',
+    hoverRing: 'group-hover:ring-violet-500/20',
   },
   {
     title: 'Phone Numbers',
@@ -89,23 +100,8 @@ const quickLinks = [
     icon: Phone,
     href: '/phone-numbers',
     iconBg: 'bg-emerald-500/10',
-    iconColor: 'text-emerald-500',
-  },
-  {
-    title: 'Analytics',
-    description: 'View performance metrics and insights',
-    icon: BarChart3,
-    href: '/analytics',
-    iconBg: 'bg-blue-500/10',
-    iconColor: 'text-blue-500',
-  },
-  {
-    title: 'Actions',
-    description: 'Configure automated actions and triggers',
-    icon: Zap,
-    href: '/actions',
-    iconBg: 'bg-amber-500/10',
-    iconColor: 'text-amber-500',
+    iconColor: 'text-emerald-600 dark:text-emerald-400',
+    hoverRing: 'group-hover:ring-emerald-500/20',
   },
   {
     title: 'Team Members',
@@ -113,15 +109,17 @@ const quickLinks = [
     icon: Users,
     href: '/members',
     iconBg: 'bg-pink-500/10',
-    iconColor: 'text-pink-500',
+    iconColor: 'text-pink-600 dark:text-pink-400',
+    hoverRing: 'group-hover:ring-pink-500/20',
   },
   {
     title: 'Integrations',
     description: 'Connect services and manage API credentials',
     icon: Settings,
     href: '/integrations',
-    iconBg: 'bg-muted',
-    iconColor: 'text-muted-foreground',
+    iconBg: 'bg-slate-500/10',
+    iconColor: 'text-slate-600 dark:text-slate-300',
+    hoverRing: 'group-hover:ring-slate-500/20',
   },
 ];
 
@@ -136,74 +134,62 @@ export default function HomePage() {
   }, [fetchStats]);
 
   return (
-    <div className="animate-page h-full space-y-8 overflow-y-auto p-6 lg:p-8">
-      {/* ── Header + Quick Actions ──────────────────────────────────────── */}
-      <div className="flex flex-col items-center gap-4 sm:flex-row sm:items-end sm:justify-between">
-        <div>
+    <div className="animate-page space-y-8">
+      {/* ── Header ──────────────────────────────────────────────────────── */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-1.5">
           <h1 className="text-2xl font-semibold tracking-tight text-foreground">Welcome to Tone</h1>
-          <p className="mt-1 text-sm text-muted-foreground">
+          <p className="text-sm text-muted-foreground">
             Build and deploy AI voice agents in minutes. Get started with the quick links below.
           </p>
         </div>
 
-        <div className="flex gap-2">
-          {quickActions.map((action) => (
-            <Link
-              key={action.label}
-              href={action.href}
-              className={cn(
-                'inline-flex items-center gap-1.5 rounded-lg px-3.5 py-2 text-[13px] font-medium no-underline transition-colors',
-                action.color,
-              )}
-            >
-              <action.icon size={15} />
-              {action.label}
-            </Link>
-          ))}
-        </div>
+        <Link
+          href="/agents"
+          className="inline-flex items-center gap-1.5 self-start rounded-lg bg-primary px-3.5 py-2 text-[13px] font-medium text-primary-foreground no-underline shadow-sm transition-all hover:bg-primary/90 hover:shadow sm:self-auto"
+        >
+          <Plus size={15} />
+          Create Agent
+        </Link>
       </div>
 
       {/* ── Stat Cards ──────────────────────────────────────────────────── */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {statCards.map((card) => {
-          const value = loading || !stats ? '--' : `${stats[card.key]}${card.suffix}`;
+          const value = loading || !stats ? '—' : `${stats[card.key]}${card.suffix}`;
 
           return (
             <Card
               key={card.label}
-              className={cn(
-                'group relative overflow-hidden border-t-2 py-0 transition-all hover:shadow-md',
-                card.accentBorder,
-              )}
+              className="group relative gap-0 overflow-hidden border-border/60 py-0 transition-all duration-200 hover:-translate-y-0.5 hover:border-border hover:shadow-md"
             >
               <div
                 className={cn(
-                  'pointer-events-none absolute inset-0 bg-gradient-to-br opacity-0 transition-opacity group-hover:opacity-100',
+                  'pointer-events-none absolute inset-0 bg-gradient-to-br opacity-60 transition-opacity duration-200 group-hover:opacity-100',
                   card.accent,
                 )}
               />
 
-              <CardContent className="relative px-5 py-4">
-                <div className="mb-3 flex items-center justify-between">
-                  <span className="text-[13px] font-medium text-muted-foreground">
-                    {card.label}
-                  </span>
-                  <div
-                    className={cn(
-                      'flex size-9 items-center justify-center rounded-lg bg-muted/50',
-                      card.iconColor,
-                    )}
-                  >
-                    <card.icon size={18} />
-                  </div>
+              <div className="relative flex items-start justify-between px-5 pt-5">
+                <div
+                  className={cn(
+                    'flex size-10 items-center justify-center rounded-xl ring-1 ring-inset ring-border/40',
+                    card.iconBg,
+                  )}
+                >
+                  <card.icon size={18} className={card.iconColor} strokeWidth={2.25} />
                 </div>
+                <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">
+                  {card.subtitle}
+                </span>
+              </div>
 
-                <div className="text-3xl font-bold tracking-tight text-foreground">{value}</div>
-
-                <div className="mt-1.5 flex items-center gap-1">
-                  <span className="text-xs text-muted-foreground">{card.subtitle}</span>
-                </div>
-              </CardContent>
+              <div className="relative px-5 pt-4 pb-5">
+                <p className="text-[13px] font-medium text-muted-foreground">{card.label}</p>
+                <p className="mt-1 text-3xl font-semibold tracking-tight tabular-nums text-foreground">
+                  {value}
+                </p>
+              </div>
             </Card>
           );
         })}
@@ -211,36 +197,43 @@ export default function HomePage() {
 
       {/* ── Quick Links ─────────────────────────────────────────────────── */}
       <div className="space-y-4">
-        <h2 className="text-lg font-semibold text-foreground">Quick Links</h2>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="flex items-end justify-between">
+          <div>
+            <h2 className="text-base font-semibold text-foreground">Quick Links</h2>
+            <p className="text-xs text-muted-foreground">Jump to the most-used parts of Tone.</p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
           {quickLinks.map((link) => (
-            <Link key={link.title} href={link.href} className="group no-underline">
-              <Card className="h-full gap-0 py-0 transition-all group-hover:-translate-y-0.5 group-hover:shadow-md">
-                <CardContent className="p-5">
-                  <div className="mb-3 flex items-center gap-3">
+            <Link key={link.title} href={link.href} className="group block no-underline">
+              <Card
+                className={cn(
+                  'h-full gap-0 border-border/60 py-0 ring-1 ring-transparent transition-all duration-200 hover:-translate-y-0.5 hover:border-border hover:shadow-md',
+                  link.hoverRing,
+                )}
+              >
+                <div className="flex h-full flex-col p-5">
+                  <div className="mb-4 flex items-start justify-between">
                     <div
                       className={cn(
-                        'flex size-10 items-center justify-center rounded-xl transition-transform group-hover:scale-105',
+                        'flex size-11 items-center justify-center rounded-xl ring-1 ring-inset ring-border/40 transition-transform group-hover:scale-[1.04]',
                         link.iconBg,
                       )}
                     >
-                      <link.icon size={20} className={link.iconColor} />
+                      <link.icon size={20} className={link.iconColor} strokeWidth={2.25} />
                     </div>
-
-                    <span className="flex-1 text-[15px] font-semibold text-foreground">
-                      {link.title}
-                    </span>
-
                     <ArrowUpRight
                       size={16}
-                      className="text-muted-foreground/50 transition-all group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-muted-foreground"
+                      className="text-muted-foreground/40 transition-all duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-foreground"
                     />
                   </div>
 
-                  <p className="text-[13px] leading-relaxed text-muted-foreground">
+                  <h3 className="text-[15px] font-semibold text-foreground">{link.title}</h3>
+                  <p className="mt-1 text-[13px] leading-relaxed text-muted-foreground">
                     {link.description}
                   </p>
-                </CardContent>
+                </div>
               </Card>
             </Link>
           ))}

--- a/frontend/src/atoms/DashboardAtom.tsx
+++ b/frontend/src/atoms/DashboardAtom.tsx
@@ -13,15 +13,27 @@ const dashboardAtom = atom<DashboardState>({
   loading: false,
 });
 
-export const fetchDashboardStatsAtom = atom(null, async (_get, set) => {
+// In-flight de-dupe — guards against React 19 Strict Mode's intentional
+// double-mount (and any parent re-render that calls the setter twice) so we
+// only fire one network request per mount cycle. The shared promise is
+// awaited by any concurrent callers so they all observe the same result.
+let inFlight: Promise<void> | null = null;
+
+export const fetchDashboardStatsAtom = atom(null, (_get, set) => {
+  if (inFlight) return inFlight;
   set(dashboardAtom, (prev) => ({ ...prev, loading: true }));
-  try {
-    const stats = await getDashboardStats();
-    set(dashboardAtom, { stats, loading: false });
-  } catch (error) {
-    set(dashboardAtom, (prev) => ({ ...prev, loading: false }));
-    handleApiError(error);
-  }
+  inFlight = (async () => {
+    try {
+      const stats = await getDashboardStats();
+      set(dashboardAtom, { stats, loading: false });
+    } catch (error) {
+      set(dashboardAtom, (prev) => ({ ...prev, loading: false }));
+      handleApiError(error);
+    } finally {
+      inFlight = null;
+    }
+  })();
+  return inFlight;
 });
 
 export default dashboardAtom;

--- a/frontend/src/atoms/DashboardAtom.tsx
+++ b/frontend/src/atoms/DashboardAtom.tsx
@@ -13,10 +13,10 @@ const dashboardAtom = atom<DashboardState>({
   loading: false,
 });
 
-// In-flight de-dupe — guards against React 19 Strict Mode's intentional
-// double-mount (and any parent re-render that calls the setter twice) so we
-// only fire one network request per mount cycle. The shared promise is
-// awaited by any concurrent callers so they all observe the same result.
+// Module-scoped in-flight de-dupe: every caller of fetchDashboardStatsAtom
+// (Strict Mode double-mount, re-renders that re-invoke the setter, sibling
+// components subscribed to the atom) shares the same promise while a request
+// is in flight, and a fresh request only fires once the previous one settles.
 let inFlight: Promise<void> | null = null;
 
 export const fetchDashboardStatsAtom = atom(null, (_get, set) => {

--- a/main.py
+++ b/main.py
@@ -14,16 +14,15 @@ from core.internal.capabilities import init_capabilities, is_ee_enabled, get_cap
 
 from core.api.v1 import (
     auth, users, organizations, agent_configs, channels, oauth,
-    knowledge_base, agents, mcp_servers, services, tools,
+    knowledge_base, agents, mcp_servers, services, tools, dashboard,
 )
-# NOTE: the following routers reference dropped pre-v2 models (account,
-# voice, model_instance, hosting_provider, etc.) and currently
-# fail to import. They are temporarily disabled so the server can boot
-# with the v2 auth schema:
-#   api_keys, accounts, service_providers, agents,
-#   agent_channel_phone_numbers, channel_phone_numbers, models,
+# NOTE: the following routers reference dropped pre-v2 models (voice,
+# model_instance, hosting_provider, etc.) and currently fail to import.
+# They are temporarily disabled so the server can boot with the v2 auth
+# schema:
+#   agent_channel_phone_numbers, channel_phone_numbers,
 #   generated_api_keys, voices, call_logs, telephony,
-#   dashboard, model_providers_menu, hosting_providers,
+#   model_providers_menu, hosting_providers,
 #   model_menu, model_instances
 import core.models
 
@@ -90,6 +89,7 @@ if ee_enabled:
     from ee.api.v1 import mcp_servers as ee_mcp_servers
     from ee.api.v1 import services as ee_services
     from ee.api.v1 import tools as ee_tools
+    from ee.api.v1 import dashboard as ee_dashboard
 
     api_v1.include_router(ee_auth.router, prefix="/auth", tags=["auth"])
     api_v1.include_router(ee_users.router, prefix="/user", tags=["users"])
@@ -102,6 +102,7 @@ if ee_enabled:
     api_v1.include_router(ee_mcp_servers.router, prefix="/mcp-server", tags=["mcp-server"])
     api_v1.include_router(ee_services.router, prefix="/services", tags=["services"])
     api_v1.include_router(ee_tools.router, prefix="/tool", tags=["tool"])
+    api_v1.include_router(ee_dashboard.router, prefix="/dashboard", tags=["dashboard"])
     print("EE edition: auth-schema routes loaded (other routers temporarily disabled pending v2 schema migration)")
 else:
     api_v1.include_router(auth.router, prefix="/auth", tags=["auth"])
@@ -115,6 +116,7 @@ else:
     api_v1.include_router(mcp_servers.router, prefix="/mcp-server", tags=["mcp-server"])
     api_v1.include_router(services.router, prefix="/services", tags=["services"])
     api_v1.include_router(tools.router, prefix="/tool", tags=["tool"])
+    api_v1.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"])
     print("Core edition: auth-schema routes loaded (other routers temporarily disabled pending v2 schema migration)")
 
 


### PR DESCRIPTION
## Summary
- Mount `/dashboard/stats` for both Core and EE editions, sharing a single handler via a new `resolve_org_id` helper.
- Port `DashboardService` to the v2 `Call` model: bounded `active_calls` to a 1h window so orphaned rows can't inflate the metric, gate success-rate denominator on `ended_at IS NOT NULL`, and add a docstring NOTE that the pipeline cut-over is pending.
- Polish the home dashboard cards/quick links UI and de-dupe in-flight stats fetches in `DashboardAtom` (module-scoped, with a clearer comment).

## Test plan
- [ ] `GET /api/v1/dashboard/stats` returns 200 on Core with a valid JWT and reflects per-org agent + call counts.
- [ ] Same endpoint on EE (`EEJWTClaims` path) returns the same payload shape.
- [ ] Home page renders 4 stat cards + 4 quick links and only fires one `/stats` request on mount under React Strict Mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)