### PR TITLE
Dev ->Split monolithic AgentFactoryService into layered pipeline package 

### DIFF
--- a/core/services/agent_config_service.py
+++ b/core/services/agent_config_service.py
@@ -197,8 +197,9 @@ class AgentConfigService(BaseService):
             ) from e
         config = self.db.query(AgentConfig).filter(AgentConfig.uuid == config_uuid).first()
 
-        # Invalidate Redis cache for this agent so next call picks up the new config
-        from core.services.redis_service import cache_delete_pattern
-        cache_delete_pattern(f"agent_bot_data:{agent_id}:*")
+        # Invalidate the agent's pipeline cache so the next call picks up the new config.
+        # (The version stamp also auto-detects this; the explicit delete makes it immediate.)
+        from core.services.redis_service import cache_delete
+        cache_delete(f"agent_pipeline_config:{agent_id}")
 
         return config

--- a/core/services/agent_runner_service.py
+++ b/core/services/agent_runner_service.py
@@ -54,7 +54,9 @@ class AgentRunnerService(BaseService):
         )
 
         if result:
-            cache_set(cache_key, result.id, ttl_seconds=1800)
+            # Store as a string — the Agent id is a UUID and json.dumps can't serialize it.
+            # No TTL: persists until invalidated (phone→agent mapping rarely changes).
+            cache_set(cache_key, str(result.id))
 
         return result
 

--- a/core/services/agent_service.py
+++ b/core/services/agent_service.py
@@ -1018,6 +1018,14 @@ class AgentService(BaseService):
         """
         incoming_numbers = {entry["number"] for entry in phone_numbers}
 
+        # Numbers currently mapped to this agent — captured before the sync so we can
+        # invalidate the phone_to_agent cache for every number that gains/loses a mapping.
+        prior_numbers = {
+            n for (n,) in self.db.query(PhoneNumber.number).filter(
+                PhoneNumber.agent_id == agent.id, PhoneNumber.organization_id == self.org_id
+            ).all()
+        }
+
         # Delete phone numbers removed from this agent
         if incoming_numbers:
             self.db.query(PhoneNumber).filter(
@@ -1060,6 +1068,13 @@ class AgentService(BaseService):
                     label=label,
                     organization_id=self.org_id,
                 ))
+
+        # Invalidate the phone→agent routing cache for every number that changed mapping
+        # (added or removed) so the next call routes to the correct agent immediately.
+        from core.services.redis_service import cache_delete
+        for num in prior_numbers | incoming_numbers:
+            if num:
+                cache_delete(f"phone_to_agent:{num.strip()}")
 
     def agent_response(self, agent: Agent) -> Dict[str, Any]:
         # Refresh to get latest state

--- a/core/services/call_service.py
+++ b/core/services/call_service.py
@@ -252,6 +252,7 @@ class CallService(BaseService):
             "from_number": from_number or call.from_number_raw_by_provider,
             "to_number": to_number,
             "provider_call_id": call.provider_call_id,
+            "trace_id": call.trace_id,
             "recording_upload_id": str(call.recording_upload_id) if call.recording_upload_id else None,
             "transcript": metadata.get("transcript"),
             "metrics": metadata.get("metrics"),

--- a/core/services/custom_tool_service.py
+++ b/core/services/custom_tool_service.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+from types import SimpleNamespace
 from typing import Any, Callable, List, Optional
 
 import httpx
@@ -39,6 +40,36 @@ def get_custom_tools_for_agent(agent_id: int) -> List[Tool]:
 
     logger.info("Found {} custom tools for agent {}", len(tools), agent_id)
     return tools
+
+
+# Tool fields the schema builder + handlers read. Serialized into the agent pipeline
+# cache so the builder can rebuild tools/handlers without a DB query.
+_CACHED_TOOL_FIELDS = (
+    "name", "description", "tool_type", "parameters",
+    "url", "method", "auth_type", "auth_config", "meta_data", "oauth_connection_id",
+)
+
+
+def serialize_agent_tools(agent_id: int) -> List[dict]:
+    """Fetch the agent's active tools and return JSON-serializable dicts (auth_config
+    decrypted) for the pipeline cache. The builder rebuilds handlers from these via
+    `tool_from_cache` — no per-call DB query for tools."""
+    tools = get_custom_tools_for_agent(agent_id)
+    out: List[dict] = []
+    for t in tools:
+        d = {f: getattr(t, f, None) for f in _CACHED_TOOL_FIELDS}
+        # oauth_connection_id is a UUID; stringify so it survives JSON round-trip.
+        if d.get("oauth_connection_id") is not None:
+            d["oauth_connection_id"] = str(d["oauth_connection_id"])
+        out.append(d)
+    return out
+
+
+def tool_from_cache(d: dict) -> SimpleNamespace:
+    """Reconstruct a lightweight tool object from a cached dict. Exposes the same
+    attributes (`.name`, `.tool_type`, `.auth_config`, …) the handlers/schema builder
+    read, so they work unchanged whether given an ORM Tool or this."""
+    return SimpleNamespace(**d)
 
 
 def sanitize_tool_name(name: str) -> str:

--- a/core/services/document_tool_service.py
+++ b/core/services/document_tool_service.py
@@ -169,51 +169,58 @@ def get_openai_api_key_for_agent(org_id: Any) -> Optional[str]:
     return None
 
 
-def register_document_tool(llm: Any, agent_id: int, org_id: Any, tool_call_entries: Optional[list] = None, current_turn: Optional[dict] = None) -> Optional[ToolsSchema]:
-    """Main entry point — call this from agent_factory_service after LLM is created.
-
-    Checks if the agent has KB uploads, and if so:
-    1. Builds the tool schema with document names
-    2. Registers the handler on the LLM
-    3. Returns the ToolsSchema (to pass to LLMContext)
-
-    Returns None if the agent has no documents.
-    """
+def get_kb_document_names(agent_id: int) -> Optional[dict]:
+    """The agent's ready KB documents (the only DB query for KB), as a cacheable dict
+    `{"document_names": [...], "upload_ids": [...]}` or None when the agent has no KB.
+    Stored in the agent pipeline cache; `build_document_tool` consumes it with no DB query."""
     from core.database.session import get_db_context
     from core.models.upload import Upload
     from core.models.agent_knowledge_base import AgentKnowledgeBase
 
     with get_db_context() as db:
-        # Fetch upload names and IDs in one query
         upload_rows = (
             db.query(Upload.file_name, Upload.id)
             .join(AgentKnowledgeBase, AgentKnowledgeBase.upload_id == Upload.id)
             .filter(AgentKnowledgeBase.agent_id == agent_id, Upload.status == "ready")
             .all()
         )
+    doc_names = [row[0] for row in upload_rows if row[0]]
+    upload_ids = [str(row[1]) for row in upload_rows]
+    if not doc_names:
+        return None
+    return {"document_names": doc_names, "upload_ids": upload_ids}
 
-        if not upload_rows:
-            logger.info("Agent {} has no KB uploads, skipping tool registration", agent_id)
-            return None
 
-        doc_names = [row[0] for row in upload_rows if row[0]]
-        upload_ids = [row[1] for row in upload_rows]
+def build_document_tool(
+    llm: Any, agent_id: int, org_id: Any, kb: Optional[dict],
+    tool_call_entries: Optional[list] = None, current_turn: Optional[dict] = None,
+) -> Optional[ToolsSchema]:
+    """Build + register the read_document tool from the cached `kb` dict (no KB DB query).
 
