### PR TITLE
Model providers: per-(provider, service_type) listing + credential reuse

### DIFF
--- a/core/api/v1/services.py
+++ b/core/api/v1/services.py
@@ -66,10 +66,13 @@ def update_service(
 @router.delete("/providers/{provider_id}", status_code=status.HTTP_200_OK)
 def delete_provider_services(
     provider_id: str,
+    service_type: str | None = None,
     claims: JWTClaims = Depends(require_org_member),
     db: Session = Depends(get_db),
 ):
-    return _service(claims, db).delete_provider_services(provider_id)
+    return _service(claims, db).delete_provider_services(
+        provider_id, service_type=service_type
+    )
 
 
 @router.delete("/{service_id}", status_code=status.HTTP_200_OK)

--- a/core/services/model_provider_service.py
+++ b/core/services/model_provider_service.py
@@ -115,21 +115,28 @@ class ModelProviderService(BaseService):
             out[k].sort()
         return out
 
-    def _provider_model_count_map(
+    def _model_count_by_provider_kind_map(
         self, provider_ids: Iterable[UUID]
-    ) -> dict[str, int]:
+    ) -> dict[tuple[str, str], int]:
+        """{(provider_id_str, kind): count} for active models. Lets the
+        listing show kind-scoped model counts when each card represents
+        one (provider, service_type) pair."""
         ids = list(provider_ids)
         if not ids:
             return {}
         rows = (
-            self.db.query(Model.provider_id, func.count(Model.id))
+            self.db.query(Model.provider_id, Model.kind, func.count(Model.id))
             .filter(Model.provider_id.in_(ids), Model.is_active.is_(True))
-            .group_by(Model.provider_id)
+            .group_by(Model.provider_id, Model.kind)
             .all()
         )
-        return {str(pid): int(count) for pid, count in rows}
+        return {(str(pid), kind): int(count) for pid, kind, count in rows}
 
-    def _default_keys_map(self, provider_ids: Iterable[UUID]) -> dict[str, dict]:
+    def _default_keys_by_provider_kind_map(
+        self, provider_ids: Iterable[UUID]
+    ) -> dict[tuple[str, str], dict]:
+        """{(provider_id_str, service_type): default_key_dict}. The partial
+        unique index guarantees at most one default per (org, service_type)."""
         ids = list(provider_ids)
         if not ids:
             return {}
@@ -144,9 +151,9 @@ class ModelProviderService(BaseService):
             )
             .all()
         )
-        out: dict[str, dict] = {}
+        out: dict[tuple[str, str], dict] = {}
         for row in rows:
-            out[str(row.provider_id)] = {
+            out[(str(row.provider_id), row.service_type)] = {
                 "id": str(row.id),
                 "label": row.label,
                 "service_type": row.service_type,
@@ -235,7 +242,9 @@ class ModelProviderService(BaseService):
     # ─── list / aggregate ──────────────────────────────────────────────────
 
     def list_services(self, body: dict) -> dict:
-        """Aggregated list — one row per distinct provider the org has ≥1 ApiKey for."""
+        """Aggregated list — one row per distinct (provider, service_type)
+        the org has ≥1 ApiKey for. A Deepgram STT key and a Deepgram TTS key
+        therefore surface as two separate cards on the listing page."""
         page = max(int(body.get("page") or 1), 1)
         page_size = min(max(int(body.get("page_size") or 12), 1), 100)
         search = body.get("search")
@@ -248,23 +257,27 @@ class ModelProviderService(BaseService):
             case((ApiKey.is_active.is_(True), ApiKey.id))
         ).label("active_api_key_count")
         last_used_at = func.max(ApiKey.updated_at).label("last_used_at")
-        service_types_agg = func.array_agg(distinct(ApiKey.service_type)).label(
-            "service_types"
-        )
 
         q = (
             self.db.query(
                 ApiKey.provider_id.label("provider_id"),
+                ApiKey.service_type.label("service_type"),
                 ModelProvider.slug,
                 ModelProvider.display_name,
                 ModelProvider.description,
                 api_key_count,
                 active_api_key_count,
                 last_used_at,
-                service_types_agg,
             )
             .join(ModelProvider, ModelProvider.id == ApiKey.provider_id)
-            .filter(ApiKey.organization_id == self.org_id)
+            .filter(
+                ApiKey.organization_id == self.org_id,
+                # Each card represents one (provider, service_type) pair, so
+                # legacy rows with NULL service_type can't be rendered or
+                # deleted from the listing — exclude them rather than surface
+                # broken cards with empty badges and 400-ing delete CTAs.
+                ApiKey.service_type.isnot(None),
+            )
         )
 
         if search:
@@ -283,6 +296,7 @@ class ModelProviderService(BaseService):
 
         q = q.group_by(
             ApiKey.provider_id,
+            ApiKey.service_type,
             ModelProvider.slug,
             ModelProvider.display_name,
             ModelProvider.description,
@@ -304,31 +318,36 @@ class ModelProviderService(BaseService):
             if f in ALLOWED_USAGE_SORT_FIELDS:
                 order_col = sort_map[f]
                 desc_dir = d
-        q = q.order_by(order_col.desc() if desc_dir else order_col.asc())
+        # Stable tiebreak so STT/TTS rows for the same provider stay
+        # adjacent and in a consistent order across requests.
+        q = q.order_by(
+            order_col.desc() if desc_dir else order_col.asc(),
+            ModelProvider.display_name.asc(),
+            ApiKey.service_type.asc(),
+        )
 
         rows = q.offset((page - 1) * page_size).limit(page_size).all()
 
         provider_ids = [r.provider_id for r in rows if r.provider_id]
-        kinds_map = self._provider_kinds_map(provider_ids)
-        model_count_map = self._provider_model_count_map(provider_ids)
-        default_map = self._default_keys_map(provider_ids)
+        model_count_map = self._model_count_by_provider_kind_map(provider_ids)
+        default_map = self._default_keys_by_provider_kind_map(provider_ids)
 
         def _row_to_dict(r) -> dict:
             pid = str(r.provider_id)
-            sts = sorted({s for s in (r.service_types or []) if s})
+            kind = r.service_type
             return {
+                "id": f"{pid}:{kind}",
                 "provider": {
                     "id": pid,
                     "slug": r.slug,
                     "display_name": r.display_name,
                     "description": r.description,
                 },
-                "kinds": kinds_map.get(pid, []),
+                "service_type": kind,
                 "api_key_count": int(r.api_key_count or 0),
                 "active_api_key_count": int(r.active_api_key_count or 0),
-                "default_api_key": default_map.get(pid),
-                "service_types": sts,
-                "model_count": model_count_map.get(pid, 0),
+                "default_api_key": default_map.get((pid, kind)),
+                "model_count": model_count_map.get((pid, kind), 0),
                 "last_used_at": (
                     int(r.last_used_at.timestamp()) if r.last_used_at else None
                 ),
@@ -352,10 +371,46 @@ class ModelProviderService(BaseService):
         )
 
         api_key_value = (body.get("api_key") or "").strip()
-        if not api_key_value:
+        source_key_id = body.get("source_key_id")
+
+        # Exactly one of api_key / source_key_id must be provided. When
+        # source_key_id is given, copy the encrypted_key from an existing key
+        # on the same provider so the user doesn't have to paste the secret
+        # again when adding a second service (e.g. Deepgram STT → TTS).
+        if api_key_value and source_key_id:
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail="api_key is required"
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Provide either api_key or source_key_id, not both",
             )
+        if not api_key_value and not source_key_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="api_key or source_key_id is required",
+            )
+
+        if source_key_id:
+            src_uuid = _parse_uuid(source_key_id, field="source_key_id")
+            source = (
+                self.db.query(ApiKey)
+                .filter(
+                    ApiKey.id == src_uuid,
+                    ApiKey.organization_id == self.org_id,
+                )
+                .first()
+            )
+            if not source:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Source API key not found",
+                )
+            if source.provider_id != provider_id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="source_key_id must belong to the same provider",
+                )
+            encrypted_key = source.encrypted_key
+        else:
+            encrypted_key = encrypt(api_key_value)
 
         label = (body.get("label") or "").strip() or None
         description = (body.get("description") or "").strip() or None
