### PR TITLE
fix(call-history): remove duplicate component-level padding

### DIFF
--- a/frontend/src/components/call-history/CallHistory.tsx
+++ b/frontend/src/components/call-history/CallHistory.tsx
@@ -245,7 +245,7 @@ const CallHistory: React.FC = () => {
   ];
 
   return (
-    <div className="animate-page flex h-full flex-col gap-5 p-6">
+    <div className="animate-page flex h-full flex-col gap-5">
       <div>
         <h1 className="text-2xl font-semibold tracking-tight text-foreground">Call History</h1>
         <p className="mt-1 text-sm text-muted-foreground">


### PR DESCRIPTION
The dashboard layout's `<main>` already applies `p-6` to every page, but the Call History component added another `p-6` on its own root, producing double padding and making it inconsistent with the other list pages (Tools, Knowledge Base). This drops the component-level padding so Call History aligns with the rest of the dashboard pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)