-        if not doc_names:
-            logger.info("Agent {} has no KB uploads, skipping tool registration", agent_id)
-            return None
+    The pgvector search still runs live at call time inside the handler. Returns the
+    ToolsSchema (for LLMContext) or None if the agent has no KB documents.
+    """
+    if not kb or not kb.get("document_names"):
+        logger.info("Agent {} has no KB documents, skipping tool registration", agent_id)
+        return None
 
-        api_key = get_openai_api_key_for_agent(org_id)
-        if not api_key:
-            logger.warning("No OpenAI API key found for org {}, skipping document tool", org_id)
-            return None
+    doc_names = kb["document_names"]
+    upload_ids = kb.get("upload_ids") or []
 
-    # Build tool schema and handler
+    api_key = get_openai_api_key_for_agent(org_id)
+    if not api_key:
+        logger.warning("No OpenAI API key found for org {}, skipping document tool", org_id)
+        return None
+
     tools_schema = get_document_tool_schema(doc_names)
     handler = create_document_handler(agent_id, org_id, api_key, upload_ids, tool_call_entries=tool_call_entries, current_turn=current_turn)
-
-    # Register handler on the LLM
     llm.register_function("read_document", handler)
     logger.info("Registered read_document tool for agent {} with docs: {}", agent_id, doc_names)
-
     return tools_schema
+
+
+def register_document_tool(llm: Any, agent_id: int, org_id: Any, tool_call_entries: Optional[list] = None, current_turn: Optional[dict] = None) -> Optional[ToolsSchema]:
+    """Back-compat entry point: fetch the agent's KB docs from the DB, then build the tool.
+    New callers should cache `get_kb_document_names()` and call `build_document_tool()`."""
+    kb = get_kb_document_names(agent_id)
+    return build_document_tool(llm, agent_id, org_id, kb, tool_call_entries=tool_call_entries, current_turn=current_turn)

--- a/core/services/pipeline/builder/pipecat.py
+++ b/core/services/pipeline/builder/pipecat.py
@@ -98,22 +98,22 @@ class PipecatPipelineBuilder(PipelineBuilder):
         _t = _time.monotonic()
         rtvi = RTVIProcessor(config=RTVIConfig(config=[]))
 
-        # Register document tool if agent has uploaded documents
+        # Register document tool from the cached KB data (no DB query; pgvector still
+        # searched live at call time inside the handler).
         doc_tools = None
         if agent:
-            from core.services.document_tool_service import register_document_tool
-            doc_tools = register_document_tool(llm, agent.id, agent.organization_id)
+            from core.services.document_tool_service import build_document_tool
+            doc_tools = build_document_tool(llm, agent.id, agent.organization_id, params.kb)
 
-        # Fetch custom tools for this agent
+        # Custom + built-in tools, rebuilt from the cached tool dicts (no DB query).
         custom_tools_schema = None
-        if agent:
+        if agent and params.tools:
             from core.services.custom_tool_service import (
                 build_custom_tool_schemas, create_built_in_tool_handler,
-                create_custom_tool_handler, get_custom_tools_for_agent,
-                sanitize_tool_name)
-            custom_tools = get_custom_tools_for_agent(agent.id)
+                create_custom_tool_handler, sanitize_tool_name, tool_from_cache)
+            custom_tools = [tool_from_cache(t) for t in params.tools]
             if custom_tools:
-                logger.info("Fetched {} custom tools for agent {}", len(custom_tools), agent.id)
+                logger.info("Building {} cached tools for agent {}", len(custom_tools), agent.id)
                 custom_tools_schema = build_custom_tool_schemas(custom_tools)
                 for tool in custom_tools:
                     # Only "custom" tools are customer webhooks; everything else

--- a/core/services/pipeline/params/base.py
+++ b/core/services/pipeline/params/base.py
@@ -57,6 +57,9 @@ class PipelineParams:
     is_s2s: bool = False
     messages: List[dict] = field(default_factory=list)
     end_call_message: Optional[str] = None
+    # Cached, DB-free tool/KB data the builder rebuilds handlers from (MCP stays live).
+    tools: List[dict] = field(default_factory=list)
+    kb: Optional[dict] = None
     telephony_creds: Optional[dict] = None
 
     @property
@@ -124,6 +127,8 @@ class PipelineParams:
             messages=d.get("messages") or [],
             end_call_message=d.get("end_call_message"),
             telephony_creds=d.get("_telephony_creds"),
+            tools=d.get("tools") or [],
+            kb=d.get("kb"),
         )
 
     @classmethod

--- a/core/services/pipeline/service_resolver.py
+++ b/core/services/pipeline/service_resolver.py
@@ -36,9 +36,13 @@ from core.models.model_provider import ModelProvider
 from core.models.model_voice import ModelVoice
 from core.utils.encryption import decrypt
 
-# Transport-specific cache key suffixes tried (in order) when no transport_type is given.
-CACHE_FALLBACK_SUFFIXES = ("twilio", "telnyx", "plivo", "exotel", "none")
-CACHE_TTL_SECONDS = 1800
+
+
+# Bump whenever the cached pipeline payload's shape changes (a key is added, renamed, or
+# removed in `load_agent_service_config`'s `result` dict). It is folded into every cache
+# version stamp, so a deploy that changes the shape invalidates all persisted entries
+# instead of serving them with a stale shape — there is no TTL to clear them otherwise.
+PAYLOAD_FORMAT_VERSION = "v1"
 
 
 def _resolve_org_id(org_id):
@@ -115,19 +119,14 @@ def _build_service_specs(
     stt_settings = config.stt_settings or {}
     voice_settings = config.voice_settings or {}
 
-    llm_pid = _to_uuid(llm_settings.get("provider_id"))
-    stt_pid = _to_uuid(stt_settings.get("provider_id"))
-    tts_pid = _to_uuid(voice_settings.get("provider_id"))
-    provider_ids = {p for p in (llm_pid, stt_pid, tts_pid) if p}
+    ids = _config_service_ids(config)
+    llm_pid, stt_pid, tts_pid = ids["llm_pid"], ids["stt_pid"], ids["tts_pid"]
+    llm_mid, stt_mid, tts_mid = ids["llm_mid"], ids["stt_mid"], ids["tts_mid"]
+    provider_ids, model_ids = ids["provider_ids"], ids["model_ids"]
 
-    llm_mid = _to_uuid(llm_settings.get("model_id"))
     stt_model_literal = stt_settings.get("model")
-    stt_mid = _to_uuid(stt_settings.get("model_id"))
-    tts_mid = _to_uuid(voice_settings.get("model_id"))
-    model_ids = {m for m in (llm_mid, stt_mid, tts_mid) if m}
-
     voice_id_raw = voice_settings.get("voice_id")
-    voice_uuid = _to_uuid(voice_id_raw)
+    voice_uuid = ids["voice_uuid"]
 
     providers = (
         db.query(ModelProvider).filter(ModelProvider.id.in_(provider_ids)).all() if provider_ids else []
@@ -171,7 +170,7 @@ def _build_service_specs(
         try:
             return decrypt(ak.encrypted_key)
         except Exception as e:
-            logger.warning("[resolver] decrypt failed for api_key %s: %s", ak.id, e)
+            logger.warning("[resolver] decrypt failed for api_key {}: {}", ak.id, e)
             return None
 
     # Filter settings to only the params the chosen model actually supports, so stale
@@ -235,51 +234,167 @@ def _build_service_specs(
     return llm_spec, stt_spec, tts_spec, is_s2s
 
 
-def _load_telephony_credentials(db: Session, org_id, transport_type: str, agent: Any) -> Optional[dict]:
-    """Fetch telephony provider credentials from the org's Channel (encrypted_config).
+def _config_service_ids(config) -> dict:
+    """Provider/model/voice ids referenced by a config's JSONB settings, extracted once.
 
-    Channels store credentials keyed by `channel_type` ("twilio"/"telnyx"/"plivo"/"exotel")
-    in an encrypted JSONB blob. Returns the decrypted config dict (e.g. account_sid/auth_token
-    for Twilio) or None.
-
-    Delegates to the shared `telephony_credentials.channel_config` (the single
-    decryption code path), reusing this resolver's DB session.
+    Returns the per-service ids (which `_build_service_specs` needs to resolve each service)
+    alongside the merged `provider_ids`/`model_ids` sets and the voice id (which the
+    cache-version stamp needs) — so the `_to_uuid(settings.get(...))` extraction lives in a
+    single place and the spec builder and the stamp can't drift apart.
     """