@@ -377,7 +432,7 @@ class ModelProviderService(BaseService):
             organization_id=self.org_id,
             provider_id=provider_id,
             label=label,
-            encrypted_key=encrypt(api_key_value),
+            encrypted_key=encrypted_key,
             is_active=is_active,
             service_type=service_type,
             description=description,
@@ -523,17 +578,24 @@ class ModelProviderService(BaseService):
         self.db.commit()
         return {"ok": True}
 
-    def delete_provider_services(self, provider_id: str) -> dict:
+    def delete_provider_services(
+        self, provider_id: str, service_type: str | None = None
+    ) -> dict:
+        """Delete all of the org's API keys for the provider, or just those of
+        a single ``service_type`` when the listing's card is per-(provider,
+        kind) and the user only wants to remove that card."""
         prov_uuid = _parse_uuid(provider_id, field="provider id")
         self._provider_or_404(prov_uuid)
-        deleted = (
-            self.db.query(ApiKey)
-            .filter(
-                ApiKey.organization_id == self.org_id,
-                ApiKey.provider_id == prov_uuid,
-            )
-            .delete(synchronize_session=False)
+
+        validated_kind = _validate_service_type(service_type, required=False)
+
+        q = self.db.query(ApiKey).filter(
+            ApiKey.organization_id == self.org_id,
+            ApiKey.provider_id == prov_uuid,
         )
+        if validated_kind:
+            q = q.filter(ApiKey.service_type == validated_kind)
+        deleted = q.delete(synchronize_session=False)
         self.db.commit()
         return {"deleted": int(deleted)}
 
@@ -617,8 +679,34 @@ class ModelProviderService(BaseService):
         page_size = min(max(int(body.get("page_size") or 50), 1), 200)
         search = body.get("search")
         sort_by = body.get("sort_by")
+        service_type = _validate_service_type(
+            body.get("service_type"), required=False
+        )
 
         q = self.db.query(Model).filter(Model.provider_id == prov_uuid)
+
+        if service_type:
+            # Detail page is scoped to one (provider, kind). Narrow to just
+            # that kind regardless of which other kinds the org has keys for.
+            q = q.filter(Model.kind == service_type)
+        else:
+            # Fallback: restrict to the kinds the org actually has active API
+            # keys for, so e.g. a Deepgram-STT-only org doesn't see Deepgram's
+            # TTS models.
+            org_kinds = {
+                row[0]
+                for row in self.db.query(distinct(ApiKey.service_type))
+                .filter(
+                    ApiKey.organization_id == self.org_id,
+                    ApiKey.provider_id == prov_uuid,
+                    ApiKey.is_active.is_(True),
+                )
+                .all()
+                if row[0]
+            }
+            if org_kinds:
+                q = q.filter(Model.kind.in_(org_kinds))
+
         if search:
             q = q.filter(Model.name.ilike(f"%{search}%"))
 

--- a/ee/api/v1/services.py
+++ b/ee/api/v1/services.py
@@ -65,10 +65,13 @@ def update_service(
 @router.delete("/providers/{provider_id}", status_code=status.HTTP_200_OK)
 def delete_provider_services(
     provider_id: str,
+    service_type: str | None = None,
     claims: EEJWTClaims = Depends(require_ee_org_member),
     db: Session = Depends(get_db),
 ):
-    return _service(claims, db).delete_provider_services(provider_id)
+    return _service(claims, db).delete_provider_services(
+        provider_id, service_type=service_type
+    )
 
 
 @router.delete("/{service_id}", status_code=status.HTTP_200_OK)

--- a/frontend/src/app/(dashboard)/model-providers/[providerId]/[serviceType]/page.tsx
+++ b/frontend/src/app/(dashboard)/model-providers/[providerId]/[serviceType]/page.tsx
@@ -1,0 +1,5 @@
+import ServiceProviderDetailPage from '@/components/service-providers/ServiceProviderDetailPage';
+
+const Page = () => <ServiceProviderDetailPage />;
+
+export default Page;

--- a/frontend/src/app/(dashboard)/model-providers/[providerId]/page.tsx
+++ b/frontend/src/app/(dashboard)/model-providers/[providerId]/page.tsx
@@ -1,5 +1,9 @@
-import ServiceProviderDetailPage from '@/components/service-providers/ServiceProviderDetailPage';
+import { redirect } from 'next/navigation';
 
-const Page = () => <ServiceProviderDetailPage />;
+// Detail pages are now scoped to (provider, service_type). Land on the
+// listing instead of trying to guess which kind the user meant.
+const Page = () => {
+  redirect('/model-providers');
+};
 
 export default Page;

--- a/frontend/src/atoms/ServicesAtom.tsx
+++ b/frontend/src/atoms/ServicesAtom.tsx
@@ -17,7 +17,13 @@ import {
   type ListServicesParams,
   type ModelUpsertPayload,
 } from '@/services/servicesService';
-import type { ProviderModel, ProviderUsage, Service, ServiceUpsertPayload } from '@/types/service';
+import type {
+  ProviderModel,
+  ProviderUsage,
+  Service,
+  ServiceKind,
+  ServiceUpsertPayload,
+} from '@/types/service';
 
 // Each fetch atom tags its call with an incrementing token, so when filters,
 // sort, or page change rapidly we can drop responses that aren't from the
@@ -107,11 +113,15 @@ export const fetchServiceAtom = atom(
   async (_get, _set, id: string): Promise<Service> => getService(id),
 );
 
-// ─── delete every ApiKey for (org, provider) ───────────────────────────────
+// ─── delete every ApiKey for (org, provider) — optionally scoped to one kind ─
 export const deleteProviderAtom = atom(
   null,
-  async (_get, _set, providerId: string): Promise<{ deleted: number }> =>
-    deleteProviderServices(providerId),
+  async (
+    _get,
+    _set,
+    payload: { providerId: string; serviceType?: ServiceKind },
+  ): Promise<{ deleted: number }> =>
+    deleteProviderServices(payload.providerId, payload.serviceType),
 );
 
 // ─── per-provider keys state (detail page) ─────────────────────────────────

--- a/frontend/src/components/service-providers/ServiceProviderDetailPage.tsx
+++ b/frontend/src/components/service-providers/ServiceProviderDetailPage.tsx
@@ -44,8 +44,16 @@ const MODELS_PAGE_SIZE = 20;
 
 export default function ServiceProviderDetailPage() {
   const router = useRouter();
-  const params = useParams<{ providerId: string }>();
+  const params = useParams<{ providerId: string; serviceType?: string }>();
   const providerId = params?.providerId;
+  // The detail page is scoped to one (provider, service_type). The route is
+  // /model-providers/{providerId}/{serviceType}; the older /{providerId} URL
+  // now redirects to the listing.
+  const rawServiceType = params?.serviceType;
+  const serviceType: ServiceKind | null =
+    rawServiceType === 'llm' || rawServiceType === 'stt' || rawServiceType === 'tts'
+      ? rawServiceType
+      : null;
 
   const [keysState] = useAtom(providerKeysAtom);
   const [modelsState] = useAtom(providerModelsAtom);
@@ -117,9 +125,10 @@ export default function ServiceProviderDetailPage() {
         page_size: KEYS_PAGE_SIZE,
         search: keysSearch || undefined,
         sort_by: keysSort,
+        service_type: serviceType ?? undefined,
       },
     });
-  }, [providerId, keysPage, keysSearch, keysSort, fetchKeys]);
+  }, [providerId, keysPage, keysSearch, keysSort, serviceType, fetchKeys]);
 
   const reloadModels = useCallback(() => {
     if (!providerId) return Promise.resolve();
@@ -130,9 +139,10 @@ export default function ServiceProviderDetailPage() {
         page_size: MODELS_PAGE_SIZE,
         search: modelsSearch || undefined,
         sort_by: modelsSort,
+        service_type: serviceType ?? undefined,
       },
     });
