### PR TITLE
User settings page + PATCH /user/me + channel modal loader

### DIFF
--- a/core/api/v1/users.py
+++ b/core/api/v1/users.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session
 from core.database.session import get_db
 from core.middleware.auth import get_jwt_claims, require_org_member, JWTClaims
 from core.schemas.list_request import ListRequest, apply_list_request
+from core.schemas.user import UserUpdate
 from core.services.auth_service import AuthService
 
 router = APIRouter()
@@ -18,6 +19,17 @@ def get_me(
     db: Session = Depends(get_db),
 ):
     return AuthService(db).get_user_me(claims.user_id)
+
+
+@router.patch("/me")
+def update_me(
+    payload: UserUpdate,
+    claims: JWTClaims = Depends(get_jwt_claims),
+    db: Session = Depends(get_db),
+):
+    return AuthService(db).update_user_me(
+        claims.user_id, payload.model_dump(exclude_unset=True)
+    )
 
 
 @router.post("/get_all_users_for_organization")

--- a/core/schemas/user.py
+++ b/core/schemas/user.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 from typing import Optional, Dict, Any
 from uuid import UUID
 
@@ -15,10 +15,10 @@ class UserCreate(UserBase):
 
 
 class UserUpdate(BaseModel):
-    first_name: Optional[str] = None
-    last_name: Optional[str] = None
-    avatar_url: Optional[str] = None
-    phone_number: Optional[str] = None
+    first_name: Optional[str] = Field(default=None, max_length=100)
+    last_name: Optional[str] = Field(default=None, max_length=100)
+    avatar_url: Optional[str] = Field(default=None, max_length=512)
+    phone_number: Optional[str] = Field(default=None, max_length=50)
     profile: Optional[Dict[str, Any]] = None
 
 

--- a/core/services/auth_service.py
+++ b/core/services/auth_service.py
@@ -709,6 +709,26 @@ class AuthService(BaseService):
             )
         return user.to_dict()
 
+    UPDATABLE_PROFILE_FIELDS = ("first_name", "last_name", "avatar_url")
+
+    def update_user_me(
+        self,
+        user_id: Union[str, uuid.UUID],
+        data: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        uid = _user_uuid(user_id)
+        user = self.db.query(User).filter(User.id == uid).first() if uid else None
+        if not user:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+            )
+        for field in self.UPDATABLE_PROFILE_FIELDS:
+            if field in data and data[field] is not None:
+                setattr(user, field, data[field])
+        self.db.commit()
+        self.db.refresh(user)
+        return user.to_dict()
+
     def get_organization_me(self, user_id: Union[str, uuid.UUID]) -> Optional[Dict[str, Any]]:
         member = self._membership_for(user_id)
         if not member:

--- a/ee/api/v1/users.py
+++ b/ee/api/v1/users.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from core.database.session import get_db
 from core.schemas.list_request import ListRequest, apply_list_request
+from core.schemas.user import UserUpdate
 from ee.services.auth_service import EEAuthService
 from ee.middleware.auth import get_ee_jwt_claims, require_ee_org_member, EEJWTClaims
 
@@ -20,6 +21,17 @@ def get_me(
     db: Session = Depends(get_db),
 ):
     return EEAuthService(db).get_user_me(claims.user_id)
+
+
+@router.patch("/me")
+def update_me(
+    payload: UserUpdate,
+    claims: EEJWTClaims = Depends(get_ee_jwt_claims),
+    db: Session = Depends(get_db),
+):
+    return EEAuthService(db).update_user_me(
+        claims.user_id, payload.model_dump(exclude_unset=True)
+    )
 
 
 @router.post("/get_all_users_for_organization")

--- a/frontend/src/app/(dashboard)/user-settings/page.tsx
+++ b/frontend/src/app/(dashboard)/user-settings/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import UserSettings from '@/components/user-settings/UserSettings';
+
+export default function UserSettingsPage() {
+  return (
+    <div className="animate-page flex h-full flex-col">
+      <UserSettings />
+    </div>
+  );
+}

--- a/frontend/src/atoms/UserSettingsAtom.tsx
+++ b/frontend/src/atoms/UserSettingsAtom.tsx
@@ -1,0 +1,10 @@
+import { atom } from 'jotai';
+
+import { authApi, type UpdateProfilePayload } from '@/lib/api/auth';
+import { useAuthStore } from '@/stores/auth';
+
+export const updateProfileAtom = atom(null, async (_get, _set, payload: UpdateProfilePayload) => {
+  const updated = await authApi.updateMe(payload);
+  useAuthStore.getState().setUser(updated);
+  return updated;
+});