-    from core.services.transport.telephony_credentials import channel_config
+    llm = config.llm_settings or {}
+    stt = config.stt_settings or {}
+    voice = config.voice_settings or {}
+    llm_pid, stt_pid, tts_pid = (
+        _to_uuid(llm.get("provider_id")),
+        _to_uuid(stt.get("provider_id")),
+        _to_uuid(voice.get("provider_id")),
+    )
+    llm_mid, stt_mid, tts_mid = (
+        _to_uuid(llm.get("model_id")),
+        _to_uuid(stt.get("model_id")),
+        _to_uuid(voice.get("model_id")),
+    )
+    return {
+        "llm_pid": llm_pid, "stt_pid": stt_pid, "tts_pid": tts_pid,
+        "llm_mid": llm_mid, "stt_mid": stt_mid, "tts_mid": tts_mid,
+        "voice_uuid": _to_uuid(voice.get("voice_id")),
+        "provider_ids": {p for p in (llm_pid, stt_pid, tts_pid) if p},
+        "model_ids": {m for m in (llm_mid, stt_mid, tts_mid) if m},
+    }
 
-    org = org_id or getattr(agent, "organization_id", None)
-    return channel_config(transport_type, org_id=org, db=db) or None
+
+def compute_agent_cache_version(db: Session, agent: Any, org_id=None) -> Tuple[Optional[str], Optional[Any]]:
+    """Return (version_stamp, active_config) for an agent.
+
+    The stamp is a composite of updated_at timestamps AND row counts across EVERY input the
+    cached pipeline payload depends on — the config, the referenced provider/model/voice/
+    api-key rows, the linked tools, and the KB uploads. Any change (incl. an in-place API-key
+    rotation, a model/voice edit, or a tool/KB add/remove) changes the stamp and invalidates
+    the cache; the counts catch removals that a bare max(updated_at) would miss. MCP is
+    intentionally excluded — it is never cached and is always resolved live in build().
+
+    Cost: one config lookup + ONE combined aggregate query (all the COUNT/MAX values are
+    scalar subqueries in a single round-trip) — far cheaper than a full resolve, and keeps
+    call-setup latency low even on a remote DB.
+    """
+    from sqlalchemy import func, select
+
+    from core.models.agent_knowledge_base import AgentKnowledgeBase
+    from core.models.agent_tool import AgentTool
+    from core.models.tool import Tool
+    from core.models.upload import Upload
+
+    config = get_active_agent_config(db, agent)
+    if not config:
+        return None, None
+
+    agent_id = agent.id if hasattr(agent, "id") else agent
+    org = org_id or getattr(config, "organization_id", None) or getattr(agent, "organization_id", None)
+    ids = _config_service_ids(config)
+    provider_ids, model_ids, voice_uuid = ids["provider_ids"], ids["model_ids"], ids["voice_uuid"]
+
+    # Each freshness value is a scalar subquery; selecting them together is ONE round-trip.
+    # Empty id-sets / a missing voice render as `IN ()` / `= NULL` → no rows → MAX = NULL,
+    # which is exactly the "nothing referenced" stamp we want.
+    prov_sq = select(func.max(ModelProvider.updated_at)).where(ModelProvider.id.in_(provider_ids)).scalar_subquery()
+    model_sq = select(func.max(Model.updated_at)).where(Model.id.in_(model_ids)).scalar_subquery()
+    voice_sq = select(func.max(ModelVoice.updated_at)).where(ModelVoice.id == voice_uuid).scalar_subquery()
+
+    _key_where = (
+        ApiKey.provider_id.in_(provider_ids),
+        ApiKey.organization_id == org,
+        ApiKey.is_active.is_(True),
+    )
+    key_cnt_sq = select(func.count(ApiKey.id)).where(*_key_where).scalar_subquery()
+    key_max_sq = select(func.max(ApiKey.updated_at)).where(*_key_where).scalar_subquery()
+
+    _tool_where = (AgentTool.agent_id == agent_id, Tool.is_active.is_(True))
+    tool_cnt_sq = (
+        select(func.count(Tool.id)).select_from(Tool)
+        .join(AgentTool, AgentTool.tool_id == Tool.id).where(*_tool_where).scalar_subquery()
+    )
+    tool_link_sq = (
+        select(func.max(AgentTool.updated_at)).select_from(AgentTool)
+        .join(Tool, Tool.id == AgentTool.tool_id).where(*_tool_where).scalar_subquery()
+    )
+    tool_max_sq = (
+        select(func.max(Tool.updated_at)).select_from(Tool)
+        .join(AgentTool, AgentTool.tool_id == Tool.id).where(*_tool_where).scalar_subquery()
+    )
+
+    _kb_where = (AgentKnowledgeBase.agent_id == agent_id, Upload.status == "ready")
+    kb_cnt_sq = (
+        select(func.count(Upload.id)).select_from(Upload)
+        .join(AgentKnowledgeBase, AgentKnowledgeBase.upload_id == Upload.id).where(*_kb_where).scalar_subquery()
+    )
+    kb_link_sq = (
+        select(func.max(AgentKnowledgeBase.updated_at)).select_from(AgentKnowledgeBase)
+        .join(Upload, Upload.id == AgentKnowledgeBase.upload_id).where(*_kb_where).scalar_subquery()
+    )
+    kb_max_sq = (
+        select(func.max(Upload.updated_at)).select_from(Upload)
+        .join(AgentKnowledgeBase, AgentKnowledgeBase.upload_id == Upload.id).where(*_kb_where).scalar_subquery()
+    )
+
+    (
+        prov_max, model_max, voice_ts, key_count, key_max,
+        tool_count, tool_link_max, tool_max, kb_count, kb_link_max, kb_max,
+    ) = db.execute(
+        select(
+            prov_sq, model_sq, voice_sq, key_cnt_sq, key_max_sq,
+            tool_cnt_sq, tool_link_sq, tool_max_sq, kb_cnt_sq, kb_link_sq, kb_max_sq,
+        )
+    ).one()
+
+    def _s(ts):
+        return ts.isoformat() if ts is not None else "none"
+
+    version = "|".join([
+        f"fmt:{PAYLOAD_FORMAT_VERSION}",
+        f"cfg:{config.id}:{_s(config.updated_at)}",
+        f"prov:{_s(prov_max)}",
+        f"model:{_s(model_max)}",
+        f"voice:{_s(voice_ts)}",
+        f"key:{key_count}:{_s(key_max)}",
+        f"tools:{tool_count}:{_s(tool_link_max)}:{_s(tool_max)}",
+        f"kb:{kb_count}:{_s(kb_link_max)}:{_s(kb_max)}",
+    ])
+    return version, config
 
 
 def load_agent_service_config(
     db: Session, agent: Any, transport_type: str = None, org_id=None
 ) -> Optional[dict]:
