### PR TITLE
fix(calendar): declare end_date/end_time in tool schema; tz-anchor bot date

### DIFF
--- a/core/bot.py
+++ b/core/bot.py
@@ -6,6 +6,8 @@
 
 import os
 import time as _time
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 from dotenv import load_dotenv
 from loguru import logger
@@ -246,8 +248,27 @@ async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
         llm = resolved["llm"]
         stt = resolved["stt"]
         tts = resolved["tts"]
+        # Anchor the model to the real current date. gpt-4o-mini has no clock, so
+        # without this it invents years (e.g. 2023) and can't enforce "no past dates".
+        # Resolve "today" in a configurable timezone (AGENT_TIMEZONE, default UTC) so
+        # the anchor matches the caller's locale instead of naive server-local time,
+        # which otherwise drifts a day at the midnight boundary. Falls back to UTC on
+        # an unknown zone.
+        from core.config import settings
+        _tz_name = getattr(settings, "AGENT_TIMEZONE", None) or "UTC"
+        try:
+            _now = datetime.now(ZoneInfo(_tz_name))
+        except Exception:
+            _tz_name = "UTC"
+            _now = datetime.now(timezone.utc)
+        _today = _now.strftime("%Y-%m-%d")
+        _date_preamble = (
+            f"Today's date is {_today} ({_tz_name}, YYYY-MM-DD). Treat this as the current date "
+            f"for all date reasoning. Never use a year earlier than the current year, and "
+            f"never schedule or book a date earlier than today.\n\n"
+        )
         messages = [
-            {"role": "system", "content": resolved["system_prompt"]},
+            {"role": "system", "content": _date_preamble + resolved["system_prompt"]},
         ]
         first_message = resolved.get("first_message")
         if first_message:
@@ -474,10 +495,14 @@ async def bot(runner_args: RunnerArguments, call_type: str = None):
         )
     
     elif isinstance(runner_args, DailyRunnerArguments):
