### PR TITLE
Auth: reconcile active workspace after switch + reload

### DIFF
--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -300,8 +300,8 @@ export function Sidebar() {
                             className={cn(
                               'flex w-full items-center gap-2.5 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors',
                               isActive
-                                ? 'bg-sidebar-accent text-foreground'
-                                : 'text-foreground/85 hover:bg-sidebar-accent/60',
+                                ? 'bg-sidebar-accent text-foreground cursor-default'
+                                : 'text-foreground/85 hover:bg-sidebar-accent/60 cursor-pointer',
                             )}
                           >
                             <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/10 text-[11px] font-semibold text-primary">
@@ -329,7 +329,7 @@ export function Sidebar() {
                   <div className="p-1.5">
                     <Link
                       href="/organizations"
-                      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[13px] text-foreground/85 hover:bg-sidebar-accent/60"
+                      className="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-[13px] text-foreground/85 hover:bg-sidebar-accent/60"
                     >
                       <Settings className="h-3.5 w-3.5 text-muted-foreground" />
                       Manage organizations

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -43,6 +43,23 @@ function readJSON<T>(key: string): T | null {
   }
 }
 
+// Build a clean Organization + User pair from the active membership. The
+// organization is rebuilt fresh (id + name only) so that fields like slug,
+// logo_url, or subscription_* from a previously-active workspace can't leak
+// through after a switch — those should be re-fetched from the API.
+function reconcileActiveOrg(
+  activeOrgId: string | null,
+  orgs: UserOrganization[],
+  user: User | null,
+): { organization: Organization; user: User | null } | null {
+  const membership = activeOrgId ? orgs.find((o) => String(o.id) === String(activeOrgId)) : null;
+  if (!membership) return null;
+  return {
+    organization: { id: membership.id, name: membership.name },
+    user: user ? { ...user, role: membership.role ?? user.role ?? null } : user,
+  };
+}
+
 function bootstrap() {
   if (typeof window === 'undefined') {
     return {
@@ -73,19 +90,26 @@ function bootstrap() {
     };
   }
 
-  // Role is contextual to the active membership — populate from the response
-  // or, failing that, from the access token claims.
+  // If the user has switched workspaces, the active org id in localStorage is
+  // the source of truth — reconcile organization name and per-org role with
+  // the matching membership so the sidebar reflects the current tenant
+  // after reload.
+  const reconciled = reconcileActiveOrg(activeOrgId, organizations, user);
+  if (reconciled) {
+    organization = reconciled.organization;
+    user = reconciled.user;
+  } else if (!organization && organizations.length) {
+    organization = {
+      id: organizations[0].id as string,
+      name: organizations[0].name ?? 'Workspace',
+    };
+    if (user && !user.role) user.role = organizations[0].role ?? null;
+  }
+
+  // Role is contextual to the active membership — fall back to the login
+  // payload / token claims when no membership row carried one.
   if (user && !user.role) {
     user.role = (loginData?.role as string) ?? readRoleFromToken(token) ?? null;
-  }
-  if (!organization && organizations.length) {
-    organization = {
-      id: activeOrgId || (organizations[0].id as string),
-      name:
-        organizations.find((o) => o.id === activeOrgId)?.name ??
-        organizations[0].name ??
-        'Workspace',
-    };
   }
 
   return {
@@ -149,7 +173,21 @@ export const useAuthStore = create<AuthState>((set) => ({
         : null,
     }));
   },
-  setOrganizations: (orgs) => set({ organizations: orgs }),
+  setOrganizations: (orgs) =>
+    set((s) => {
+      // The full membership list arrives async (DashboardLayout fetches it
+      // after bootstrap), so this is our first chance to reconcile the
+      // displayed organization and role with the active tenant in
+      // localStorage. Without this, switching workspaces + reload shows the
+      // original login org until something else updates the store.
+      const reconciled = reconcileActiveOrg(s.activeOrgId, orgs, s.user);
+      if (!reconciled) return { organizations: orgs };
+      return {
+        organizations: orgs,
+        organization: reconciled.organization,
+        user: reconciled.user,
+      };
+    }),
   clearAuth: () => {
     if (typeof window !== 'undefined') {
       localStorage.removeItem(ACCESS_TOKEN);


### PR DESCRIPTION
## Summary
- Sidebar workspace switcher only updates `TENANT_ID` in localStorage, so `LOGIN_DATA` still points at the original login org and the sidebar showed the old workspace after reload.
- Added a shared `reconcileActiveOrg` helper used by both `bootstrap()` and `setOrganizations` to override organization id/name and per-org role against the active membership; the org is rebuilt fresh (id + name only) so stale `slug`/`logo_url`/`subscription_*` can't leak across workspaces.
- Minor sidebar polish: explicit `cursor-default` on the active workspace item and `cursor-pointer` on inactive items + the "Manage organizations" link.

## Test plan
- [ ] Log in to workspace A, switch to workspace B via the sidebar, reload — sidebar shows B and the role reflects B's membership.
- [ ] Refresh on a stale `TENANT_ID` that isn't in the membership list — falls back gracefully without clobbering the current org.
- [ ] Hover states on the workspace switcher show the correct cursor for active vs inactive rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)