-    """Pre-fetch all data needed to build LLM/STT/TTS services into a JSON-serializable dict.
+    """Resolve the full pipeline payload (LLM/STT/TTS specs + prompt + tools + KB) for an
+    agent, served from a version-stamped Redis cache under one transport-independent key.
 
-    If transport_type is provided, also fetches telephony credentials in the same DB session.
-    Returns None if config or any required service is missing. Results are cached in Redis
-    keyed by agent_id + transport_type.
-
-    This is the single resolution path used by PipelineParams.from_agent.
+    On every call the live version stamp is recomputed and compared to the cached stamp: a
+    byte-identical match returns the cached payload with no further DB work; ANY change
+    (config, provider/model/voice/key, tools, or KB) forces a fresh resolve + re-stamp, so a
+    call never runs on stale data. `transport_type` is accepted for signature compatibility
+    but no longer affects the cache — telephony credentials are resolved per-transport at the
+    serializer, not cached here. Returns None if config/required services are missing.
     """
+    from core.services.custom_tool_service import serialize_agent_tools
+    from core.services.document_tool_service import get_kb_document_names
     from core.services.redis_service import cache_get, cache_set
 
-    org_id = _resolve_org_id(org_id)
-    _t_ser = _time.monotonic()
-
+    _t = _time.monotonic()
     agent_id = agent.id if hasattr(agent, "id") else agent
-    cache_key = f"agent_bot_data:{agent_id}:{transport_type or 'none'}"
-    cached = cache_get(cache_key)
-    if cached is not None:
-        logger.info("[TIMING] serialize: CACHE HIT for agent_id=%s (+%.3fs)", agent_id, _time.monotonic() - _t_ser)
-        return cached
+    org_id = _resolve_org_id(org_id)
 
-    config = get_active_agent_config(db, agent)
-    if not config or not config.system_prompt_template:
+    version, config = compute_agent_cache_version(db, agent, org_id=org_id)
+    if config is None or not config.system_prompt_template:
         return None
 
-    org_id = org_id or getattr(config, "organization_id", None) or getattr(agent, "organization_id", None)
+    cache_key = f"agent_pipeline_config:{agent_id}"
+    cached = cache_get(cache_key)
+    if cached is not None and cached.get("_cache_version") == version:
+        logger.info("[TIMING] pipeline config: CACHE HIT (fresh) agent_id={} (+{:.3f}s)", agent_id, _time.monotonic() - _t)
+        return cached
 
+    org_id = org_id or getattr(config, "organization_id", None) or getattr(agent, "organization_id", None)
     llm_spec, stt_spec, tts_spec, is_s2s = _build_service_specs(db, org_id, config)
     if not llm_spec:
         return None
@@ -291,41 +406,24 @@ def load_agent_service_config(
         messages.append({"role": "assistant", "content": config.first_message.strip()})
 
     result = {
+        "_cache_version": version,
         "llm": llm_spec,
         "stt": stt_spec,
         "tts": tts_spec,
         "is_s2s": is_s2s,
         "messages": messages,
         "end_call_message": getattr(config, "end_call_message", None),
+        "tools": serialize_agent_tools(agent_id),
+        "kb": get_kb_document_names(agent_id),
     }
-
-    if transport_type:
-        telephony_creds = _load_telephony_credentials(db, org_id, transport_type, agent)
-        if telephony_creds:
-            result["_telephony_creds"] = telephony_creds
-
-    cache_set(cache_key, result, ttl_seconds=CACHE_TTL_SECONDS)
-    logger.info(
-        "[TIMING] serialize: CACHE MISS — stored in Redis for agent_id=%s (+%.3fs)",
-        agent_id,
-        _time.monotonic() - _t_ser,
-    )
+    # Persistent (no TTL): the version stamp guarantees freshness on every read, and edits
+    # overwrite/invalidate the entry — so there is no need to expire it on a timer.
+    cache_set(cache_key, result, ttl_seconds=None)
+    logger.info("[TIMING] pipeline config: CACHE MISS — resolved + stored agent_id={} (+{:.3f}s)", agent_id, _time.monotonic() - _t)
     return result
 
 
 def load_agent_service_config_cached(db: Session, agent: Any, org_id=None) -> Optional[dict]:
-    """Resolve agent services trying transport-specific Redis cache keys first.
-
-    Used when no transport_type is known (e.g. the in-process /ws/test + WebRTC paths).
-    Falls back to a fresh resolution under the 'none' key.
-    """
-    from core.services.redis_service import cache_get
-
-    agent_id = agent.id if hasattr(agent, "id") else agent
-    for transport_suffix in CACHE_FALLBACK_SUFFIXES:
-        cache_key = f"agent_bot_data:{agent_id}:{transport_suffix}"
-        cached = cache_get(cache_key)
-        if cached is not None:
-            logger.info("[TIMING] using Redis-cached service data from key=%s (no DB queries)", cache_key)
-            return cached
+    """The cache is now one transport-independent key with a freshness stamp, so this just
+    delegates to load_agent_service_config (kept for the no-transport call sites)."""
     return load_agent_service_config(db, agent, transport_type=None, org_id=org_id)

--- a/core/services/redis_service.py
+++ b/core/services/redis_service.py
@@ -37,12 +37,18 @@ def cache_get(key: str) -> Optional[Any]:
     return None
 
 
-def cache_set(key: str, value: Any, ttl_seconds: int = 1800) -> bool:
-    """Set a JSON value in cache with TTL (default: 30 minutes). Returns True on success."""
+def cache_set(key: str, value: Any, ttl_seconds: Optional[int] = None) -> bool:
+    """Set a JSON value in cache. By default (ttl_seconds=None) the entry is stored
+    persistently with no expiry; pass an explicit ttl_seconds to expire it after that
+    many seconds. Returns True on success."""
     if not _client:
         return False
     try:
-        _client.setex(key, ttl_seconds, json.dumps(value))
+        data = json.dumps(value)
+        if ttl_seconds is None:
+            _client.set(key, data)
+        else:
+            _client.setex(key, ttl_seconds, data)
         return True
     except Exception as e:
         logger.debug("Redis cache_set error for key={}: {}", key, e)

--- a/frontend/src/components/call-history/CallHistory.tsx
+++ b/frontend/src/components/call-history/CallHistory.tsx
@@ -9,9 +9,17 @@ import { Badge } from '@/components/ui/badge';
 import { AGENT_TYPE_OPTIONS, CALL_STATUS_OPTIONS } from '@/lib/constants/filters';
 import type { CallLogFilterParam, CallLogQueryParams, CallLogRow } from '@/types/callLog';
 import type { CustomTableColumn, CustomTableSortState } from '@/types/components';
+import { buildGrafanaLogsUrl, isGrafanaConfigured } from '@/utils/grafana';
 import { handleApiError } from '@/utils/helpers';
 import { useAtom } from 'jotai';
-import { CalendarDays, ChartNoAxesCombined, MessageSquareText, Phone, X } from 'lucide-react';
+import {
+  CalendarDays,
+  ChartNoAxesCombined,
+  MessageSquareText,
+  Phone,
+  ScrollText,
+  X,
+} from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import CallDetailDrawer from './CallDetailDrawer';
@@ -239,6 +247,22 @@ const CallHistory: React.FC = () => {
               <ChartNoAxesCombined className="size-3.5" />
             </CustomButton>
           </CustomTooltip>
+          {isGrafanaConfigured() && (
+            <CustomTooltip content="View logs">
+              <CustomButton
+                type="default"
+                size="icon-xs"
+                disabled={!record.trace_id}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const url = buildGrafanaLogsUrl(record);
+                  if (url) window.open(url, '_blank', 'noopener,noreferrer');
+                }}
+              >
+                <ScrollText className="size-3.5" />
+              </CustomButton>
+            </CustomTooltip>
+          )}
         </div>
       ),
     },

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -12,3 +12,8 @@ export const ROUTE_LOGIN = '/login';
 export const ROUTE_HOME = '/home';
 
 export const BACKEND_URL = `${process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000'}/api/v1`;
+
+// Grafana Loki logs link (Call History → per-call logs). Environment-specific: the base
+// host and the Loki "app" label differ between staging and production.
+export const GRAFANA_BASE_URL = process.env.NEXT_PUBLIC_GRAFANA_BASE_URL;
+export const GRAFANA_LOG_APP = process.env.NEXT_PUBLIC_GRAFANA_LOG_APP;

--- a/frontend/src/types/callLog.ts
+++ b/frontend/src/types/callLog.ts
@@ -57,6 +57,7 @@ export interface CallLogRow {
   from_number: string | null;
   to_number: string | null;
   provider_call_id: string | null;
+  trace_id: string | null;
   recording_upload_id: string | null;
   transcript: Array<{ role: string; text: string; timestamp?: string }> | null;
   metrics: CallMetrics | null;

--- a/frontend/src/utils/grafana.ts
+++ b/frontend/src/utils/grafana.ts
@@ -1,0 +1,60 @@
+import { GRAFANA_BASE_URL, GRAFANA_LOG_APP } from '@/constants';
+
+/** Padding added around a call's time range so the Loki window comfortably brackets it. */
+const TIME_BUFFER_MS = 5 * 60 * 1000;
+
+/**
+ * Pre-encoded Grafana Loki Explore URL, filtered to a single trace_id.
+ *
+ * Placeholders ({BASE}, {APP}, {FROM}, {TO}, {TRACE_ID}) are substituted by
+ * buildGrafanaLogsUrl. The query string is already URL-encoded (%7C%3D%7C === "|=|", and
+ * __gfc__ is Grafana's in-value comma escape); trace_id and app values are URL-safe, so
+ * plain string substitution is correct here — do not re-encode.
+ */
+const GRAFANA_LOGS_URL_TEMPLATE =
+  '{BASE}/a/grafana-lokiexplore-app/explore/app/{APP}/logs' +
+  '?from={FROM}&to={TO}&var-ds=grafanacloud-logs&var-filters=app%7C%3D%7C{APP}' +
+  '&patterns=%5B%5D&var-lineFormat=' +
+  '&var-fields=trace_id%7C%3D%7C%7B%22parser%22:%22logfmt%22__gfc__%22value%22:%22{TRACE_ID}%22%7D,{TRACE_ID}' +
+  '&var-levels=&var-metadata=&var-jsonFields=&var-patterns=&var-lineFilterV2=&var-lineFilters=&timezone=browser' +
+  '&var-all-fields=trace_id%7C%3D%7C%7B%22parser%22:%22logfmt%22__gfc__%22value%22:%22{TRACE_ID}%22%7D,{TRACE_ID}' +
+  '&var-levels=&var-metadata=&var-jsonFields=&var-patterns=&var-lineFilterV2=&var-lineFilters=&timezone=browser' +
+  '&userDisplayedFields=false&displayedFields=%5B%5D' +
+  '&urlColumns=%5B%22Time%22,%22Line%22,%22detected_level%22%5D' +
+  '&visualizationType=%22table%22&sortOrder=%22Descending%22';
+
+interface GrafanaLogsCall {
+  trace_id: string | null;
+  started_at: string | null;
+  ended_at: string | null;
+}
+
+/**
+ * Whether the Grafana logs link is configured for this environment (both the base URL and
+ * the app/service label are set). When false, the Call History "View logs" button is hidden
+ * since there is nowhere to redirect to.
+ */
+export function isGrafanaConfigured(): boolean {
+  return Boolean(GRAFANA_BASE_URL && GRAFANA_LOG_APP);
+}
+
+/**
+ * Build a Grafana Loki Explore URL filtered to this call's trace_id. The time window is
+ * derived from the call's start/end (padded by TIME_BUFFER_MS) so the logs load regardless
+ * of the call's age. Returns null when Grafana is not configured or the call has no trace_id.
+ */
+export function buildGrafanaLogsUrl(call: GrafanaLogsCall): string | null {
+  const traceId = call.trace_id;
+  if (!traceId || !GRAFANA_BASE_URL || !GRAFANA_LOG_APP) return null;
+
+  const startMs = call.started_at ? Date.parse(call.started_at) : NaN;
+  const endMs = call.ended_at ? Date.parse(call.ended_at) : NaN;
+  const from = (Number.isNaN(startMs) ? Date.now() : startMs) - TIME_BUFFER_MS;
+  const to = (Number.isNaN(endMs) ? Date.now() : endMs) + TIME_BUFFER_MS;
+
+  return GRAFANA_LOGS_URL_TEMPLATE.replaceAll('{BASE}', GRAFANA_BASE_URL)
+    .replaceAll('{APP}', GRAFANA_LOG_APP)
+    .replaceAll('{FROM}', String(from))
+    .replaceAll('{TO}', String(to))
+    .replaceAll('{TRACE_ID}', traceId);
+}


### PR DESCRIPTION
…all logs (#388)

* Split monolithic AgentFactoryService into layered pipeline package (#378) (#383)

* Split monolithic AgentFactoryService into layered pipeline package

Extract the voice pipeline out of the 1700-line AgentFactoryService into a 3-layer core/services/pipeline/ package (params -> builder -> runner, each a framework-agnostic base + Pipecat child), with service_resolver (the only DB access) and service_factory (pure construction). AgentFactoryService is kept as a thin back-compat facade; BotRunnerService is renamed to AgentRunnerService with reusable agent-lookup helpers. Wires bot.py and the telephony routers to the new engine registry.


(cherry picked from commit 89ca9b4f53b6150d846da4acbe994434324b2e46)

* Port call_engines telephony voice fixes onto the new pipeline design

Re-wire the three telephony-resilience processors that Parandhama added in the call_engines/pipeline_builders work (and that adopting 89ca9b4's pipeline package left orphaned) into PipecatPipelineBuilder, keeping the new design's Smart Turn as the primary turn detector:

- VADSpeakingTimeoutProcessor(8s) before STT: caps a stuck Silero VAD "speaking" segment on phone-line noise so segmented STTs flush.
- DuplicateTranscriptionFilter after STT: drops repeated final transcripts that otherwise trigger a duplicate LLM response (the turn-stop race).
- TranscriptionTimeoutUserTurnStopStrategy(1.5s) added to the turn-stop list as a VAD-independent fallback alongside the Smart Turn analyzer.

The processor files already existed; only the wiring was lost. Provider coverage (service_factory) and transport VAD setup are unchanged.



* Refresh GitNexus index metadata in AGENTS.md and CLAUDE.md

Regenerated by `npx gitnexus analyze` after the pipeline refactor — updates symbol/relationship counts and the repo label.



* Remove typo'd venu/ entry from .gitignore

Drop the misspelled "venu/" ignore line (intended venv/, already covered).



* Address PR review on pipeline revamp

- Restore configurable BOT_DISPLAY_NAME for Daily transport (was hardcoded)
- Revert no-agent fallback LLM to gpt-4o-mini
- Re-apply current-date preamble at build time (fresh per call, applies to both in-process and subprocess paths) via PipelineParams.messages_with_date_anchor()
- Extract shared core/utils/telephony.provider_call_id(), de-duplicating the call_id/call_control_id/stream_id logic across bot.py, bot_worker.py, and the runner



* chore: refresh GitNexus index counts in AGENTS.md / CLAUDE.md



* Address pipeline-revamp PR review + add transport package

- Introduce core/services/transport package (CallTransport / TelephonyProvider registry) replacing the isinstance chain in bot()
- service_factory: convert leftover TTS print() debug to logger.debug; create aiohttp sessions lazily per HTTP provider and close them on failure paths (fixes "Unclosed client session" leak on import/init failure)
- runner: assemble call metrics via one helper so the fallback completion path persists user_bot_latency + turns like on_audio_data
- DRY: make telephony_credentials.channel_config the single channel-decryption path; AgentRunnerService and service_resolver now delegate to it



* Merge origin/dev into feature/staging/agent-pipeline-revamp

Resolve modify/delete conflicts in favor of this branch's pipeline revamp:
- Keep deletion of core/services/agent_runtime_resolver.py and core/services/pipeline_builders/ (replaced by core/services/pipeline/). dev's versions were resurrected by the merge but import pipeline_builders modules that no longer exist and nothing references them at runtime.
- Take dev's model meta_data_schema feature (models/seed/services/frontend), alembic migrations, and dev tooling as-is (clean merge).



* fix: S2S Gemini system_instruction + STT init error handling

- service_resolver: set both system_prompt and system_instruction for S2S agents so Gemini Live (reads system_instruction) gets its prompt, not just OpenAI Realtime (reads system_prompt).
- service_factory: build_stt now catches broad Exception (log + return None), matching build_llm/build_tts, so a non-import STT init failure degrades gracefully instead of crashing the pipeline build.



---------



* Version-stamped agent pipeline cache with DB-free tool/KB rebuild

Replace transport-keyed, TTL-based pipeline caching with a single transport-independent key guarded by a recomputed version stamp, so a call never runs on stale config. Serialize tools/KB into the cached payload so the builder rebuilds handlers without per-call DB queries (MCP stays live). Invalidate the phone->agent cache on number remapping.

Add a shared _config_service_ids helper so the spec builder and the cache stamp extract provider/model/voice ids from one place, and fold a PAYLOAD_FORMAT_VERSION into the stamp so a payload-shape change on deploy invalidates persisted (now TTL-less) entries.



* feat(call-logs): expose trace_id for Grafana Loki per-call logs

Surface call.trace_id in the call detail payload and CallLogRow type, and add environment-configurable Grafana base URL and Loki app label constants so Call History can deep-link to per-call logs.



* feat(call-history): add Grafana Loki logs link per call

Add a "View logs" action in the Quick View column that opens the call's logs in Grafana Loki, filtered by the call's trace_id with the time window derived from the call's start/end. Disabled for calls with no trace_id. Completes the trace_id exposure from 0d2841c.



* feat(call-history): hide Grafana logs button when not configured

Drop the staging defaults for the Grafana env vars and hide the "View logs" button entirely unless both NEXT_PUBLIC_GRAFANA_BASE_URL and NEXT_PUBLIC_GRAFANA_LOG_APP are set. buildGrafanaLogsUrl now also returns null when either is missing so it never builds a broken URL.



---------