-  }, [providerId, modelsPage, modelsSearch, modelsSort, fetchModels]);
+  }, [providerId, modelsPage, modelsSearch, modelsSort, serviceType, fetchModels]);
 
   useEffect(() => {
     reloadKeys().catch(handleApiError);
@@ -515,12 +525,24 @@ export default function ServiceProviderDetailPage() {
       <header className="flex shrink-0 items-center gap-3">
         <ProviderLogo
           providerName={provider?.slug}
-          serviceType={provider?.kinds[0] ?? ''}
+          serviceType={serviceType ?? provider?.kinds[0] ?? ''}
           className="size-10"
         />
         <div className="min-w-0 flex-1">
-          <h1 className="font-display text-2xl font-semibold leading-tight tracking-tight text-foreground">
-            {providerLoading ? 'Loading…' : (provider?.display_name ?? 'Unknown provider')}
+          <h1 className="flex items-center gap-2 font-display text-2xl font-semibold leading-tight tracking-tight text-foreground">
+            <span className="truncate">
+              {providerLoading ? 'Loading…' : (provider?.display_name ?? 'Unknown provider')}
+            </span>
+            {serviceType && (
+              <Badge
+                className={cn(
+                  'px-2 py-0 text-[10px] font-semibold uppercase tracking-wider',
+                  TYPE_BADGE_STYLES[serviceType] ?? '',
+                )}
+              >
+                {serviceType}
+              </Badge>
+            )}
           </h1>
           {provider?.description && (
             <p className="truncate text-xs text-muted-foreground">{provider.description}</p>
@@ -684,7 +706,7 @@ export default function ServiceProviderDetailPage() {
       <ApiKeyCreateDrawer
         open={createOpen}
         lockedProviderId={providerId}
-        defaultServiceType={(provider?.kinds[0] as ServiceKind) ?? null}
+        defaultServiceType={serviceType ?? (provider?.kinds[0] as ServiceKind) ?? null}
         onClose={() => setCreateOpen(false)}
         onSubmit={handleCreateKey}
         isPending={isSaving}
@@ -719,8 +741,10 @@ export default function ServiceProviderDetailPage() {
       <ModelFormDrawer
         open={modelDrawerOpen}
         editing={editingModel}
-        defaultKind={(provider?.kinds[0] as ServiceKind) ?? null}
-        allowedKinds={(provider?.kinds as ServiceKind[]) ?? undefined}
+        defaultKind={serviceType ?? (provider?.kinds[0] as ServiceKind) ?? null}
+        allowedKinds={
+          serviceType ? [serviceType] : ((provider?.kinds as ServiceKind[]) ?? undefined)
+        }
         onClose={() => {
           setModelDrawerOpen(false);
           setEditingModel(null);

--- a/frontend/src/components/service-providers/ServiceProvidersPage.tsx
+++ b/frontend/src/components/service-providers/ServiceProvidersPage.tsx
@@ -13,6 +13,7 @@ import servicesAtom, {
 } from '@/atoms/ServicesAtom';
 import { CustomButton, CustomModal, SearchBar, SelectInput } from '@/components/shared';
 import { Badge } from '@/components/ui/badge';
+import { listProviderKeys } from '@/services/servicesService';
 import type { ProviderUsage, Service, ServiceKind, ServiceUpsertPayload } from '@/types/service';
 import { handleApiError } from '@/utils/helpers';
 import { showToast } from '@/utils/toast';
@@ -42,7 +43,9 @@ export default function ServiceProvidersPage() {
   const [search, setSearch] = useState('');
   const [typeFilter, setTypeFilter] = useState<'all' | ServiceKind>('all');
   const [createOpen, setCreateOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
   const [editingService, setEditingService] = useState<Service | null>(null);
+  const [editLoading, setEditLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<ProviderUsage | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -104,7 +107,7 @@ export default function ServiceProvidersPage() {
 
   const handleSelect = useCallback(
     (u: ProviderUsage) => {
-      router.push(`/model-providers/${u.provider.id}`);
+      router.push(`/model-providers/${u.provider.id}/${u.service_type}`);
     },
     [router],
   );
@@ -115,20 +118,45 @@ export default function ServiceProvidersPage() {
 
   const handleEdit = useCallback(
     async (u: ProviderUsage) => {
-      const keyId = u.default_api_key?.id;
-      if (!keyId) {
-        router.push(`/model-providers/${u.provider.id}`);
-        return;
-      }
+      // Open the drawer immediately with a loader, then resolve the key.
+      // Prefer the default key for this (provider, kind); fall back to the
+      // most recently updated key of that kind so the pencil always opens an
+      // editor instead of bouncing the user to the detail page.
+      setEditingService(null);
+      setEditOpen(true);
+      setEditLoading(true);
       try {
+        let keyId = u.default_api_key?.id;
+        if (!keyId) {
+          const { rows } = await listProviderKeys(u.provider.id, {
+            page: 1,
+            page_size: 1,
+            service_type: u.service_type,
+            sort_by: '-updated_at',
+          });
+          keyId = rows[0]?.id;
+        }
+        if (!keyId) {
+          setEditOpen(false);
+          router.push(`/model-providers/${u.provider.id}/${u.service_type}`);
+          return;
+        }
         const svc = await fetchService(keyId);
         setEditingService(svc);
       } catch (err) {
+        setEditOpen(false);
         handleApiError(err);
+      } finally {
+        setEditLoading(false);
       }
     },
     [fetchService, router],
   );
+
+  const handleEditClose = useCallback(() => {
+    setEditOpen(false);
+    setEditingService(null);
+  }, []);
 
   const handleDeleteRequest = useCallback((u: ProviderUsage) => {
     setDeleteTarget(u);
@@ -138,13 +166,20 @@ export default function ServiceProvidersPage() {
     if (!deleteTarget) return;
     setIsDeleting(true);
     try {
-      const { deleted } = await deleteProvider(deleteTarget.provider.id);
+      const { deleted } = await deleteProvider({
+        providerId: deleteTarget.provider.id,
+        serviceType: deleteTarget.service_type,
+      });
+      // Keep the modal open with the Delete button still in its loading state
+      // until the listing refresh lands, so the user doesn't see a stale card
+      // briefly remain after dismissing the dialog.
+      await loadInitial();
+      const typeLabel = deleteTarget.service_type.toUpperCase();
       showToast.success(
         `Removed ${deleted} key${deleted === 1 ? '' : 's'}`,
-        `All keys for ${deleteTarget.provider.display_name} have been deleted.`,
+        `${deleteTarget.provider.display_name} · ${typeLabel} keys have been deleted.`,
       );
       setDeleteTarget(null);
-      await loadInitial();
     } catch (err) {
       handleApiError(err);
     } finally {
@@ -157,9 +192,11 @@ export default function ServiceProvidersPage() {
       setIsSaving(true);
       try {
         await upsertService({ values: payload });
+        // Wait for the listing refresh before dismissing the drawer so the
+        // Create button keeps its loading state until the new card is in view.
+        await loadInitial();
         showToast.success('Provider added');
         setCreateOpen(false);
-        await loadInitial();
       } catch (err) {
         handleApiError(err);
       } finally {
@@ -174,9 +211,12 @@ export default function ServiceProvidersPage() {
       setIsSaving(true);
       try {
         await upsertService({ id, values: payload as ServiceUpsertPayload });
-        showToast.success('Provider updated');
-        setEditingService(null);
+        // Mirror handleCreate / handleDeleteConfirm: keep the Save button in
+        // its loading state until the refreshed list lands.
         await loadInitial();
+        showToast.success('Provider updated');
+        setEditOpen(false);
+        setEditingService(null);
       } catch (err) {
         handleApiError(err);
       } finally {
@@ -262,11 +302,15 @@ export default function ServiceProvidersPage() {
         isPending={isSaving}
       />
 
-      {/* edit drawer */}
+      {/* edit drawer — opened from the listing where each card is a provider
+          connection, so the copy mirrors the "Add provider" button. */}
       <ApiKeyEditDrawer
-        open={!!editingService}
+        open={editOpen}
         editing={editingService}
-        onClose={() => setEditingService(null)}
+        loading={editLoading}
+        title="Edit provider"
+        description="Update this provider connection. To rotate the secret, delete this key and add a new one."
+        onClose={handleEditClose}
         onSubmit={handleUpdate}
         isPending={isSaving}
       />
@@ -278,7 +322,7 @@ export default function ServiceProvidersPage() {
         title="Delete provider keys?"
         description={
           deleteTarget
-            ? `This will permanently delete ${deleteTarget.api_key_count} key${
+            ? `This will permanently delete ${deleteTarget.api_key_count} ${deleteTarget.service_type.toUpperCase()} key${
                 deleteTarget.api_key_count === 1 ? '' : 's'
               } for ${deleteTarget.provider.display_name}. Agents using these credentials will stop working.`
             : ''

--- a/frontend/src/components/service-providers/api-key-create-drawer.tsx
+++ b/frontend/src/components/service-providers/api-key-create-drawer.tsx
@@ -6,12 +6,18 @@ import {
   CheckboxField,
   CustomButton,
   CustomDrawer,
+  RadioGroupField,
   SelectInput,
   TextAreaField,
   TextInput,
 } from '@/components/shared';
-import { listProviderCatalog } from '@/services/servicesService';
-import type { ProviderCatalogItem, ServiceKind, ServiceUpsertPayload } from '@/types/service';
+import { listProviderCatalog, listProviderKeys } from '@/services/servicesService';
+import type {
+  ProviderCatalogItem,
+  Service,
+  ServiceKind,
+  ServiceUpsertPayload,
+} from '@/types/service';
 import { handleApiError } from '@/utils/helpers';
 import { showToast } from '@/utils/toast';
 
@@ -31,6 +37,19 @@ const SERVICE_TYPE_OPTIONS = [
   { value: 'stt', label: 'Speech-to-Text' },
   { value: 'tts', label: 'Text-to-Speech' },
 ];
+
+const SERVICE_TYPE_LABEL: Record<ServiceKind, string> = {
+  llm: 'LLM',
+  stt: 'STT',
+  tts: 'TTS',
+};
+
+const KEY_SOURCE_OPTIONS = [
+  { value: 'new', label: 'Enter a new key' },
+  { value: 'reuse', label: 'Use an existing key' },
+];
+
+type KeySource = 'new' | 'reuse';
 
 interface FormState {
   service_type: ServiceKind | '';
@@ -71,9 +90,20 @@ export default function ApiKeyCreateDrawer({
   const [providers, setProviders] = useState<ProviderCatalogItem[]>([]);
   const [catalogLoading, setCatalogLoading] = useState(false);
 
+  // Existing keys for the currently selected provider — drives the
+  // "Use an existing key" option so the user doesn't have to retype a
+  // credential they've already stored (e.g. Deepgram STT → TTS).
+  const [existingKeys, setExistingKeys] = useState<Service[]>([]);
+  const [existingKeysLoading, setExistingKeysLoading] = useState(false);
+  const [keySource, setKeySource] = useState<KeySource>('new');
+  const [sourceKeyId, setSourceKeyId] = useState('');
+
   useEffect(() => {
     if (open) {
       setForm(initialFormState(lockedProviderId, defaultServiceType));
+      setKeySource('new');
+      setSourceKeyId('');
+      setExistingKeys([]);
     }
   }, [open, lockedProviderId, defaultServiceType]);
 
@@ -96,12 +126,61 @@ export default function ApiKeyCreateDrawer({
     };
   }, [open]);
 
+  // Fetch existing keys whenever the selected provider changes. Skip when the
+  // drawer is closed or no provider has been picked yet.
+  useEffect(() => {
+    // Reset selection when the provider changes so we don't carry a key id
+    // that belongs to the previous provider into the new options.
+    setSourceKeyId('');
+    if (!open || !form.provider_id) {
+      setExistingKeys([]);
+      return;
+    }
+    let cancelled = false;
+    setExistingKeysLoading(true);
+    listProviderKeys(form.provider_id, { page: 1, page_size: 100, status: 'active' })
+      .then((res) => {
+        if (cancelled) return;
+        setExistingKeys(res.rows);
+      })
+      .catch((err) => {
+        if (!cancelled) handleApiError(err);
+      })
+      .finally(() => {
+        if (!cancelled) setExistingKeysLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, form.provider_id]);
+
+  // When existing keys arrive, pre-select the default (or first) so the
+  // "reuse" option works on first click without an extra interaction.
+  useEffect(() => {
+    if (existingKeys.length === 0) {
+      setSourceKeyId('');
+      if (keySource === 'reuse') setKeySource('new');
+      return;
+    }
+    const preferred = existingKeys.find((k) => k.is_default) ?? existingKeys[0];
+    setSourceKeyId((prev) => prev || preferred.id);
+  }, [existingKeys, keySource]);
+
   const providerOptions = useMemo(() => {
     const filtered = form.service_type
       ? providers.filter((p) => p.kinds.includes(form.service_type as ServiceKind))
       : providers;
     return filtered.map((p) => ({ value: p.id, label: p.display_name }));
   }, [providers, form.service_type]);
+
+  const existingKeyOptions = useMemo(
+    () =>
+      existingKeys.map((k) => ({
+        value: k.id,
+        label: `${k.label || 'Unnamed key'} · ${SERVICE_TYPE_LABEL[k.service_type]}`,
+      })),
+    [existingKeys],
+  );
 
   const update = <K extends keyof FormState>(key: K, value: FormState[K]) => {
     setForm((prev) => ({ ...prev, [key]: value }));
@@ -119,11 +198,19 @@ export default function ApiKeyCreateDrawer({
   };
 
   const trimmedKey = form.api_key.trim();
-  const canSubmit = form.service_type !== '' && form.provider_id !== '' && trimmedKey.length > 0;
+  const canSubmit =
+    form.service_type !== '' &&
+    form.provider_id !== '' &&
+    (keySource === 'new' ? trimmedKey.length > 0 : sourceKeyId !== '');
 
   const handleConfirm = async () => {
     if (!canSubmit) {
-      showToast.error('Required fields missing', 'Provider, service type, and key are required.');
+      showToast.error(
+        'Required fields missing',
+        keySource === 'reuse'
+          ? 'Provider, service type, and an existing key are required.'
+          : 'Provider, service type, and key are required.',
+      );
       return;
     }
 
@@ -134,7 +221,7 @@ export default function ApiKeyCreateDrawer({
       description: form.description.trim() || undefined,
       is_default: form.is_default,
       is_active: form.is_active,
-      api_key: trimmedKey,
+      ...(keySource === 'new' ? { api_key: trimmedKey } : { source_key_id: sourceKeyId }),
     };
 
     try {
@@ -153,12 +240,23 @@ export default function ApiKeyCreateDrawer({
         ? 'No providers support this type'
         : 'Select a provider';
 
+  const showKeySourceToggle = form.provider_id !== '' && existingKeys.length > 0;
+
+  // When the drawer is opened from the listing page the user is adding a new
+  // provider connection; from the detail page they're adding another key to
+  // an already-connected provider, so the copy differs.
+  const isAddingProvider = !lockedProviderId;
+  const drawerTitle = isAddingProvider ? 'Add provider' : 'Add API key';
+  const drawerDescription = isAddingProvider
+    ? 'Connect a model provider with an API key so your agents can use it.'
+    : 'Add another API key for this provider.';
+
   return (
     <CustomDrawer
       open={open}
       onClose={onClose}
-      title="Add API key"
-      description="Connect a provider with an API key so your agents can use it."
+      title={drawerTitle}
+      description={drawerDescription}
       width="sm:max-w-lg"
       footer={
         <div className="flex justify-end gap-2">
@@ -212,15 +310,38 @@ export default function ApiKeyCreateDrawer({
           rows={2}
           placeholder="Optional notes for your team."
         />
-        <TextInput
-          name="api_key"
-          label="API key"
-          type="password"
-          value={form.api_key}
-          onChange={(e) => update('api_key', e.target.value)}
-          placeholder="sk-..."
-          isRequired
-        />
+        {showKeySourceToggle && (
+          <RadioGroupField
+            name="key_source"
+            label="API key"
+            options={KEY_SOURCE_OPTIONS}
+            value={keySource}
+            onValueChange={(v) => setKeySource(v as KeySource)}
+            orientation="horizontal"
+          />
+        )}
+        {keySource === 'reuse' && showKeySourceToggle ? (
+          <SelectInput
+            name="source_key_id"
+            label="Existing key"
+            options={existingKeyOptions}
+            value={sourceKeyId}
+            onValueChange={setSourceKeyId}
+            placeholder="Select an existing key"
+            loading={existingKeysLoading}
+            isRequired
+          />
+        ) : (
+          <TextInput
+            name="api_key"
+            label={showKeySourceToggle ? 'New API key' : 'API key'}
+            type="password"
+            value={form.api_key}
+            onChange={(e) => update('api_key', e.target.value)}
+            placeholder="sk-..."
+            isRequired
+          />
+        )}
         <div className="flex flex-wrap items-center gap-6">
           <CheckboxField
             id="is_active"

--- a/frontend/src/components/service-providers/api-key-edit-drawer.tsx
+++ b/frontend/src/components/service-providers/api-key-edit-drawer.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 
 import {
+  AppLoader,
   CheckboxField,
   CustomButton,
   CustomDrawer,
@@ -19,6 +20,13 @@ import { TYPE_BADGE_STYLES } from './constants';
 interface ApiKeyEditDrawerProps {
   open: boolean;
   editing: Service | null;
+  /** Override drawer copy when opened from a different surface (e.g. the
+   * listing page, where the card represents a provider connection). */
+  title?: string;
+  description?: string;
+  /** When true, render an in-drawer spinner instead of the form. Used so the
+   * drawer can pop open immediately while the parent fetches the key. */
+  loading?: boolean;
   onClose: () => void;
   onSubmit: (payload: Partial<ServiceUpsertPayload>, id: string) => Promise<void>;
   isPending: boolean;
@@ -51,6 +59,9 @@ function initialFormState(editing: Service | null): FormState {
 export default function ApiKeyEditDrawer({
   open,
   editing,
+  title = 'Edit API key',
+  description = 'Update key details. To rotate the secret, delete this key and add a new one.',
+  loading = false,
   onClose,
   onSubmit,
   isPending,
@@ -88,69 +99,78 @@ export default function ApiKeyEditDrawer({
     <CustomDrawer
       open={open}
       onClose={onClose}
-      title="Edit API key"
-      description="Update key details. To rotate the secret, delete this key and add a new one."
+      title={title}
+      description={description}
       width="sm:max-w-lg"
       footer={
         <div className="flex justify-end gap-2">
           <CustomButton type="default" onClick={onClose} disabled={isPending}>
             Cancel
           </CustomButton>
-          <CustomButton type="primary" onClick={handleConfirm} loading={isPending}>
+          <CustomButton
+            type="primary"
+            onClick={handleConfirm}
+            loading={isPending}
+            disabled={loading || !editing}
+          >
             Save
           </CustomButton>
         </div>
       }
     >
-      <div className="flex flex-col gap-4 pt-1">
-        {editing && (
-          <div className="flex flex-wrap items-center gap-2 rounded-md border border-border/70 bg-muted/30 px-3 py-2 text-xs">
-            <span className="text-muted-foreground">Provider</span>
-            <span className="font-medium text-foreground">
-              {editing.provider?.display_name ?? '—'}
-            </span>
-            <span className="text-muted-foreground/40">·</span>
-            <Badge
-              className={cn(
-                'px-2 py-0 text-[10px] font-semibold uppercase tracking-wider',
-                TYPE_BADGE_STYLES[editing.service_type] ?? '',
-              )}
-            >
-              {editing.service_type}
-            </Badge>
-          </div>
-        )}
+      {loading && !editing ? (
+        <AppLoader className="min-h-0 flex-1 py-16" />
+      ) : (
+        <div className="flex flex-col gap-4 pt-1">
+          {editing && (
+            <div className="flex flex-wrap items-center gap-2 rounded-md border border-border/70 bg-muted/30 px-3 py-2 text-xs">
+              <span className="text-muted-foreground">Provider</span>
+              <span className="font-medium text-foreground">
+                {editing.provider?.display_name ?? '—'}
+              </span>
+              <span className="text-muted-foreground/40">·</span>
+              <Badge
+                className={cn(
+                  'px-2 py-0 text-[10px] font-semibold uppercase tracking-wider',
+                  TYPE_BADGE_STYLES[editing.service_type] ?? '',
+                )}
+              >
+                {editing.service_type}
+              </Badge>
+            </div>
+          )}
 
-        <TextInput
-          name="label"
-          label="Service name"
-          value={form.label}
-          onChange={(e) => update('label', e.target.value)}
-          placeholder="e.g. OpenAI production"
-        />
-        <TextAreaField
-          id="description"
-          label="Description"
-          value={form.description}
-          onChange={(e) => update('description', e.target.value)}
-          rows={2}
-          placeholder="Optional notes for your team."
-        />
-        <div className="flex flex-wrap items-center gap-6">
-          <CheckboxField
-            id="is_active"
-            label="Active"
-            checked={form.is_active}
-            onCheckedChange={(v) => update('is_active', !!v)}
+          <TextInput
+            name="label"
+            label="Service name"
+            value={form.label}
+            onChange={(e) => update('label', e.target.value)}
+            placeholder="e.g. OpenAI production"
           />
-          <CheckboxField
-            id="is_default"
-            label="Default for this service type"
-            checked={form.is_default}
-            onCheckedChange={(v) => update('is_default', !!v)}
+          <TextAreaField
+            id="description"
+            label="Description"
+            value={form.description}
+            onChange={(e) => update('description', e.target.value)}
+            rows={2}
+            placeholder="Optional notes for your team."
           />
+          <div className="flex flex-wrap items-center gap-6">
+            <CheckboxField
+              id="is_active"
+              label="Active"
+              checked={form.is_active}
+              onCheckedChange={(v) => update('is_active', !!v)}
+            />
+            <CheckboxField
+              id="is_default"
+              label="Default for this service type"
+              checked={form.is_default}
+              onCheckedChange={(v) => update('is_default', !!v)}
+            />
+          </div>
         </div>
-      </div>
+      )}
     </CustomDrawer>
   );
 }

--- a/frontend/src/components/service-providers/service-card.tsx
+++ b/frontend/src/components/service-providers/service-card.tsx
@@ -59,7 +59,7 @@ export default function ServiceCard({ usage, onClick, onEdit, onDelete }: Servic
         <div className="flex items-start gap-3">
           <ProviderLogo
             providerName={usage.provider.slug}
-            serviceType={usage.service_types[0] ?? ''}
+            serviceType={usage.service_type}
             className="size-11 shrink-0"
           />
           <div className="min-w-0 flex-1">
@@ -102,19 +102,16 @@ export default function ServiceCard({ usage, onClick, onEdit, onDelete }: Servic
           </div>
         </div>
 
-        {/* type pills + default indicator */}
+        {/* type pill + default indicator */}
         <div className="flex flex-wrap items-center gap-2">
-          {usage.service_types.map((t) => (
-            <Badge
-              key={t}
-              className={cn(
-                'px-2 py-0 text-[10px] font-semibold uppercase tracking-wider',
-                TYPE_BADGE_STYLES[t] ?? '',
-              )}
-            >
-              {t}
-            </Badge>
-          ))}
+          <Badge
+            className={cn(
+              'px-2 py-0 text-[10px] font-semibold uppercase tracking-wider',
+              TYPE_BADGE_STYLES[usage.service_type] ?? '',
+            )}
+          >
+            {usage.service_type}
+          </Badge>
           {usage.default_api_key && (
             <span
               className="inline-flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground"

--- a/frontend/src/components/service-providers/service-grid.tsx
+++ b/frontend/src/components/service-providers/service-grid.tsx
@@ -61,7 +61,7 @@ export default function ServiceGrid({
         <AnimatePresence mode="popLayout">
           {items.map((u) => (
             <ServiceCard
-              key={u.provider.id}
+              key={u.id}
               usage={u}
               onClick={onSelect}
               onEdit={onEdit}

--- a/frontend/src/services/servicesService.ts
+++ b/frontend/src/services/servicesService.ts
@@ -56,8 +56,14 @@ export async function deleteService(id: string): Promise<void> {
   await axios.delete(`/services/${id}`);
 }
 
-export async function deleteProviderServices(providerId: string): Promise<{ deleted: number }> {
-  const { data } = await axios.delete<{ deleted: number }>(`/services/providers/${providerId}`);
+export async function deleteProviderServices(
+  providerId: string,
+  serviceType?: 'llm' | 'stt' | 'tts',
+): Promise<{ deleted: number }> {
+  const { data } = await axios.delete<{ deleted: number }>(
+    `/services/providers/${providerId}`,
+    serviceType ? { params: { service_type: serviceType } } : undefined,
+  );
   return data;
 }
 
@@ -93,6 +99,7 @@ export interface ListProviderModelsParams {
   page_size?: number;
   search?: string;
   sort_by?: string;
+  service_type?: 'llm' | 'stt' | 'tts';
 }
 
 export async function listProviderModels(

--- a/frontend/src/types/service.ts
+++ b/frontend/src/types/service.ts
@@ -29,7 +29,13 @@ export interface ServiceUpsertPayload {
   description?: string;
   is_default?: boolean;
   is_active?: boolean;
+  /** Plaintext API key. Mutually exclusive with `source_key_id` on create. */
   api_key?: string;
+  /**
+   * ID of an existing ApiKey for the same provider whose encrypted credential
+   * should be copied into the new row. Mutually exclusive with `api_key`.
+   */
+  source_key_id?: string;
   config?: Record<string, unknown>;
 }
 
@@ -41,10 +47,16 @@ export interface ProviderCatalogItem {
   kinds: ServiceKind[];
 }
 
-/** Aggregated "card" view — one row per provider the org has ≥1 ApiKey for. */
+/**
+ * Aggregated "card" view — one row per (provider, service_type) the org has
+ * ≥1 ApiKey for. A Deepgram STT key and a Deepgram TTS key therefore surface
+ * as two separate cards. `id` is the composite `${providerId}:${serviceType}`
+ * so React lists have a stable key.
+ */
 export interface ProviderUsage {
+  id: string;
   provider: ServiceProviderRef;
-  kinds: ServiceKind[];
+  service_type: ServiceKind;
   api_key_count: number;
   active_api_key_count: number;
   default_api_key: {
@@ -52,7 +64,6 @@ export interface ProviderUsage {
     label: string | null;
     service_type: ServiceKind;
   } | null;
-  service_types: ServiceKind[];
   model_count: number;
   last_used_at: number | null;
 }


### PR DESCRIPTION
## Summary
- Listing groups by `(provider_id, service_type)` so e.g. Deepgram STT and TTS show as separate cards; the nested route `/model-providers/{providerId}/{serviceType}` scopes the detail page, and the old single-segment URL redirects to the listing.
- `POST /services` accepts `source_key_id` so a second service for the same provider can reuse an already-stored encrypted credential without retyping (e.g. Deepgram STT → TTS). `DELETE /services/providers/{id}` takes a `service_type` query param to scope removal to one card.
- Create drawer adds a "new vs. existing key" toggle (resetting selection when provider changes), edit drawer pops open immediately with a loader while the parent resolves the key id, and legacy rows with `NULL` service_type are filtered out of the listing to avoid broken cards.

## Test plan
- [ ] Add Deepgram STT, then add a Deepgram TTS using "Use an existing key" — verify both cards show, both work, and only one secret was entered.
- [ ] On the listing, delete a single card and confirm only that `service_type`'s keys are removed.
- [ ] In the create drawer (Add provider), switch provider mid-flow and verify the existing-key select clears.
- [ ] Visit the old `/model-providers/{id}` URL and confirm it redirects to the listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)