--- a/frontend/src/components/integrations/channel-form-modal.tsx
+++ b/frontend/src/components/integrations/channel-form-modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CustomModal, SelectInput, TextInput } from '@/components/shared';
+import { AppLoader, CustomModal, SelectInput, TextInput } from '@/components/shared';
 import { getChannel } from '@/services/channelService';
 import type { Channel, ChannelUpsertPayload } from '@/types/integration';
 import { handleApiError } from '@/utils/helpers';
@@ -109,41 +109,45 @@ export default function ChannelFormModal({
       confirmLoading={saving}
       confirmDisabled={!formState.isValid || hydrating}
     >
-      <div className="space-y-4">
-        <TextInput
-          name="name"
-          control={control}
-          label="Name"
-          placeholder="e.g. Twilio Production"
-          isRequired
-          disabled={saving || hydrating}
-        />
-        <SelectInput
-          name="channel-type"
-          label="Type"
-          options={CHANNEL_TYPE_OPTIONS}
-          value={channelType}
-          onValueChange={setChannelType}
-          disabled={saving || hydrating || !!providerKey || isEdit}
-        />
-        <TextInput
-          name="auth_token"
-          control={control}
-          label="Auth Token"
-          type="password"
-          placeholder="Enter auth token"
-          isRequired
-          disabled={saving || hydrating}
-        />
-        <TextInput
-          name="account_sid"
-          control={control}
-          label="Account SID"
-          placeholder="Enter account SID"
-          isRequired
-          disabled={saving || hydrating}
-        />
-      </div>
+      {hydrating ? (
+        <AppLoader className="min-h-[260px]" />
+      ) : (
+        <div className="space-y-4">
+          <TextInput
+            name="name"
+            control={control}
+            label="Name"
+            placeholder="e.g. Twilio Production"
+            isRequired
+            disabled={saving}
+          />
+          <SelectInput
+            name="channel-type"
+            label="Type"
+            options={CHANNEL_TYPE_OPTIONS}
+            value={channelType}
+            onValueChange={setChannelType}
+            disabled={saving || !!providerKey || isEdit}
+          />
+          <TextInput
+            name="auth_token"
+            control={control}
+            label="Auth Token"
+            type="password"
+            placeholder="Enter auth token"
+            isRequired
+            disabled={saving}
+          />
+          <TextInput
+            name="account_sid"
+            control={control}
+            label="Account SID"
+            placeholder="Enter account SID"
+            isRequired
+            disabled={saving}
+          />
+        </div>
+      )}
     </CustomModal>
   );
 }

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -439,9 +439,9 @@ export function Sidebar() {
                 fullWidth
                 className="justify-start gap-3 px-3 h-9 font-normal"
               >
-                <Link href="/members">
+                <Link href="/user-settings">
                   <Settings className="h-4 w-4 text-muted-foreground" />
-                  Settings
+                  User settings
                 </Link>
               </Button>
               <Button

--- a/frontend/src/components/user-settings/ProfileForm.tsx
+++ b/frontend/src/components/user-settings/ProfileForm.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useSetAtom } from 'jotai';
+import { Asterisk, Lock, Save } from 'lucide-react';
+import { useEffect } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
+import { z } from 'zod';
+
+import { updateProfileAtom } from '@/atoms/UserSettingsAtom';
+import { CustomButton, TextInput } from '@/components/shared';
+import { getInitials } from '@/lib/utils';
+import { useAuthStore } from '@/stores/auth';
+import { handleApiError } from '@/utils/helpers';
+import { showToast } from '@/utils/toast';
+
+import { AvatarPreview } from './UserSettings';
+
+const profileSchema = z.object({
+  first_name: z
+    .string()
+    .min(1, 'First name is required')
+    .max(100, 'First name must be at most 100 characters'),
+  last_name: z
+    .string()
+    .min(1, 'Last name is required')
+    .max(100, 'Last name must be at most 100 characters'),
+  avatar_url: z
+    .string()
+    .trim()
+    .max(512, 'Avatar URL must be at most 512 characters')
+    .url('Enter a valid URL')
+    .optional()
+    .or(z.literal('')),
+});
+
+type ProfileFormData = z.infer<typeof profileSchema>;
+
+function SectionLabel({ index, title, hint }: { index: string; title: string; hint: string }) {
+  return (
+    <div className="mb-4 flex items-baseline gap-3">
+      <span className="text-[10px] font-mono font-semibold tracking-[0.18em] text-muted-foreground/60">
+        {index}
+      </span>
+      <div className="min-w-0">
+        <h3 className="text-[13px] font-semibold tracking-tight text-foreground">{title}</h3>
+        <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">{hint}</p>
+      </div>
+    </div>
+  );
+}
+
+export default function ProfileForm() {
+  const user = useAuthStore((s) => s.user);
+  const updateProfile = useSetAtom(updateProfileAtom);
+
+  const { control, handleSubmit, reset, formState } = useForm<ProfileFormData>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: {
+      first_name: '',
+      last_name: '',
+      avatar_url: '',
+    },
+    mode: 'onChange',
+  });
+
+  // Watch the avatar URL + name so the swatch preview reflects typing in real time.
+  const watchedAvatar = useWatch({ control, name: 'avatar_url' });
+  const watchedFirst = useWatch({ control, name: 'first_name' });
+  const watchedLast = useWatch({ control, name: 'last_name' });
+
+  useEffect(() => {
+    if (!user) return;
+    reset({
+      first_name: user.first_name ?? '',
+      last_name: user.last_name ?? '',
+      avatar_url: user.avatar_url ?? '',
+    });
+  }, [user, reset]);
+
+  const onSubmit = async (data: ProfileFormData) => {
+    try {
+      await updateProfile({
+        first_name: data.first_name.trim(),
+        last_name: data.last_name.trim(),
+        avatar_url: data.avatar_url?.trim() ? data.avatar_url.trim() : null,
+      });
+      showToast.success('Profile updated');
+    } catch (err) {
+      handleApiError(err);
+    }
+  };
+
+  const saving = formState.isSubmitting;
+  const previewInitials =
+    getInitials(watchedFirst || user?.first_name, watchedLast || user?.last_name) || 'U';
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      {/* ── Identity ─────────────────────────────────────────── */}
+      <div className="p-5 sm:p-6">
+        <SectionLabel
+          index="01"
+          title="Identity"
+          hint="Your name and avatar appear in the sidebar, on shared resources, and in audit logs."
+        />
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <TextInput
+            name="first_name"
+            control={control}
+            label="First name"
+            placeholder="Jane"
+            isRequired
+            disabled={saving}
+          />
+          <TextInput
+            name="last_name"
+            control={control}
+            label="Last name"
+            placeholder="Doe"
+            isRequired
+            disabled={saving}
+          />
+        </div>
+
+        <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-[1fr_auto] sm:items-end">
+          <TextInput
+            name="avatar_url"
+            control={control}
+            label="Avatar URL"
+            placeholder="https://example.com/avatar.png"
+            disabled={saving}
+            helperText="Paste an image link. Leave blank to use your initials."
+          />
+          <div className="flex shrink-0 items-center gap-3 rounded-2xl border border-dashed border-border/70 bg-muted/30 px-3 py-2.5 sm:mb-[2px]">
+            <AvatarPreview url={watchedAvatar || null} initials={previewInitials} size="sm" />
+            <div className="hidden text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground sm:block">
+              Preview
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Divider ──────────────────────────────────────────── */}
+      <div className="relative">
+        <div className="h-px bg-border/70" />
+        <span
+          aria-hidden
+          className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full border border-border/70 bg-card px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/70"
+        >
+          Read only
+        </span>
+      </div>
+
+      {/* ── Account ──────────────────────────────────────────── */}
+      <div className="p-5 sm:p-6">
+        <SectionLabel
+          index="02"
+          title="Account"
+          hint="Managed by your workspace owner. Contact an admin to change these."
+        />
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="relative">
+            <TextInput
+              name="email"
+              label="Email"
+              value={user?.email ?? ''}
+              readOnly
+              disabled
+              leftIcon={<Lock className="size-3.5 text-muted-foreground/70" />}
+            />
+          </div>
+          <div className="relative">
+            <TextInput
+              name="role"
+              label="Role"
+              value={user?.role ?? '—'}
+              readOnly
+              disabled
+              leftIcon={<Lock className="size-3.5 text-muted-foreground/70" />}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* ── Footer / save bar ────────────────────────────────── */}
+      <div className="flex items-center justify-between gap-3 border-t border-border/70 bg-muted/20 px-5 py-3 sm:px-6">
+        <p className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+          <Asterisk className="size-3 text-rose-500" strokeWidth={3} />
+          Required field
+        </p>
+        <CustomButton
+          type="primary"
+          onClick={handleSubmit(onSubmit)}
+          icon={<Save className="size-4" />}
+          loading={saving}
+          disabled={!formState.isValid || saving || !formState.isDirty}
+        >
+          {saving ? 'Saving...' : 'Save changes'}
+        </CustomButton>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/user-settings/UserSettings.tsx
+++ b/frontend/src/components/user-settings/UserSettings.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { BadgeCheck, Crown, Mail, ShieldCheck, UserCircle } from 'lucide-react';
+import { useState } from 'react';
+
+import { getInitials } from '@/lib/utils';
+import { useAuthStore } from '@/stores/auth';
+import { cn } from '@/utils/cn';
+
+import ProfileForm from './ProfileForm';
+
+interface AvatarPreviewProps {
+  url?: string | null;
+  initials: string;
+  size?: 'sm' | 'lg';
+}
+
+export function AvatarPreview({ url, initials, size = 'lg' }: AvatarPreviewProps) {
+  const [broken, setBroken] = useState(false);
+  const ringClass =
+    size === 'lg'
+      ? 'size-20 sm:size-[88px] ring-4 ring-background shadow-[0_8px_28px_-12px_rgba(99,102,241,0.45)]'
+      : 'size-10 ring-2 ring-background shadow-sm';
+  const labelClass = size === 'lg' ? 'text-2xl tracking-tight' : 'text-[13px]';
+
+  const showImage = url && !broken;
+
+  return (
+    <div className="relative shrink-0">
+      <div
+        className={cn(
+          'relative flex items-center justify-center overflow-hidden rounded-full',
+          ringClass,
+        )}
+      >
+        {/* Gradient background sits behind the image so transparent PNGs still look intentional */}
+        <span
+          aria-hidden
+          className="absolute inset-0 bg-gradient-to-br from-violet-500 via-indigo-500 to-fuchsia-500"
+        />
+        {showImage ? (
+          <img
+            src={url}
+            alt="Avatar preview"
+            className="relative size-full object-cover"
+            onError={() => setBroken(true)}
+          />
+        ) : (
+          <span className={cn('relative font-semibold text-white', labelClass)}>{initials}</span>
+        )}
+      </div>
+      {size === 'lg' && (
+        <span
+          aria-hidden
+          className="absolute -bottom-0.5 -right-0.5 flex size-6 items-center justify-center rounded-full border-2 border-background bg-emerald-500 shadow-sm"
+        >
+          <BadgeCheck className="size-3.5 text-white" strokeWidth={2.5} />
+        </span>
+      )}
+    </div>
+  );
+}
+
+function RolePill({ role }: { role?: string | null }) {
+  const normalized = (role ?? '').toLowerCase();
+  const isOwner = normalized === 'owner';
+  const isAdmin = normalized === 'admin';
+
+  const palette = isOwner
+    ? 'bg-amber-500/10 text-amber-700 ring-amber-500/20 dark:text-amber-300'
+    : isAdmin
+      ? 'bg-indigo-500/10 text-indigo-700 ring-indigo-500/20 dark:text-indigo-300'
+      : 'bg-violet-500/10 text-violet-700 ring-violet-500/20 dark:text-violet-300';
+
+  const Icon = isOwner ? Crown : ShieldCheck;
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.08em] ring-1 ring-inset',
+        palette,
+      )}
+    >
+      <Icon className="size-3" strokeWidth={2.5} />
+      {role ?? 'member'}
+    </span>
+  );
+}
+
+export default function UserSettings() {
+  const user = useAuthStore((s) => s.user);
+  const initials = getInitials(user?.first_name, user?.last_name) || 'U';
+  const fullName =
+    [user?.first_name, user?.last_name].filter(Boolean).join(' ').trim() ||
+    user?.email ||
+    'Your account';
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* ── Fixed page header ─────────────────────────────────── */}
+      <header className="shrink-0 border-b border-border/60 bg-background">
+        <div className="mx-auto flex max-w-4xl flex-col gap-3 px-6 py-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0">
+            <h1 className="text-[22px] font-semibold leading-tight tracking-tight text-foreground">
+              User settings
+            </h1>
+            <p className="mt-1 max-w-xl text-xs leading-relaxed text-muted-foreground sm:text-sm">
+              Manage your personal account details and how you appear across the workspace.
+            </p>
+          </div>
+        </div>
+      </header>
+
+      {/* ── Scrollable content ──────────────────────────────────── */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="mx-auto w-full max-w-4xl space-y-6 px-6 pb-12 pt-6">
+          {/* ── Hero / account summary ─────────────────────────── */}
+          <section className="relative overflow-hidden rounded-3xl border border-border/70 bg-gradient-to-br from-violet-500/[0.08] via-background to-background p-6 sm:p-7">
+            <span
+              aria-hidden
+              className="pointer-events-none absolute -right-24 -top-24 size-64 rounded-full bg-violet-500/[0.10] blur-3xl"
+            />
+            <span
+              aria-hidden
+              className="pointer-events-none absolute -bottom-28 -left-24 size-72 rounded-full bg-indigo-500/[0.08] blur-3xl"
+            />
+
+            <div className="relative flex flex-col items-start gap-5 sm:flex-row sm:items-center sm:gap-6">
+              <AvatarPreview url={user?.avatar_url} initials={initials} />
+              <div className="min-w-0 flex-1">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-muted-foreground/80">
+                  Account
+                </p>
+                <h2 className="mt-1.5 truncate text-[26px] font-semibold leading-tight tracking-tight text-foreground">
+                  {fullName}
+                </h2>
+                <div className="mt-1.5 flex items-center gap-1.5 text-sm text-muted-foreground">
+                  <Mail className="size-3.5" strokeWidth={2.25} />
+                  <span className="truncate">{user?.email ?? '—'}</span>
+                </div>
+                <div className="mt-3 flex flex-wrap items-center gap-2">
+                  <RolePill role={user?.role} />
+                  {user?.is_verified && (
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-emerald-700 ring-1 ring-inset ring-emerald-500/20 dark:text-emerald-300">
+                      <BadgeCheck className="size-3" strokeWidth={2.5} />
+                      Verified
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          </section>
+
+          {/* ── Profile form ───────────────────────────────────── */}
+          <section className="space-y-3">
+            <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 px-1">
+              <div className="flex items-center gap-2">
+                <UserCircle className="size-4 text-violet-500" strokeWidth={2.25} />
+                <h2 className="text-[15px] font-semibold tracking-tight text-foreground">
+                  Profile
+                </h2>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Update your name, avatar, and how teammates see you.
+              </p>
+            </div>
+            <div className="overflow-hidden rounded-3xl border border-border/70 bg-card">
+              <ProfileForm />
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -11,6 +11,12 @@ export interface AcceptInvitationPayload {
   last_name?: string;
 }
 
+export interface UpdateProfilePayload {
+  first_name?: string;
+  last_name?: string;
+  avatar_url?: string | null;
+}
+
 export const authApi = {
   login: async (payload: LoginFormData): Promise<AuthLoginResponse> => {
     const { data } = await axios.post<AuthLoginResponse>('/auth/login', payload);
@@ -36,6 +42,10 @@ export const authApi = {
   },
   me: async (): Promise<User> => {
     const { data } = await axios.get<User>('/user/me');
+    return data;
+  },
+  updateMe: async (payload: UpdateProfilePayload): Promise<User> => {
+    const { data } = await axios.patch<User>('/user/me', payload);
     return data;
   },
   myOrg: async (): Promise<Organization | null> => {


### PR DESCRIPTION
## Summary
- New `/user-settings` route with a polished SaaS-style hero card (avatar preview, role pill, verified badge) and a sectioned profile form (Identity / Account) wired to a new Jotai `updateProfileAtom` that syncs the auth store so the sidebar refreshes immediately on save.
- Backend `PATCH /user/me` on Core + EE (whitelist updates `first_name` / `last_name` / `avatar_url`), backed by tightened `UserUpdate` Pydantic schema with length constraints.
- Sidebar popover entry **Settings → User settings**, rerouted from `/members` to `/user-settings`; Team Members entry unchanged.
- `frontend/src/lib/api/auth.ts` gains an `updateMe` wrapper; channel edit modal now renders `AppLoader` inside while `getChannel(id, include_config=true)` hydrates.

## Test plan
- [ ] Backend: `curl -X PATCH .../api/v1/user/me -d '{"first_name":"Foo"}'` returns 200 with the partially updated user; oversized strings return 422.
- [ ] Frontend: avatar → **User settings** opens the new page; editing name/avatar URL → Save → success toast → sidebar display updates immediately; refresh confirms persistence.
- [ ] Frontend: email + role are locked (lock icon visible); Save button stays disabled until the form is both valid and dirty.
- [ ] Frontend: opening the channel **edit** modal shows `AppLoader` until the hydrate request resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)