### PR TITLE
Feature/staging/ignore venv artifacts (#373)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,9 +102,13 @@ celerybeat.pid
 .venv
 env/
 venv/
+venu/
 ENV/
 env.bak/
 venv.bak/
+# venv accidentally created at repo root by dev-bootstrap.sh
+/bin/
+/pyvenv.cfg
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
* feat(logging): one trace_id per call across all server logs (#355) (#356)

* feat(logging): one trace_id per call across all server logs

Auto-generate a single {short_uuid}-{agent_id}-{call_id} trace_id at the start of every call and stamp it onto every log line — the /ws entry, setup, pipeline, Pipecat internals, and the background DB thread — so a whole call can be filtered by one id in the server logs. Implemented via contextvars + an exception-safe loguru patcher; the id is established at the earliest entry (bot/run_bot/ bot_worker) using the provider call_id, which is known synchronously. Logging-only: call_data is read-only, the patcher can never raise into a call, and there are no call-flow, DB schema, API, or UI changes.



* feat(logging): store trace_id on calls + clean trace rendering

- Add a trace_id column to the calls table (+ migration) and persist the call's trace_id on the call row so a call can be correlated to its server logs.
- Render the trace_id by dropping empty segments, so it's never a trailing dash or a "-0" filler: "{call_uuid}" until the agent is known, then "{call_uuid}-{agent_id}", then "{call_uuid}-{agent_id}-{call_id}". The stable call_uuid prefix is on every line, so the whole call is always filterable.



* ci: remove pr-review workflow so Actions run only on deploy branches

PR Code Review triggered on every pull_request, so it ran for feature/bugfix branches. Removing it leaves only the push-triggered deploy workflows (main, staging, staging-gcp, staging-gcp-kube), each scoped to its own branch.



---------



* Ignore venv artifacts created by dev-bootstrap.sh

Add venu/ and the root-level /bin/ + /pyvenv.cfg that dev-bootstrap.sh creates when a virtualenv is generated at the repo root.



---------