### PR TITLE
fix(tools): always refetch tool list on mount

### DIFF
--- a/frontend/src/lib/api/tools.ts
+++ b/frontend/src/lib/api/tools.ts
@@ -40,6 +40,10 @@ export function useTools(params: ListToolsParams = {}) {
     queryKey: [TOOLS_QUERY_KEY, params],
     queryFn: () => toolsApi.list(params),
     placeholderData: (prev) => prev,
+    // The create/edit flow upserts via Jotai atoms and does not invalidate this
+    // cache, so always refetch on mount to pick up changes when returning to the
+    // list page (otherwise the 30s global staleTime serves stale data).
+    refetchOnMount: 'always',
   });
 }
 


### PR DESCRIPTION
The tools list relied on the global React Query 30s `staleTime`, but the tool create/edit flow upserts via Jotai atoms and never invalidates the `TOOLS_QUERY_KEY` cache. As a result, returning to the list page within 30s served stale cached data and skipped the `/tool/list` call, so newly created or edited tools did not appear. This sets `refetchOnMount: 'always'` on the `useTools` query so the list endpoint fires on every mount, while `placeholderData` keeps the previous rows visible during the refetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)