+        # Daily participant display name for the bot. Not hardcoded to any one
+        # agent — configurable per deployment (BOT_DISPLAY_NAME), generic default.
+        from core.config import settings
+        bot_display_name = getattr(settings, "BOT_DISPLAY_NAME", None) or "AI Voice Agent"
         transport = DailyTransport(
             runner_args.room_url,
             runner_args.token,
-            "Hotel Booking Bot",
+            bot_display_name,
             DailyParams(
                 audio_in_enabled=True,
                 audio_out_enabled=True,

--- a/core/services/custom_tool_service.py
+++ b/core/services/custom_tool_service.py
@@ -358,30 +358,46 @@ def _create_google_calendar_handler(tool: Tool, org_id=None, tool_call_entries: 
 async def _calendar_create_event(base_url: str, headers: dict, arguments: dict, timezone: str) -> str:
     """Create a calendar event."""
     title = arguments.get("title", "Appointment")
-    date = arguments.get("date")  # e.g. "2026-05-10"
+    date = arguments.get("date")  # check-in / event date, e.g. "2026-11-01"
+    end_date = arguments.get("end_date")  # check-out date for multi-day stays
     start_time = arguments.get("start_time")  # e.g. "14:00"
+    end_time = arguments.get("end_time")  # e.g. "21:00"
     duration_minutes = int(arguments.get("duration_minutes", 30))
     description = arguments.get("description", "")
     attendee_email = arguments.get("attendee_email")
 
-    if not date or not start_time:
-        return "Error: 'date' and 'start_time' are required to create an event."
+    if not date:
+        return "Error: 'date' is required to create an event."
 
-    # Build start/end datetime strings
-    start_dt = f"{date}T{start_time}:00"
-    # Calculate end time
-    start_hour, start_min = map(int, start_time.split(":"))
-    total_minutes = start_hour * 60 + start_min + duration_minutes
-    end_hour = total_minutes // 60
-    end_min = total_minutes % 60
-    end_dt = f"{date}T{end_hour:02d}:{end_min:02d}:00"
-
-    event_body = {
-        "summary": title,
-        "description": description,
-        "start": {"dateTime": start_dt, "timeZone": timezone},
-        "end": {"dateTime": end_dt, "timeZone": timezone},
-    }
+    if end_date and not start_time:
+        # All-day, multi-day event — e.g. a hotel stay from check-in to check-out.
+        # Google all-day events use date-only start/end, and end.date is EXCLUSIVE,
+        # so passing the check-out date spans the nights of the stay.
+        event_body = {
+            "summary": title,
+            "description": description,
+            "start": {"date": date},
+            "end": {"date": end_date},
+        }
+        when_desc = f"{date} to {end_date} (all-day)"
+    else:
+        if not start_time:
+            return "Error: provide 'start_time' for a timed event, or 'end_date' for an all-day stay."
+        start_dt = f"{date}T{start_time}:00"
+        if end_time:
+            # Honor an explicit end time (and an optional end_date for overnight slots).
+            end_dt = f"{end_date or date}T{end_time}:00"
+        else:
+            start_hour, start_min = map(int, start_time.split(":"))
+            total_minutes = start_hour * 60 + start_min + duration_minutes
+            end_dt = f"{date}T{total_minutes // 60:02d}:{total_minutes % 60:02d}:00"
+        event_body = {
+            "summary": title,
+            "description": description,
+            "start": {"dateTime": start_dt, "timeZone": timezone},
+            "end": {"dateTime": end_dt, "timeZone": timezone},
+        }
+        when_desc = f"{date} {start_time}" + (f"-{end_time}" if end_time else "")
 
     if attendee_email:
         event_body["attendees"] = [{"email": attendee_email}]
@@ -394,7 +410,7 @@ async def _calendar_create_event(base_url: str, headers: dict, arguments: dict, 
     if response.status_code in (200, 201):
         event = response.json()
         logger.info("google_calendar create_event SUCCESS: event_id={} status={} htmlLink={}", event.get("id"), event.get("status"), event.get("htmlLink"))
-        return f"Event '{title}' created successfully on {date} at {start_time} for {duration_minutes} minutes. Event link: {event.get('htmlLink', 'N/A')}"
+        return f"Event '{title}' created successfully ({when_desc}). Event link: {event.get('htmlLink', 'N/A')}"
     else:
         logger.error("google_calendar create_event FAILED: status={} body={}", response.status_code, response.text)
         return f"Failed to create event: {response.text}"

--- a/core/services/mcp_server_service.py
+++ b/core/services/mcp_server_service.py
@@ -58,21 +58,46 @@ def _try_decrypt(value):
 
 
 def build_auth_headers(auth_config, already_decrypted=False) -> dict:
-    """Build HTTP headers from auth_config."""
+    """Build HTTP headers from auth_config.
+
+    All auth sources are MERGED (not mutually exclusive), because the UI lets a
+    server use an API key / bearer token AND custom HTTP headers at the same time
+    (e.g. ClickUp: ``Authorization: Bearer <key>`` plus ``x-workspace-id``).
+    Explicit custom headers win on name conflicts; the api_key/token only fills
+    ``Authorization`` if a custom header hasn't already set it.
+    """
     if not auth_config:
         return {}
     decrypted = auth_config if already_decrypted else decrypt_auth_config(auth_config)
     headers = {}
-    if decrypted.get("headers") and isinstance(decrypted["headers"], list):
+
+    # 1) Explicit custom headers (list form), e.g. x-workspace-id
+    if isinstance(decrypted.get("headers"), list):
         for h in decrypted["headers"]:
             if h.get("header_name") and h.get("header_value"):
                 headers[h["header_name"]] = h["header_value"]
-    elif decrypted.get("header_name") and decrypted.get("header_value"):
-        headers[decrypted["header_name"]] = decrypted["header_value"]
-    elif decrypted.get("api_key"):
-        headers["Authorization"] = f"Bearer {decrypted['api_key']}"
-    elif decrypted.get("token") or decrypted.get("bearer_token"):
-        headers["Authorization"] = f"Bearer {decrypted.get('token') or decrypted.get('bearer_token')}"
+
+    # 2) Single header_name/header_value pair (legacy single-header form)
+    if decrypted.get("header_name") and decrypted.get("header_value"):
+        headers.setdefault(decrypted["header_name"], decrypted["header_value"])
+
+    # 3) API key / bearer token → a CONFIGURABLE header + scheme, so this works for
+    #    any provider instead of being hardcoded to "Authorization: Bearer".
+    #      default                         -> Authorization: Bearer <secret>
+    #      auth_header="X-Api-Key", scheme="" -> X-Api-Key: <secret>      (e.g. Postman)
+    #      auth_scheme=""                  -> Authorization: <secret>     (e.g. ClickUp raw token)
+    #      auth_scheme="Basic"             -> Authorization: Basic <secret>
+    #    Only applied if that header wasn't already set by a custom header above.
+    secret = decrypted.get("api_key") or decrypted.get("token") or decrypted.get("bearer_token")
+    if secret:
+        target = decrypted.get("auth_header") or decrypted.get("api_key_header") or "Authorization"
+        scheme = decrypted.get("auth_scheme")
+        if scheme is None:
+            scheme = "Bearer"
+        value = f"{scheme} {secret}".strip() if scheme else str(secret)
+        if not any(k.lower() == target.lower() for k in headers):
+            headers[target] = value
+
     return headers
 
 

--- a/core/services/oauth_service.py
+++ b/core/services/oauth_service.py
@@ -14,6 +14,7 @@ from uuid import UUID
 
 import httpx
 from fastapi import HTTPException, status
+from loguru import logger
 
 from core.models.oauth_connection import OAuthConnection
 from core.services.base import BaseService
@@ -244,9 +245,31 @@ class OAuthService(BaseService):
             response = client.post(config["token_url"], data=refresh_data)
 
         if response.status_code != 200:
+            # Surface the provider's real reason (e.g. invalid_grant = token
+            # expired/revoked → must reconnect; invalid_client = config issue).
+            # Without this the failure is opaque and looks like a code bug.
+            provider_error = ""
+            try:
+                body = response.json()
+                provider_error = body.get("error") or ""
+                if body.get("error_description"):
+                    provider_error = f"{provider_error}: {body['error_description']}"
+            except Exception:
+                provider_error = (response.text or "")[:200]
+            logger.warning(
+                "OAuth refresh failed for '{}' (status={}): {}",
+                provider, response.status_code, provider_error,
+            )
+            hint = "Please reconnect."
+            if "invalid_grant" in provider_error:
+                hint = (
+                    "Refresh token expired or revoked — reconnect, and publish the "
+                    "OAuth app (Google Cloud Console → OAuth consent screen) so tokens "
+                    "stop expiring in 7 days."
+                )
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Token refresh failed for '{provider}'. Please reconnect.",
+                detail=f"Token refresh failed for '{provider}' ({provider_error or response.status_code}). {hint}",
             )
 
         new_tokens = response.json()

--- a/dev/dev-data.json
+++ b/dev/dev-data.json
@@ -49897,7 +49897,11 @@
           },
           "date": {
             "type": "string",
-            "description": "Date in YYYY-MM-DD format"
+            "description": "Date in YYYY-MM-DD format. For create_event this is the start/check-in date."
+          },
+          "end_date": {
+            "type": "string",
+            "description": "End date in YYYY-MM-DD format (create_event). For a multi-day all-day event such as a hotel stay, set this to the check-out date and omit start_time; Google treats the end date as exclusive, so it spans the nights between 'date' and 'end_date'."
           },
           "start_time": {
             "type": "string",
@@ -49917,7 +49921,7 @@
           },
           "end_time": {
             "type": "string",
-            "description": "End time in HH:MM format for check_availability (default 17:00)"
+            "description": "End time in HH:MM format (24-hour). For create_event it sets the event's end time (overrides duration_minutes); for check_availability it is the window end (default 17:00)."
           },
           "max_results": {
             "type": "number",

--- a/dev/seed_built_in_tools.py
+++ b/dev/seed_built_in_tools.py
@@ -49,7 +49,11 @@ BUILT_IN_TOOLS = [
                 },
                 "date": {
                     "type": "string",
-                    "description": "Date in YYYY-MM-DD format",
+                    "description": "Date in YYYY-MM-DD format. For create_event this is the start/check-in date.",
+                },
+                "end_date": {
+                    "type": "string",
+                    "description": "End date in YYYY-MM-DD format (create_event). For a multi-day all-day event such as a hotel stay, set this to the check-out date and omit start_time; Google treats the end date as exclusive, so it spans the nights between 'date' and 'end_date'.",
                 },
                 "start_time": {
                     "type": "string",
@@ -69,7 +73,7 @@ BUILT_IN_TOOLS = [
                 },
                 "end_time": {
                     "type": "string",
-                    "description": "End time in HH:MM format for check_availability (default 17:00)",
+                    "description": "End time in HH:MM format (24-hour). For create_event it sets the event's end time (overrides duration_minutes); for check_availability it is the window end (default 17:00).",
                 },
                 "max_results": {
                     "type": "number",


### PR DESCRIPTION


- Add end_date property and clarify end_time in the google_calendar built-in tool schema (seed + dev-data) so the LLM can populate the all-day multi-day (check-in/check-out) create_event path.
- Anchor the system-prompt "today" to a configurable AGENT_TIMEZONE (default UTC) instead of naive server-local time, avoiding midnight date drift; safe fallback to UTC on unknown/unavailable zones.