### PR TITLE
fix(dashboard): stop /dashboard/stats 500 and show stats loader (#431)

### DIFF
--- a/core/services/dashboard_service.py
+++ b/core/services/dashboard_service.py
@@ -33,10 +33,17 @@ class DashboardService(BaseService):
             self.query(Agent).filter(Agent.deleted_at.is_(None)).count()
         )
 
+        # Count via with_entities(count(id)) instead of Query.count(): the latter
+        # wraps a "SELECT <all Call columns>" subquery, which references model
+        # columns that may not exist on the live `calls` table (e.g.
+        # pipeline_config). Selecting only count(id) keeps tenant scoping while
+        # touching a single, guaranteed column.
         active_calls = (
             self.query(Call)
+            .with_entities(func.count(Call.id))
             .filter(Call.ended_at.is_(None), Call.started_at >= active_since)
-            .count()
+            .scalar()
+            or 0
         )
 
         total_seconds = (
@@ -49,21 +56,25 @@ class DashboardService(BaseService):
 
         finished_calls_30d = (
             self.query(Call)
+            .with_entities(func.count(Call.id))
             .filter(
                 Call.started_at >= thirty_days_ago,
                 Call.ended_at.isnot(None),
             )
-            .count()
+            .scalar()
+            or 0
         )
         if finished_calls_30d > 0:
             successful_calls_30d = (
                 self.query(Call)
+                .with_entities(func.count(Call.id))
                 .filter(
                     Call.started_at >= thirty_days_ago,
                     Call.ended_at.isnot(None),
                     Call.duration_seconds > 0,
                 )
-                .count()
+                .scalar()
+                or 0
             )
             success_rate = round((successful_calls_30d / finished_calls_30d) * 100, 1)
         else:

--- a/frontend/src/app/(dashboard)/home/page.tsx
+++ b/frontend/src/app/(dashboard)/home/page.tsx
@@ -145,44 +145,48 @@ export default function HomePage() {
 
       {/* ── Stat Cards ──────────────────────────────────────────────────── */}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {statCards.map((card) => {
-          const value = loading || !stats ? '—' : `${stats[card.key]}${card.suffix}`;
+        {statCards.map((card) => (
+          <Card
+            key={card.label}
+            className="group relative gap-0 overflow-hidden border-border/60 py-0 transition-all duration-200 hover:-translate-y-0.5 hover:border-border hover:shadow-md"
+          >
+            <div
+              className={cn(
+                'pointer-events-none absolute inset-0 bg-gradient-to-br opacity-60 transition-opacity duration-200 group-hover:opacity-100',
+                card.accent,
+              )}
+            />
 
-          return (
-            <Card
-              key={card.label}
-              className="group relative gap-0 overflow-hidden border-border/60 py-0 transition-all duration-200 hover:-translate-y-0.5 hover:border-border hover:shadow-md"
-            >
+            <div className="relative flex items-start justify-between px-5 pt-5">
               <div
                 className={cn(
-                  'pointer-events-none absolute inset-0 bg-gradient-to-br opacity-60 transition-opacity duration-200 group-hover:opacity-100',
-                  card.accent,
+                  'flex size-10 items-center justify-center rounded-xl ring-1 ring-inset ring-border/40',
+                  card.iconBg,
                 )}
-              />
+              >
+                <card.icon size={18} className={card.iconColor} strokeWidth={2.25} />
+              </div>
+              <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">
+                {card.subtitle}
+              </span>
+            </div>
 
-              <div className="relative flex items-start justify-between px-5 pt-5">
+            <div className="relative px-5 pt-4 pb-5">
+              <p className="text-[13px] font-medium text-muted-foreground">{card.label}</p>
+              {loading ? (
                 <div
-                  className={cn(
-                    'flex size-10 items-center justify-center rounded-xl ring-1 ring-inset ring-border/40',
-                    card.iconBg,
-                  )}
-                >
-                  <card.icon size={18} className={card.iconColor} strokeWidth={2.25} />
-                </div>
-                <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">
-                  {card.subtitle}
-                </span>
-              </div>
-
-              <div className="relative px-5 pt-4 pb-5">
-                <p className="text-[13px] font-medium text-muted-foreground">{card.label}</p>
+                  className="mt-2 h-8 w-16 animate-pulse rounded-md bg-muted"
+                  role="status"
+                  aria-label={`Loading ${card.label}`}
+                />
+              ) : (
                 <p className="mt-1 text-3xl font-semibold tracking-tight tabular-nums text-foreground">
-                  {value}
+                  {stats ? `${stats[card.key]}${card.suffix}` : '—'}
                 </p>
-              </div>
-            </Card>
-          );
-        })}
+              )}
+            </div>
+          </Card>
+        ))}
       </div>
 
       {/* ── Quick Links ─────────────────────────────────────────────────── */}


### PR DESCRIPTION
* Split monolithic AgentFactoryService into layered pipeline package (#378) (#383)

* Split monolithic AgentFactoryService into layered pipeline package

Extract the voice pipeline out of the 1700-line AgentFactoryService into a 3-layer core/services/pipeline/ package (params -> builder -> runner, each a framework-agnostic base + Pipecat child), with service_resolver (the only DB access) and service_factory (pure construction). AgentFactoryService is kept as a thin back-compat facade; BotRunnerService is renamed to AgentRunnerService with reusable agent-lookup helpers. Wires bot.py and the telephony routers to the new engine registry.


(cherry picked from commit 89ca9b4f53b6150d846da4acbe994434324b2e46)

* Port call_engines telephony voice fixes onto the new pipeline design

Re-wire the three telephony-resilience processors that Parandhama added in the call_engines/pipeline_builders work (and that adopting 89ca9b4's pipeline package left orphaned) into PipecatPipelineBuilder, keeping the new design's Smart Turn as the primary turn detector:

- VADSpeakingTimeoutProcessor(8s) before STT: caps a stuck Silero VAD "speaking" segment on phone-line noise so segmented STTs flush.
- DuplicateTranscriptionFilter after STT: drops repeated final transcripts that otherwise trigger a duplicate LLM response (the turn-stop race).
- TranscriptionTimeoutUserTurnStopStrategy(1.5s) added to the turn-stop list as a VAD-independent fallback alongside the Smart Turn analyzer.

The processor files already existed; only the wiring was lost. Provider coverage (service_factory) and transport VAD setup are unchanged.



* Refresh GitNexus index metadata in AGENTS.md and CLAUDE.md

Regenerated by `npx gitnexus analyze` after the pipeline refactor — updates symbol/relationship counts and the repo label.



* Remove typo'd venu/ entry from .gitignore

Drop the misspelled "venu/" ignore line (intended venv/, already covered).



* Address PR review on pipeline revamp

- Restore configurable BOT_DISPLAY_NAME for Daily transport (was hardcoded)
- Revert no-agent fallback LLM to gpt-4o-mini
- Re-apply current-date preamble at build time (fresh per call, applies to both in-process and subprocess paths) via PipelineParams.messages_with_date_anchor()
- Extract shared core/utils/telephony.provider_call_id(), de-duplicating the call_id/call_control_id/stream_id logic across bot.py, bot_worker.py, and the runner



* chore: refresh GitNexus index counts in AGENTS.md / CLAUDE.md



* Address pipeline-revamp PR review + add transport package

- Introduce core/services/transport package (CallTransport / TelephonyProvider registry) replacing the isinstance chain in bot()
- service_factory: convert leftover TTS print() debug to logger.debug; create aiohttp sessions lazily per HTTP provider and close them on failure paths (fixes "Unclosed client session" leak on import/init failure)
- runner: assemble call metrics via one helper so the fallback completion path persists user_bot_latency + turns like on_audio_data
- DRY: make telephony_credentials.channel_config the single channel-decryption path; AgentRunnerService and service_resolver now delegate to it



* Merge origin/dev into feature/staging/agent-pipeline-revamp

Resolve modify/delete conflicts in favor of this branch's pipeline revamp:
- Keep deletion of core/services/agent_runtime_resolver.py and core/services/pipeline_builders/ (replaced by core/services/pipeline/). dev's versions were resurrected by the merge but import pipeline_builders modules that no longer exist and nothing references them at runtime.
- Take dev's model meta_data_schema feature (models/seed/services/frontend), alembic migrations, and dev tooling as-is (clean merge).



* fix: S2S Gemini system_instruction + STT init error handling

- service_resolver: set both system_prompt and system_instruction for S2S agents so Gemini Live (reads system_instruction) gets its prompt, not just OpenAI Realtime (reads system_prompt).
- service_factory: build_stt now catches broad Exception (log + return None), matching build_llm/build_tts, so a non-import STT init failure degrades gracefully instead of crashing the pipeline build.



---------



* Version-stamped agent pipeline cache with DB-free rebuild + Grafana call logs (#388) (#391)

* Split monolithic AgentFactoryService into layered pipeline package (#378) (#383)

* Split monolithic AgentFactoryService into layered pipeline package

Extract the voice pipeline out of the 1700-line AgentFactoryService into a 3-layer core/services/pipeline/ package (params -> builder -> runner, each a framework-agnostic base + Pipecat child), with service_resolver (the only DB access) and service_factory (pure construction). AgentFactoryService is kept as a thin back-compat facade; BotRunnerService is renamed to AgentRunnerService with reusable agent-lookup helpers. Wires bot.py and the telephony routers to the new engine registry.


(cherry picked from commit 89ca9b4f53b6150d846da4acbe994434324b2e46)

* Port call_engines telephony voice fixes onto the new pipeline design

Re-wire the three telephony-resilience processors that Parandhama added in the call_engines/pipeline_builders work (and that adopting 89ca9b4's pipeline package left orphaned) into PipecatPipelineBuilder, keeping the new design's Smart Turn as the primary turn detector:

- VADSpeakingTimeoutProcessor(8s) before STT: caps a stuck Silero VAD "speaking" segment on phone-line noise so segmented STTs flush.
- DuplicateTranscriptionFilter after STT: drops repeated final transcripts that otherwise trigger a duplicate LLM response (the turn-stop race).
- TranscriptionTimeoutUserTurnStopStrategy(1.5s) added to the turn-stop list as a VAD-independent fallback alongside the Smart Turn analyzer.

The processor files already existed; only the wiring was lost. Provider coverage (service_factory) and transport VAD setup are unchanged.



* Refresh GitNexus index metadata in AGENTS.md and CLAUDE.md

Regenerated by `npx gitnexus analyze` after the pipeline refactor — updates symbol/relationship counts and the repo label.



* Remove typo'd venu/ entry from .gitignore

Drop the misspelled "venu/" ignore line (intended venv/, already covered).



* Address PR review on pipeline revamp

- Restore configurable BOT_DISPLAY_NAME for Daily transport (was hardcoded)
- Revert no-agent fallback LLM to gpt-4o-mini
- Re-apply current-date preamble at build time (fresh per call, applies to both in-process and subprocess paths) via PipelineParams.messages_with_date_anchor()
- Extract shared core/utils/telephony.provider_call_id(), de-duplicating the call_id/call_control_id/stream_id logic across bot.py, bot_worker.py, and the runner



* chore: refresh GitNexus index counts in AGENTS.md / CLAUDE.md



* Address pipeline-revamp PR review + add transport package

- Introduce core/services/transport package (CallTransport / TelephonyProvider registry) replacing the isinstance chain in bot()
- service_factory: convert leftover TTS print() debug to logger.debug; create aiohttp sessions lazily per HTTP provider and close them on failure paths (fixes "Unclosed client session" leak on import/init failure)
- runner: assemble call metrics via one helper so the fallback completion path persists user_bot_latency + turns like on_audio_data
- DRY: make telephony_credentials.channel_config the single channel-decryption path; AgentRunnerService and service_resolver now delegate to it



* Merge origin/dev into feature/staging/agent-pipeline-revamp

Resolve modify/delete conflicts in favor of this branch's pipeline revamp:
- Keep deletion of core/services/agent_runtime_resolver.py and core/services/pipeline_builders/ (replaced by core/services/pipeline/). dev's versions were resurrected by the merge but import pipeline_builders modules that no longer exist and nothing references them at runtime.
- Take dev's model meta_data_schema feature (models/seed/services/frontend), alembic migrations, and dev tooling as-is (clean merge).



* fix: S2S Gemini system_instruction + STT init error handling

- service_resolver: set both system_prompt and system_instruction for S2S agents so Gemini Live (reads system_instruction) gets its prompt, not just OpenAI Realtime (reads system_prompt).
- service_factory: build_stt now catches broad Exception (log + return None), matching build_llm/build_tts, so a non-import STT init failure degrades gracefully instead of crashing the pipeline build.



---------



* Version-stamped agent pipeline cache with DB-free tool/KB rebuild

Replace transport-keyed, TTL-based pipeline caching with a single transport-independent key guarded by a recomputed version stamp, so a call never runs on stale config. Serialize tools/KB into the cached payload so the builder rebuilds handlers without per-call DB queries (MCP stays live). Invalidate the phone->agent cache on number remapping.

Add a shared _config_service_ids helper so the spec builder and the cache stamp extract provider/model/voice ids from one place, and fold a PAYLOAD_FORMAT_VERSION into the stamp so a payload-shape change on deploy invalidates persisted (now TTL-less) entries.



* feat(call-logs): expose trace_id for Grafana Loki per-call logs

Surface call.trace_id in the call detail payload and CallLogRow type, and add environment-configurable Grafana base URL and Loki app label constants so Call History can deep-link to per-call logs.



* feat(call-history): add Grafana Loki logs link per call

Add a "View logs" action in the Quick View column that opens the call's logs in Grafana Loki, filtered by the call's trace_id with the time window derived from the call's start/end. Disabled for calls with no trace_id. Completes the trace_id exposure from 0d2841c.



* feat(call-history): hide Grafana logs button when not configured

Drop the staging defaults for the Grafana env vars and hide the "View logs" button entirely unless both NEXT_PUBLIC_GRAFANA_BASE_URL and NEXT_PUBLIC_GRAFANA_LOG_APP are set. buildGrafanaLogsUrl now also returns null when either is missing so it never builds a broken URL.



---------





* Version-stamped agent pipeline cache with DB-free rebuild (#393)

* Version-stamped agent pipeline cache with DB-free rebuild + Grafana call logs (#388)

* Split monolithic AgentFactoryService into layered pipeline package (#378) (#383)

* Split monolithic AgentFactoryService into layered pipeline package

Extract the voice pipeline out of the 1700-line AgentFactoryService into a 3-layer core/services/pipeline/ package (params -> builder -> runner, each a framework-agnostic base + Pipecat child), with service_resolver (the only DB access) and service_factory (pure construction). AgentFactoryService is kept as a thin back-compat facade; BotRunnerService is renamed to AgentRunnerService with reusable agent-lookup helpers. Wires bot.py and the telephony routers to the new engine registry.


(cherry picked from commit 89ca9b4f53b6150d846da4acbe994434324b2e46)

* Port call_engines telephony voice fixes onto the new pipeline design

Re-wire the three telephony-resilience processors that Parandhama added in the call_engines/pipeline_builders work (and that adopting 89ca9b4's pipeline package left orphaned) into PipecatPipelineBuilder, keeping the new design's Smart Turn as the primary turn detector:

- VADSpeakingTimeoutProcessor(8s) before STT: caps a stuck Silero VAD "speaking" segment on phone-line noise so segmented STTs flush.
- DuplicateTranscriptionFilter after STT: drops repeated final transcripts that otherwise trigger a duplicate LLM response (the turn-stop race).
- TranscriptionTimeoutUserTurnStopStrategy(1.5s) added to the turn-stop list as a VAD-independent fallback alongside the Smart Turn analyzer.

The processor files already existed; only the wiring was lost. Provider coverage (service_factory) and transport VAD setup are unchanged.



* Refresh GitNexus index metadata in AGENTS.md and CLAUDE.md

Regenerated by `npx gitnexus analyze` after the pipeline refactor — updates symbol/relationship counts and the repo label.



* Remove typo'd venu/ entry from .gitignore

Drop the misspelled "venu/" ignore line (intended venv/, already covered).



* Address PR review on pipeline revamp

- Restore configurable BOT_DISPLAY_NAME for Daily transport (was hardcoded)
- Revert no-agent fallback LLM to gpt-4o-mini
- Re-apply current-date preamble at build time (fresh per call, applies to both in-process and subprocess paths) via PipelineParams.messages_with_date_anchor()
- Extract shared core/utils/telephony.provider_call_id(), de-duplicating the call_id/call_control_id/stream_id logic across bot.py, bot_worker.py, and the runner



* chore: refresh GitNexus index counts in AGENTS.md / CLAUDE.md



* Address pipeline-revamp PR review + add transport package

- Introduce core/services/transport package (CallTransport / TelephonyProvider registry) replacing the isinstance chain in bot()
- service_factory: convert leftover TTS print() debug to logger.debug; create aiohttp sessions lazily per HTTP provider and close them on failure paths (fixes "Unclosed client session" leak on import/init failure)
- runner: assemble call metrics via one helper so the fallback completion path persists user_bot_latency + turns like on_audio_data
- DRY: make telephony_credentials.channel_config the single channel-decryption path; AgentRunnerService and service_resolver now delegate to it



* Merge origin/dev into feature/staging/agent-pipeline-revamp

Resolve modify/delete conflicts in favor of this branch's pipeline revamp:
- Keep deletion of core/services/agent_runtime_resolver.py and core/services/pipeline_builders/ (replaced by core/services/pipeline/). dev's versions were resurrected by the merge but import pipeline_builders modules that no longer exist and nothing references them at runtime.
- Take dev's model meta_data_schema feature (models/seed/services/frontend), alembic migrations, and dev tooling as-is (clean merge).



* fix: S2S Gemini system_instruction + STT init error handling

- service_resolver: set both system_prompt and system_instruction for S2S agents so Gemini Live (reads system_instruction) gets its prompt, not just OpenAI Realtime (reads system_prompt).
- service_factory: build_stt now catches broad Exception (log + return None), matching build_llm/build_tts, so a non-import STT init failure degrades gracefully instead of crashing the pipeline build.



---------



* Version-stamped agent pipeline cache with DB-free tool/KB rebuild

Replace transport-keyed, TTL-based pipeline caching with a single transport-independent key guarded by a recomputed version stamp, so a call never runs on stale config. Serialize tools/KB into the cached payload so the builder rebuilds handlers without per-call DB queries (MCP stays live). Invalidate the phone->agent cache on number remapping.

Add a shared _config_service_ids helper so the spec builder and the cache stamp extract provider/model/voice ids from one place, and fold a PAYLOAD_FORMAT_VERSION into the stamp so a payload-shape change on deploy invalidates persisted (now TTL-less) entries.



* feat(call-logs): expose trace_id for Grafana Loki per-call logs

Surface call.trace_id in the call detail payload and CallLogRow type, and add environment-configurable Grafana base URL and Loki app label constants so Call History can deep-link to per-call logs.



* feat(call-history): add Grafana Loki logs link per call

Add a "View logs" action in the Quick View column that opens the call's logs in Grafana Loki, filtered by the call's trace_id with the time window derived from the call's start/end. Disabled for calls with no trace_id. Completes the trace_id exposure from 0d2841c.



* feat(call-history): hide Grafana logs button when not configured

Drop the staging defaults for the Grafana env vars and hide the "View logs" button entirely unless both NEXT_PUBLIC_GRAFANA_BASE_URL and NEXT_PUBLIC_GRAFANA_LOG_APP are set. buildGrafanaLogsUrl now also returns null when either is missing so it never builds a broken URL.



---------





* Feature/staging/cache key sync agent data (#392)

* Split monolithic AgentFactoryService into layered pipeline package (#378) (#383)

* Split monolithic AgentFactoryService into layered pipeline package

Extract the voice pipeline out of the 1700-line AgentFactoryService into a 3-layer core/services/pipeline/ package (params -> builder -> runner, each a framework-agnostic base + Pipecat child), with service_resolver (the only DB access) and service_factory (pure construction). AgentFactoryService is kept as a thin back-compat facade; BotRunnerService is renamed to AgentRunnerService with reusable agent-lookup helpers. Wires bot.py and the telephony routers to the new engine registry.


(cherry picked from commit 89ca9b4f53b6150d846da4acbe994434324b2e46)

* Port call_engines telephony voice fixes onto the new pipeline design

Re-wire the three telephony-resilience processors that Parandhama added in the call_engines/pipeline_builders work (and that adopting 89ca9b4's pipeline package left orphaned) into PipecatPipelineBuilder, keeping the new design's Smart Turn as the primary turn detector:

- VADSpeakingTimeoutProcessor(8s) before STT: caps a stuck Silero VAD "speaking" segment on phone-line noise so segmented STTs flush.
- DuplicateTranscriptionFilter after STT: drops repeated final transcripts that otherwise trigger a duplicate LLM response (the turn-stop race).
- TranscriptionTimeoutUserTurnStopStrategy(1.5s) added to the turn-stop list as a VAD-independent fallback alongside the Smart Turn analyzer.

The processor files already existed; only the wiring was lost. Provider coverage (service_factory) and transport VAD setup are unchanged.



* Refresh GitNexus index metadata in AGENTS.md and CLAUDE.md

Regenerated by `npx gitnexus analyze` after the pipeline refactor — updates symbol/relationship counts and the repo label.



* Remove typo'd venu/ entry from .gitignore

Drop the misspelled "venu/" ignore line (intended venv/, already covered).



* Address PR review on pipeline revamp

- Restore configurable BOT_DISPLAY_NAME for Daily transport (was hardcoded)
- Revert no-agent fallback LLM to gpt-4o-mini
- Re-apply current-date preamble at build time (fresh per call, applies to both in-process and subprocess paths) via PipelineParams.messages_with_date_anchor()
- Extract shared core/utils/telephony.provider_call_id(), de-duplicating the call_id/call_control_id/stream_id logic across bot.py, bot_worker.py, and the runner



* chore: refresh GitNexus index counts in AGENTS.md / CLAUDE.md



* Address pipeline-revamp PR review + add transport package

- Introduce core/services/transport package (CallTransport / TelephonyProvider registry) replacing the isinstance chain in bot()
- service_factory: convert leftover TTS print() debug to logger.debug; create aiohttp sessions lazily per HTTP provider and close them on failure paths (fixes "Unclosed client session" leak on import/init failure)
- runner: assemble call metrics via one helper so the fallback completion path persists user_bot_latency + turns like on_audio_data
- DRY: make telephony_credentials.channel_config the single channel-decryption path; AgentRunnerService and service_resolver now delegate to it



* Merge origin/dev into feature/staging/agent-pipeline-revamp

Resolve modify/delete conflicts in favor of this branch's pipeline revamp:
- Keep deletion of core/services/agent_runtime_resolver.py and core/services/pipeline_builders/ (replaced by core/services/pipeline/). dev's versions were resurrected by the merge but import pipeline_builders modules that no longer exist and nothing references them at runtime.
- Take dev's model meta_data_schema feature (models/seed/services/frontend), alembic migrations, and dev tooling as-is (clean merge).



* fix: S2S Gemini system_instruction + STT init error handling

- service_resolver: set both system_prompt and system_instruction for S2S agents so Gemini Live (reads system_instruction) gets its prompt, not just OpenAI Realtime (reads system_prompt).
- service_factory: build_stt now catches broad Exception (log + return None), matching build_llm/build_tts, so a non-import STT init failure degrades gracefully instead of crashing the pipeline build.



---------



* Version-stamped agent pipeline cache with DB-free tool/KB rebuild

Replace transport-keyed, TTL-based pipeline caching with a single transport-independent key guarded by a recomputed version stamp, so a call never runs on stale config. Serialize tools/KB into the cached payload so the builder rebuilds handlers without per-call DB queries (MCP stays live). Invalidate the phone->agent cache on number remapping.

Add a shared _config_service_ids helper so the spec builder and the cache stamp extract provider/model/voice ids from one place, and fold a PAYLOAD_FORMAT_VERSION into the stamp so a payload-shape change on deploy invalidates persisted (now TTL-less) entries.



* feat(call-logs): expose trace_id for Grafana Loki per-call logs

Surface call.trace_id in the call detail payload and CallLogRow type, and add environment-configurable Grafana base URL and Loki app label constants so Call History can deep-link to per-call logs.



* feat(call-history): add Grafana Loki logs link per call

Add a "View logs" action in the Quick View column that opens the call's logs in Grafana Loki, filtered by the call's trace_id with the time window derived from the call's start/end. Disabled for calls with no trace_id. Completes the trace_id exposure from 0d2841c.



* feat(call-history): hide Grafana logs button when not configured

Drop the staging defaults for the Grafana env vars and hide the "View logs" button entirely unless both NEXT_PUBLIC_GRAFANA_BASE_URL and NEXT_PUBLIC_GRAFANA_LOG_APP are set. buildGrafanaLogsUrl now also returns null when either is missing so it never builds a broken URL.



---------





---------





* fix(dashboard): stop 500 on /dashboard/stats + show loader while stats load

Backend: DashboardService.get_stats counted Call rows with Query.count(), which wraps a "SELECT <all Call columns>" subquery and references calls.pipeline_config — a model column absent from the live DB — causing "UndefinedColumn: column calls.pipeline_config does not exist". Switched the three counts to with_entities(func.count(Call.id)).scalar() (matching the existing total_seconds query) so only count(calls.id) is selected while tenant scoping is preserved.

Frontend: home stat cards now render a skeleton loader while the stats request is in flight instead of a static dash, falling back to "—" only when it resolves empty.



---------