### PR TITLE
feat(call-history): filterable call history with faceted filter drawer

### DIFF
--- a/alembic/versions/56e0fb796b3e_add_pipeline_config_to_calls.py
+++ b/alembic/versions/56e0fb796b3e_add_pipeline_config_to_calls.py
@@ -19,7 +19,7 @@ from sqlalchemy.dialects import postgresql
 
 
 revision = '56e0fb796b3e'
-down_revision = 'c9a1d3f5b8e2'
+down_revision = '6bd88c8ee3dc'
 branch_labels = None
 depends_on = None
 

--- a/core/api/v1/call_logs.py
+++ b/core/api/v1/call_logs.py
@@ -73,6 +73,26 @@ def get_calls(
     )
 
 
+class FacetsRequest(BaseModel):
+    start_date_time: Optional[str] = None
+    end_date_time: Optional[str] = None
+    filters: Optional[List[CallFilterParam]] = None
+
+
+@router.post("/facets")
+def get_facets(
+    body: FacetsRequest,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    filters = [f.model_dump() for f in body.filters] if body.filters else None
+    return _get_service(claims, db).get_facets(
+        start_date_time=body.start_date_time,
+        end_date_time=body.end_date_time,
+        filters=filters,
+    )
+
+
 @router.get("/{call_id}/audio-url")
 def get_audio_url(
     call_id: str,

--- a/core/services/call_service.py
+++ b/core/services/call_service.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import HTTPException
 from sqlalchemy import Float, and_, asc, cast, desc, func, or_, select
-from sqlalchemy.orm import Session, aliased
+from sqlalchemy.orm import Query, Session, aliased
 
 from core.models.agent import Agent
 from core.models.call import Call
@@ -81,37 +81,17 @@ class CallService(BaseService):
 
         return {"column": column_name, "values": values}
 
-    def get_calls(
-        self,
-        page_no: int = 1,
-        page_size: int = 10,
-        start_date_time: Optional[str] = None,
-        end_date_time: Optional[str] = None,
-        filters: Optional[List[Dict[str, Any]]] = None,
-        sort_by: Optional[str] = None,
-        sort_order: str = "desc",
-    ) -> Dict[str, Any]:
-        from_pn = aliased(PhoneNumber, name="from_pn")
-        to_pn = aliased(PhoneNumber, name="to_pn")
+    # ------------------------------------------------------------------
+    # Filtering helpers (shared by get_calls and get_facets)
+    # ------------------------------------------------------------------
 
-        base_query = (
-            self.query(Call)
-            .join(Agent, Call.agent_id == Agent.id)
-            .join(Channel, Call.channel_id == Channel.id)
-            .outerjoin(from_pn, Call.from_phone_number_id == from_pn.id)
-            .outerjoin(to_pn, Call.to_phone_number_id == to_pn.id)
-            # 1:1 on call_id (unique) — keeps row count equal to call count
-            # so pagination math is unaffected.
-            .outerjoin(CallMetrics, CallMetrics.call_id == Call.id)
-        )
+    def _filter_column_map(self) -> Dict[str, Any]:
+        """Map filter/sort field names to their SQLAlchemy column expressions.
 
-        if start_date_time is not None:
-            base_query = base_query.filter(Call.started_at >= start_date_time)
-        if end_date_time is not None:
-            base_query = base_query.filter(Call.started_at <= end_date_time)
-
-        # Column mapping for filters and sorting
-        column_map = {
+        ``status`` is None because it is derived from (ended_at, metadata) and
+        handled specially in :meth:`_apply_filters`.
+        """
+        return {
             "status": None,  # derived, handled specially
             "direction": Call.direction,
             "duration_seconds": Call.duration_seconds,
@@ -148,56 +128,195 @@ class CallService(BaseService):
             ),
         }
 
-        if filters:
-            for f in filters:
-                field = f.get("field")
-                operator = f.get("operator")
-                value = f.get("value")
+    def _status_predicates(self) -> Dict[str, Any]:
+        """Map each derived call status to its SQL predicate.
 
-                if field == "status":
-                    # Derived from (Call.ended_at, Call.metadata_['status']):
-                    #   failed       → metadata.status == 'failed'
-                    #   completed    → ended_at IS NOT NULL AND not failed
-                    #   in_progress  → ended_at IS NULL
-                    # Selecting multiple statuses ORs the predicates together.
-                    # NOTE: coalesce(NULL, "") is required because most rows
-                    # have metadata_ = NULL (only fail_call writes it). Without
-                    # coalesce, `metadata_['status'].astext` returns SQL NULL,
-                    # ~NULL is NULL, and the WHERE clause drops every row.
-                    if operator == "in" and isinstance(value, list):
-                        status_text = func.coalesce(
-                            Call.metadata_["status"].astext, ""
-                        )
-                        is_failed = status_text == "failed"
-                        preds = []
-                        if "failed" in value:
-                            preds.append(is_failed)
-                        if "completed" in value:
-                            preds.append(and_(Call.ended_at.isnot(None), ~is_failed))
-                        if "in_progress" in value:
-                            preds.append(Call.ended_at.is_(None))
-                        if preds:
-                            base_query = base_query.filter(or_(*preds))
-                    continue
+        Status is derived from (Call.ended_at, Call.metadata_['status']):
+          failed       → metadata.status == 'failed'
+          completed    → ended_at IS NOT NULL AND not failed
+          in_progress  → ended_at IS NULL
 
-                col = column_map.get(field)
-                if col is None:
-                    continue
+        NOTE: coalesce(NULL, "") is required because most rows have
+        metadata_ = NULL (only fail_call writes it). Without coalesce,
+        `metadata_['status'].astext` returns SQL NULL, ~NULL is NULL, and the
+        WHERE clause drops every row. Shared by :meth:`_apply_filters` (status
+        filter) and :meth:`get_facets` (per-status counts) so the taxonomy lives
+        in one place.
+        """
+        status_text = func.coalesce(Call.metadata_["status"].astext, "")
+        is_failed = status_text == "failed"
+        return {
+            "completed": and_(Call.ended_at.isnot(None), ~is_failed),
+            "in_progress": Call.ended_at.is_(None),
+            "failed": is_failed,
+        }
 
-                if operator == "equal_to":
-                    base_query = base_query.filter(col == value)
-                elif operator == "greater_than":
-                    base_query = base_query.filter(col > value)
-                elif operator == "less_than":
-                    base_query = base_query.filter(col < value)
-                elif operator == "between":
-                    if isinstance(value, list) and len(value) == 2:
-                        base_query = base_query.filter(col.between(value[0], value[1]))
-                elif operator == "in":
-                    if isinstance(value, list):
-                        base_query = base_query.filter(col.in_(value))
-                elif operator == "contains":
-                    base_query = base_query.filter(col.ilike(f"%{value}%"))
+    def _apply_filters(
+        self,
+        query: Query,
+        filters: Optional[List[Dict[str, Any]]],
+        column_map: Optional[Dict[str, Any]] = None,
+        exclude_field: Optional[str] = None,
+    ) -> Query:
+        """Apply a list of {field, operator, value} filters to ``query``.
+
+        Returns a new ``Query`` (filters are applied immutably, never in place).
+        ``exclude_field`` skips one field — used by faceting so a facet's own
+        selection doesn't constrain its own counts (Vercel semantics).
+        """
+        if not filters:
+            return query
+        if column_map is None:
+            column_map = self._filter_column_map()
+
+        for f in filters:
+            field = f.get("field")
+            operator = f.get("operator")
+            value = f.get("value")
+
+            if exclude_field is not None and field == exclude_field:
+                continue
+
+            if field == "status":
+                # Selecting multiple statuses ORs the predicates together; see
+                # _status_predicates for how each state is derived.
+                if operator == "in" and isinstance(value, list):
+                    predicates = self._status_predicates()
+                    preds = [predicates[v] for v in value if v in predicates]
+                    if preds:
+                        query = query.filter(or_(*preds))
+                continue
+
+            col = column_map.get(field)
+            if col is None:
+                continue
+
+            if operator == "equal_to":
+                query = query.filter(col == value)
+            elif operator == "greater_than":
+                query = query.filter(col > value)
+            elif operator == "less_than":
+                query = query.filter(col < value)
+            elif operator == "between":
+                if isinstance(value, list) and len(value) == 2:
+                    query = query.filter(col.between(value[0], value[1]))
+            elif operator == "in":
+                if isinstance(value, list):
+                    query = query.filter(col.in_(value))
+            elif operator == "contains":
+                query = query.filter(col.ilike(f"%{value}%"))
+
+        return query
+
+    def get_facets(
+        self,
+        start_date_time: Optional[str] = None,
+        end_date_time: Optional[str] = None,
+        filters: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        """Per-value counts for each facet field, for the filter drawer.
+
+        Each facet reflects the active date range and every *other* active
+        filter, but NOT its own selection — so toggling a value within a facet
+        doesn't zero out its siblings (Vercel-style faceting).
+        """
+        column_map = self._filter_column_map()
+        # Faceted (non-numeric, checkbox) fields and their column expressions.
+        facet_fields = [
+            "status",
+            "agent_name",
+            "direction",
+            "channel_type",
+            "llm_model",
+            "stt_model",
+            "tts_model",
+        ]
+        FACET_LIMIT = 50
+
+        def _base():
+            q = (
+                self.query(Call)
+                .join(Agent, Call.agent_id == Agent.id)
+                .join(Channel, Call.channel_id == Channel.id)
+                # 1:1 outerjoin keeps row count == call count so COUNT(*) is the
+                # number of calls; also lets turn_count/avg_latency filters apply.
+                .outerjoin(CallMetrics, CallMetrics.call_id == Call.id)
+            )
+            if start_date_time is not None:
+                q = q.filter(Call.started_at >= start_date_time)
+            if end_date_time is not None:
+                q = q.filter(Call.started_at <= end_date_time)
+            return q
+
+        result: Dict[str, List[Dict[str, Any]]] = {}
+
+        for field in facet_fields:
+            scoped = self._apply_filters(
+                _base(), filters, column_map=column_map, exclude_field=field
+            )
+
+            if field == "status":
+                predicates = self._status_predicates()
+                # One query, one filtered COUNT per state (Postgres FILTER
+                # clause), instead of a round-trip per status.
+                row = scoped.with_entities(
+                    *[func.count().filter(pred).label(name) for name, pred in predicates.items()]
+                ).one()
+                # Fixed enum set — emit all three even when zero (Vercel shows
+                # zero-count rows for known levels).
+                result[field] = [
+                    {"value": name, "count": getattr(row, name)} for name in predicates
+                ]
+                continue
+
+            col = column_map.get(field)
+            rows = (
+                scoped.with_entities(col, func.count())
+                .group_by(col)
+                .order_by(func.count().desc())
+                .limit(FACET_LIMIT)
+                .all()
+            )
+            result[field] = [
+                {"value": value, "count": count}
+                for value, count in rows
+                if value is not None and value != ""
+            ]
+
+        return result
+
+    def get_calls(
+        self,
+        page_no: int = 1,
+        page_size: int = 10,
+        start_date_time: Optional[str] = None,
+        end_date_time: Optional[str] = None,
+        filters: Optional[List[Dict[str, Any]]] = None,
+        sort_by: Optional[str] = None,
+        sort_order: str = "desc",
+    ) -> Dict[str, Any]:
+        from_pn = aliased(PhoneNumber, name="from_pn")
+        to_pn = aliased(PhoneNumber, name="to_pn")
+
+        base_query = (
+            self.query(Call)
+            .join(Agent, Call.agent_id == Agent.id)
+            .join(Channel, Call.channel_id == Channel.id)
+            .outerjoin(from_pn, Call.from_phone_number_id == from_pn.id)
+            .outerjoin(to_pn, Call.to_phone_number_id == to_pn.id)
+            # 1:1 on call_id (unique) — keeps row count equal to call count
+            # so pagination math is unaffected.
+            .outerjoin(CallMetrics, CallMetrics.call_id == Call.id)
+        )
+
+        if start_date_time is not None:
+            base_query = base_query.filter(Call.started_at >= start_date_time)
+        if end_date_time is not None:
+            base_query = base_query.filter(Call.started_at <= end_date_time)
+
+        # Column mapping for filters and sorting (shared with get_facets).
+        column_map = self._filter_column_map()
+        base_query = self._apply_filters(base_query, filters, column_map=column_map)
 
         total = base_query.count()
 

--- a/ee/api/v1/call_logs.py
+++ b/ee/api/v1/call_logs.py
@@ -3,7 +3,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
-from core.api.v1.call_logs import ListCallsRequest
+from core.api.v1.call_logs import FacetsRequest, ListCallsRequest
 from core.database.session import get_db
 from core.services.call_service import CallService
 from ee.middleware.auth import EEJWTClaims, require_ee_org_member
@@ -47,6 +47,20 @@ def get_calls(
         filters=filters,
         sort_by=body.sort_by,
         sort_order=body.sort_order,
+    )
+
+
+@router.post("/facets")
+def get_facets(
+    body: FacetsRequest,
+    claims: EEJWTClaims = Depends(require_ee_org_member),
+    db: Session = Depends(get_db),
+):
+    filters = [f.model_dump() for f in body.filters] if body.filters else None
+    return _get_service(claims, db).get_facets(
+        start_date_time=body.start_date_time,
+        end_date_time=body.end_date_time,
+        filters=filters,
     )
 
 

--- a/frontend/docs/shared-components.md
+++ b/frontend/docs/shared-components.md
@@ -925,9 +925,100 @@ import { Trash2 } from 'lucide-react';
 
 ---
 
+## DateRangePicker
+
+Timezone-aware date-range picker built on `react-day-picker` v9 + `@date-fns/tz`. A popover trigger opens a panel with relative presets, a range calendar, start/end time inputs, an Apply/Clear footer, and an IANA timezone selector. Drafts live inside the popover until **Apply**. Emits `{ start, end, timeZone }` where `start`/`end` are **UTC ISO** instants (the wall-clock time the user picked, resolved in `timeZone`).
+
+### Props
+
+| Prop             | Type                                | Default               | Description                                                      |
+| ---------------- | ----------------------------------- | --------------------- | --------------------------------------------------------------- |
+| value            | `DateRangeValue`                    | —                     | Applied value `{ start, end, timeZone }` (`start`/`end` UTC ISO). |
+| onChange         | `(value: DateRangeValue) => void`   | —                     | Fired on Apply / Clear with the new value.                      |
+| placeholder      | string                              | `'Select date range'` | Trigger text when no range is set.                              |
+| presets          | boolean                             | `true`                | Show the relative preset rail (Last 15m / 30m / 1h / 24h / 7d). |
+| align            | `'start' \| 'center' \| 'end'`      | `'start'`             | Popover alignment.                                              |
+| triggerClassName | string                              | —                     | Extra classes for the trigger button.                           |
+| disabled         | boolean                             | `false`               | Disables the trigger.                                           |
+
+**DateRangeValue:** `{ start: string \| null; end: string \| null; timeZone: string }`
+
+### Example
+
+```tsx
+const [range, setRange] = useState<DateRangeValue>({ start: null, end: null, timeZone: 'UTC' });
+
+<DateRangePicker value={range} onChange={setRange} />;
+
+// Send to an API expecting ISO bounds:
+const params = {
+  start_date_time: range.start ?? undefined,
+  end_date_time: range.end ?? undefined,
+};
+```
+
+### Do's and Don'ts
+
+- **Do** treat `start`/`end` as UTC ISO — pass them straight to backends that compare against UTC timestamps.
+- **Do** persist `timeZone` alongside the range so the trigger re-renders in the same zone.
+- **Don't** format `start`/`end` with `formatDate` (no timezone) for display — use `formatTzDateTime(iso, tz)` from `@/utils/date`.
+
+---
+
+## TokenSearchBar
+
+Tokenized `field:value` search bar with autocomplete chips (Vercel-style). Typing shows a field list; selecting a field loads its values (for `enum` fields, via `fetchValues`, cached after first load) and shows a value list; confirmed filters render as removable chips. Typing `status:` directly auto-activates that field. Emits a normalized `SearchToken[]`.
+
+### Props
+
+| Prop        | Type                            | Default | Description                                            |
+| ----------- | ------------------------------- | ------- | ------------------------------------------------------ |
+| fields      | `TokenSearchField[]`            | —       | **Required.** Field definitions (see below).           |
+| value       | `SearchToken[]`                 | —       | **Required.** Controlled list of active tokens.        |
+| onChange    | `(tokens: SearchToken[]) => void` | —     | **Required.** Fired when tokens are added/removed.     |
+| placeholder | string                          | `'Filter by field…'` | Placeholder when empty.                   |
+| className   | string                          | —       | Class for the outer wrapper.                           |
+| hideChips   | boolean                         | `false` | Hide the inline chips (e.g. when chips are shown elsewhere). |
+| onClear     | `() => void`                    | —       | Show a trailing clear (×) control inside the bar; called on click. |
+| showClear   | boolean                         | —       | Force-show the clear control (defaults to showing whenever there are tokens). |
+
+**TokenSearchField:** `{ key: string; label: string; type?: 'enum' \| 'text'; fetchValues?: () => Promise<string[]>; formatValue?: (value: string) => string }`
+
+**SearchToken:** `{ field: string; value: string }`
+
+### Keyboard
+
+↑/↓ move the highlight, Enter selects, Esc closes, **Backspace on an empty input** clears the active field (or removes the last chip). Adds/removals are announced via an `aria-live` region.
+
+### Example
+
+```tsx
+const [tokens, setTokens] = useState<SearchToken[]>([]);
+
+<TokenSearchBar
+  fields={[
+    { key: 'status', label: 'Status', type: 'enum', fetchValues: () => getFilterValues('status').then((r) => r.values) },
+    { key: 'agent_name', label: 'Agent', type: 'enum', fetchValues: () => getFilterValues('agent_name').then((r) => r.values) },
+  ]}
+  value={tokens}
+  onChange={setTokens}
+/>;
+
+// Map tokens → API filter params:
+const filters = tokens.map((t) => ({ field: t.field, operator: 'in', value: [t.value] }));
+```
+
+### Do's and Don'ts
+
+- **Do** group multiple tokens of the same field into one `in` filter when building API params.
+- **Do** provide `fetchValues` for `enum` fields so the value list autocompletes.
+- **Don't** call `fetchValues` eagerly — the component lazy-loads and caches per field on first open.
+
+---
+
 ## Exports from `@/components/shared`
 
-- **Components:** `ActionMenu`, `CheckboxField`, `CustomButton`, `CustomLink`, `CustomModal`, `CustomTab`, `CustomTable`, `CustomTooltip`, `Divider`, `Form`, `Logo`, `MultiSelectField`, `RadioGroupField`, `SearchableSelect`, `SelectInput`, `SliderField`, `TextAreaField`, `TextInput`
+- **Components:** `ActionMenu`, `CheckboxField`, `CustomButton`, `CustomLink`, `CustomModal`, `CustomTab`, `CustomTable`, `CustomTooltip`, `DateRangePicker`, `Divider`, `Form`, `Logo`, `MultiSelectField`, `RadioGroupField`, `SearchableSelect`, `SelectInput`, `SliderField`, `TextAreaField`, `TextInput`, `TokenSearchBar`
 - **Types:** `ActionMenuProps`, `CheckboxFieldBaseProps`, `CustomModalProps`, `CustomTableColumn`, `CustomTablePagination`, `CustomTableProps`, `FormCheckboxFieldProps`, `FormMultiSelectFieldProps`, `FormRadioGroupFieldProps`, `FormSelectInputProps`, `FormSliderFieldProps`, `FormTextAreaFieldProps`, `FormTextInputProps`, `MultiSelectFieldBaseProps`, `MultiSelectOption`, `RadioGroupOption`, `SearchableSelectOption`, `SelectInputBaseProps`, `SelectOption`, `SliderFieldBaseProps`, `TabItem`, `TextAreaFieldBaseProps`, `TextInputBaseProps`
 
 ---

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     ]
   },
   "dependencies": {
+    "@date-fns/tz": "^1.5.0",
     "@hookform/resolvers": "^5.2.2",
     "@tailwindcss/postcss": "^4.2.1",
     "@tanstack/react-query": "^5.100.11",
@@ -59,6 +60,7 @@
     "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "19.1.0",
+    "react-day-picker": "^9",
     "react-dom": "19.1.0",
     "react-hook-form": "^7.71.2",
     "sass": "^1.91.0",

--- a/frontend/src/atoms/CallLogAtom.tsx
+++ b/frontend/src/atoms/CallLogAtom.tsx
@@ -1,11 +1,33 @@
-import { getCallLogs } from '@/services/callLogService';
-import type { CallLogQueryParams, CallLogRow, CallLogsState } from '@/types/callLog';
+import { getCallFacets, getCallLogs } from '@/services/callLogService';
+import type {
+  CallFacetsParams,
+  CallFacetsState,
+  CallLogQueryParams,
+  CallLogRow,
+  CallLogsState,
+} from '@/types/callLog';
 import { atom } from 'jotai';
 
 const callLogsAtom = atom<CallLogsState>({
   callLogs: [],
   total: 0,
   loading: false,
+});
+
+export const callFacetsAtom = atom<CallFacetsState>({
+  facets: {},
+  loading: false,
+});
+
+export const fetchCallFacets = atom(null, async (_get, set, params: CallFacetsParams) => {
+  set(callFacetsAtom, (prev) => ({ ...prev, loading: true }));
+  try {
+    const facets = await getCallFacets(params);
+    set(callFacetsAtom, { facets: facets ?? {}, loading: false });
+  } catch (err) {
+    set(callFacetsAtom, (prev) => ({ ...prev, loading: false }));
+    throw err;
+  }
 });
 
 export const fetchCallLogs = atom(null, async (_get, set, params: CallLogQueryParams) => {

--- a/frontend/src/components/call-history/CallHistory.tsx
+++ b/frontend/src/components/call-history/CallHistory.tsx
@@ -1,32 +1,36 @@
 'use client';
 
-import agentsAtom, { fetchAllAgentsAtom } from '@/atoms/AgentsAtom';
-import callLogsAtom, { fetchCallLogs } from '@/atoms/CallLogAtom';
+import callLogsAtom, { callFacetsAtom, fetchCallFacets, fetchCallLogs } from '@/atoms/CallLogAtom';
 import { AgentTypeBadge } from '@/components/agents/AgentTypeBadge';
 import {
   CustomButton,
-  CustomDrawer,
   CustomPopover,
   CustomTable,
   CustomTooltip,
   PhoneNumberDisplay,
+  TokenSearchBar,
 } from '@/components/shared';
-import SelectInput from '@/components/shared/SelectInput';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
-import { Slider } from '@/components/ui/slider';
-import { CALL_STATUS_OPTIONS } from '@/lib/constants/filters';
 import { getFilterValues } from '@/services/callLogService';
-import { useAuthStore } from '@/stores/auth';
-import type { CallLogFilterParam, CallLogQueryParams, CallLogRow } from '@/types/callLog';
-import type { CustomTableColumn, CustomTableSortState, SelectOption } from '@/types/components';
+import type {
+  CallFacetsParams,
+  CallLogFilterParam,
+  CallLogQueryParams,
+  CallLogRow,
+} from '@/types/callLog';
+import type {
+  CustomTableColumn,
+  CustomTableSortState,
+  SearchToken,
+  TokenSearchField,
+} from '@/types/components';
+import { formatDuration, formatTimestamp, getBrowserTimeZone } from '@/utils/date';
 import { buildGrafanaLogsUrl, isGrafanaConfigured } from '@/utils/grafana';
-import { formatDuration, formatTimestamp } from '@/utils/date';
 import { handleApiError } from '@/utils/helpers';
 import { useAtom } from 'jotai';
 import {
   BarChart3,
-  CalendarDays,
   Columns3,
   MessageSquareText,
   Phone,
@@ -38,9 +42,32 @@ import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import CallDetailDrawer from './CallDetailDrawer';
+import CallHistoryFilterDrawer, {
+  countDrawerFilters,
+  createEmptyFilterState,
+  DRAWER_FACET_SECTIONS,
+  DRAWER_FIELD_KEYS,
+  isLatencyActive,
+  titleCase,
+  type CallFilterState,
+} from './filter-drawer';
 import TranscriptionModal from './TranscriptionModal';
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+
+const BROWSER_TZ = getBrowserTimeZone();
+
+// The token search mirrors the drawer's facets (all live in the drawer now).
+// Selections sync both ways through filterState.facets, so a value chosen in the
+// drawer shows up as a chip here and vice versa. Values autocomplete from
+// /filter-values (lazy-loaded + cached by TokenSearchBar).
+const TOKEN_FIELDS: TokenSearchField[] = DRAWER_FACET_SECTIONS.map((s) => ({
+  key: s.field,
+  label: s.label,
+  type: 'enum',
+  fetchValues: () => getFilterValues(s.field).then((r) => r.values),
+  formatValue: s.titleCase ? titleCase : undefined,
+}));
 
 const STATUS_BADGE_CLASSES: Record<string, string> = {
   completed: 'bg-emerald-500/15 text-emerald-600 hover:bg-emerald-500/15 dark:text-emerald-400',
@@ -52,12 +79,9 @@ const formatSeconds = (v: number | null) => (v == null ? '-' : `${v.toFixed(2)}s
 const formatCount = (v: number | null) => (v == null ? '-' : v.toLocaleString());
 
 // Single source of truth for the column-visibility popover. Columns are
-// grouped so the user can toggle a whole section in one click. The table
-// itself doesn't reorder based on these groups — visibility just filters
-// the existing column array in place.
-// `agent_name` and `actions` are intentionally absent here: the Agent and
-// Quick View columns are required for the table to be usable, so they're
-// always rendered and not exposed as togglable in the UI.
+// grouped so the user can toggle a whole section in one click. `agent_name`
+// and `actions` are intentionally absent: the Agent and Quick View columns are
+// always rendered and not exposed as togglable.
 const COLUMN_GROUPS: Array<{
   name: string;
   columns: Array<{ key: string; label: string }>;
@@ -84,12 +108,6 @@ const COLUMN_GROUPS: Array<{
   },
 ];
 const ALL_COLUMN_KEYS = COLUMN_GROUPS.flatMap((g) => g.columns.map((c) => c.key));
-
-// Bounds for the avg-latency slider in the pipeline-filters drawer.
-const MIN_LATENCY_SECONDS = 0;
-const MAX_LATENCY_SECONDS = 5;
-const LATENCY_STEP = 0.1;
-const DEFAULT_LATENCY_RANGE: [number, number] = [MIN_LATENCY_SECONDS, MAX_LATENCY_SECONDS];
 /** Columns that are pinned to the table regardless of popover selection. */
 const ALWAYS_VISIBLE_COLUMN_KEYS = new Set<string>(['agent_name', 'actions']);
 
@@ -109,40 +127,30 @@ const CallHistory: React.FC = () => {
   const router = useRouter();
   const [data] = useAtom(callLogsAtom);
   const [, doFetchCallLogs] = useAtom(fetchCallLogs);
-  const [{ agentList }] = useAtom(agentsAtom);
-  const [, doFetchAllAgents] = useAtom(fetchAllAgentsAtom);
-  // Distinct LLM/STT/TTS model lists are scoped to the active org by the
-  // backend; refetch whenever the active org changes so a tenant switch
-  // doesn't leak the previous workspace's models into the dropdowns.
-  const activeOrgId = useAuthStore((s) => s.activeOrgId);
+  const [facetsState] = useAtom(callFacetsAtom);
+  const [, doFetchCallFacets] = useAtom(fetchCallFacets);
 
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
-  const [agentFilter, setAgentFilter] = useState('all');
-  const [statusFilter, setStatusFilter] = useState('all');
-  const [llmModelFilter, setLlmModelFilter] = useState('all');
-  const [sttModelFilter, setSttModelFilter] = useState('all');
-  const [ttsModelFilter, setTtsModelFilter] = useState('all');
-  const [llmModels, setLlmModels] = useState<string[]>([]);
-  const [sttModels, setSttModels] = useState<string[]>([]);
-  const [ttsModels, setTtsModels] = useState<string[]>([]);
   const [sortBy, setSortBy] = useState<string | undefined>(undefined);
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
-  const [startDateTime, setStartDateTime] = useState('');
-  const [endDateTime, setEndDateTime] = useState('');
-  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
-  const [minTurns, setMinTurns] = useState('');
-  const [maxTurns, setMaxTurns] = useState('');
-  const [latencyRange, setLatencyRange] = useState<[number, number]>(DEFAULT_LATENCY_RANGE);
 
-  // Column visibility — sentinel 'all' means every column is shown so a fresh
-  // session doesn't need to enumerate keys. Drafts live inside the popover
-  // until the user clicks Apply, mirroring the pipeline-filters drawer.
+  // Single source of truth: date range, facets (toolbar + drawer), turns, latency.
+  const [filterState, setFilterState] = useState<CallFilterState>(() =>
+    createEmptyFilterState(BROWSER_TZ),
+  );
+  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
+
+  // Column visibility — sentinel 'all' means every column is shown. Drafts live
+  // inside the popover until the user clicks Apply.
   const [visibleColumnKeys, setVisibleColumnKeys] = useState<Set<string> | 'all'>('all');
   const [columnFilterOpen, setColumnFilterOpen] = useState(false);
   const [draftColumnKeys, setDraftColumnKeys] = useState<Set<string>>(
     () => new Set(ALL_COLUMN_KEYS),
   );
+
+  const [selectedCallLog, setSelectedCallLog] = useState<CallLogRow | null>(null);
+  const [transcriptionCallLog, setTranscriptionCallLog] = useState<CallLogRow | null>(null);
 
   useEffect(() => {
     if (columnFilterOpen) {
@@ -185,202 +193,80 @@ const CallHistory: React.FC = () => {
   const hiddenColumnCount =
     visibleColumnKeys === 'all' ? 0 : ALL_COLUMN_KEYS.length - visibleColumnKeys.size;
 
-  // Drafts live inside the drawer until the user clicks Apply. They are seeded
-  // from the applied state every time the drawer opens, and discarded when the
-  // drawer is closed via the X / backdrop without applying.
-  const [draftLlmModel, setDraftLlmModel] = useState('all');
-  const [draftSttModel, setDraftSttModel] = useState('all');
-  const [draftTtsModel, setDraftTtsModel] = useState('all');
-  const [draftMinTurns, setDraftMinTurns] = useState('');
-  const [draftMaxTurns, setDraftMaxTurns] = useState('');
-  const [draftLatencyRange, setDraftLatencyRange] =
-    useState<[number, number]>(DEFAULT_LATENCY_RANGE);
+  // The Filters button badge reflects only the drawer-managed filters; the
+  // date range, status and agent live in the toolbar with their own indicators.
+  const drawerFilterCount = useMemo(() => countDrawerFilters(filterState), [filterState]);
 
-  useEffect(() => {
-    if (filterDrawerOpen) {
-      setDraftLlmModel(llmModelFilter);
-      setDraftSttModel(sttModelFilter);
-      setDraftTtsModel(ttsModelFilter);
-      setDraftMinTurns(minTurns);
-      setDraftMaxTurns(maxTurns);
-      setDraftLatencyRange(latencyRange);
+  // Filter predicates derived purely from filterState. All facet selections
+  // (toolbar status/agent + drawer direction/channel/models, kept in sync with
+  // the token search) become one `in` filter per field; turns/latency become
+  // `between`. Kept separate from pagination/sort so the facets request below
+  // stays stable across page and sort changes (it doesn't depend on either).
+  const filters = useMemo<CallLogFilterParam[]>(() => {
+    const out: CallLogFilterParam[] = [];
+
+    for (const [field, vals] of Object.entries(filterState.facets)) {
+      if (vals?.length) out.push({ field, operator: 'in', value: vals });
     }
-  }, [
-    filterDrawerOpen,
-    llmModelFilter,
-    sttModelFilter,
-    ttsModelFilter,
-    minTurns,
-    maxTurns,
-    latencyRange,
-  ]);
 
-  const turnsActive = minTurns.trim() !== '' || maxTurns.trim() !== '';
-  const latencyActive =
-    latencyRange[0] > MIN_LATENCY_SECONDS || latencyRange[1] < MAX_LATENCY_SECONDS;
-  const activeModelFilterCount =
-    (llmModelFilter !== 'all' ? 1 : 0) +
-    (sttModelFilter !== 'all' ? 1 : 0) +
-    (ttsModelFilter !== 'all' ? 1 : 0) +
-    (turnsActive ? 1 : 0) +
-    (latencyActive ? 1 : 0);
-
-  const draftTurnsActive = draftMinTurns.trim() !== '' || draftMaxTurns.trim() !== '';
-  const draftLatencyActive =
-    draftLatencyRange[0] > MIN_LATENCY_SECONDS || draftLatencyRange[1] < MAX_LATENCY_SECONDS;
-  const draftActiveCount =
-    (draftLlmModel !== 'all' ? 1 : 0) +
-    (draftSttModel !== 'all' ? 1 : 0) +
-    (draftTtsModel !== 'all' ? 1 : 0) +
-    (draftTurnsActive ? 1 : 0) +
-    (draftLatencyActive ? 1 : 0);
-
-  const handleResetDrafts = useCallback(() => {
-    setDraftLlmModel('all');
-    setDraftSttModel('all');
-    setDraftTtsModel('all');
-    setDraftMinTurns('');
-    setDraftMaxTurns('');
-    setDraftLatencyRange(DEFAULT_LATENCY_RANGE);
-  }, []);
-
-  const handleApplyDrafts = useCallback(() => {
-    setLlmModelFilter(draftLlmModel);
-    setSttModelFilter(draftSttModel);
-    setTtsModelFilter(draftTtsModel);
-    setMinTurns(draftMinTurns);
-    setMaxTurns(draftMaxTurns);
-    setLatencyRange(draftLatencyRange);
-    setPage(1);
-    setFilterDrawerOpen(false);
-  }, [
-    draftLlmModel,
-    draftSttModel,
-    draftTtsModel,
-    draftMinTurns,
-    draftMaxTurns,
-    draftLatencyRange,
-  ]);
-
-  useEffect(() => {
-    doFetchAllAgents().catch(handleApiError);
-  }, [doFetchAllAgents]);
-
-  useEffect(() => {
-    // Single failure shouldn't blank all three dropdowns — fall back per column.
-    const safe = (col: string) =>
-      getFilterValues(col)
-        .then((r) => r.values)
-        .catch(() => [] as string[]);
-    Promise.all([safe('llm_model'), safe('stt_model'), safe('tts_model')]).then(
-      ([llm, stt, tts]) => {
-        setLlmModels(llm);
-        setSttModels(stt);
-        setTtsModels(tts);
-      },
-    );
-  }, [activeOrgId]);
-
-  const agentOptions = useMemo<SelectOption[]>(
-    () => [
-      { value: 'all', label: 'All agents' },
-      ...agentList.filter((a) => !!a.uuid).map((a) => ({ value: a.uuid, label: a.name })),
-    ],
-    [agentList],
-  );
-
-  const modelOptions = (label: string, values: string[]): SelectOption[] => [
-    { value: 'all', label },
-    ...values.map((v) => ({ value: v, label: v })),
-  ];
-  const llmModelOptions = useMemo(() => modelOptions('All LLM models', llmModels), [llmModels]);
-  const sttModelOptions = useMemo(() => modelOptions('All STT models', sttModels), [sttModels]);
-  const ttsModelOptions = useMemo(() => modelOptions('All TTS models', ttsModels), [ttsModels]);
-
-  const [selectedCallLog, setSelectedCallLog] = useState<CallLogRow | null>(null);
-  const [transcriptionCallLog, setTranscriptionCallLog] = useState<CallLogRow | null>(null);
-
-  const params = useMemo<CallLogQueryParams>(() => {
-    const q: CallLogQueryParams = {
-      page_no: page,
-      page_size: pageSize,
-    };
-
-    const filters: CallLogFilterParam[] = [];
-    if (agentFilter !== 'all') {
-      filters.push({ field: 'agent_id', operator: 'equal_to', value: agentFilter });
-    }
-    if (statusFilter !== 'all') {
-      filters.push({ field: 'status', operator: 'in', value: [statusFilter] });
-    }
-    if (llmModelFilter !== 'all') {
-      filters.push({ field: 'llm_model', operator: 'equal_to', value: llmModelFilter });
-    }
-    if (sttModelFilter !== 'all') {
-      filters.push({ field: 'stt_model', operator: 'equal_to', value: sttModelFilter });
-    }
-    if (ttsModelFilter !== 'all') {
-      filters.push({ field: 'tts_model', operator: 'equal_to', value: ttsModelFilter });
-    }
-    {
-      const minN = parseInt(minTurns, 10);
-      const maxN = parseInt(maxTurns, 10);
-      const hasMin = Number.isFinite(minN);
-      const hasMax = Number.isFinite(maxN);
-      if (hasMin || hasMax) {
-        // Bounds chosen so BETWEEN behaves as a half-open range when only one
-        // side is provided. NULL turn_count (no metrics row) is excluded by
-        // BETWEEN, which matches the intent "calls with N turns in range".
-        filters.push({
-          field: 'turn_count',
-          operator: 'between',
-          value: [hasMin ? minN : 0, hasMax ? maxN : 999999],
-        });
-      }
-    }
-    if (latencyActive) {
-      // Same NULL-excluding semantics: rows without metrics or with an empty
-      // user_bot_latency array are dropped when this filter is engaged.
-      filters.push({
-        field: 'avg_latency_seconds',
+    const minN = parseInt(filterState.minTurns, 10);
+    const maxN = parseInt(filterState.maxTurns, 10);
+    const hasMin = Number.isFinite(minN);
+    const hasMax = Number.isFinite(maxN);
+    if (hasMin || hasMax) {
+      // NULL turn_count (no metrics row) is excluded by BETWEEN, matching the
+      // intent "calls with N turns in range".
+      out.push({
+        field: 'turn_count',
         operator: 'between',
-        value: [latencyRange[0], latencyRange[1]],
+        value: [hasMin ? minN : 0, hasMax ? maxN : 999999],
       });
     }
-    if (filters.length > 0) {
-      q.filters = filters;
+
+    if (isLatencyActive(filterState.latency)) {
+      out.push({
+        field: 'avg_latency_seconds',
+        operator: 'between',
+        value: [filterState.latency[0], filterState.latency[1]],
+      });
     }
 
-    if (startDateTime) {
-      q.start_date_time = new Date(startDateTime).toISOString();
-    }
-    if (endDateTime) {
-      q.end_date_time = new Date(endDateTime).toISOString();
-    }
+    return out;
+  }, [filterState]);
 
+  // Build the list query: filters + date range (start/end) + pagination + sort.
+  const params = useMemo<CallLogQueryParams>(() => {
+    const q: CallLogQueryParams = { page_no: page, page_size: pageSize };
+    if (filters.length > 0) q.filters = filters;
+    if (filterState.dateRange.start) q.start_date_time = filterState.dateRange.start;
+    if (filterState.dateRange.end) q.end_date_time = filterState.dateRange.end;
     if (sortBy) {
       q.sort_by = sortBy;
       q.sort_order = sortOrder;
     }
-
     return q;
   }, [
     page,
     pageSize,
-    agentFilter,
-    statusFilter,
-    llmModelFilter,
-    sttModelFilter,
-    ttsModelFilter,
-    minTurns,
-    maxTurns,
-    latencyActive,
-    latencyRange,
-    startDateTime,
-    endDateTime,
+    filters,
+    filterState.dateRange.start,
+    filterState.dateRange.end,
     sortBy,
     sortOrder,
   ]);
+
+  // Facet counts use the same filter scope (the backend excludes each facet's
+  // own field) so the toolbar Status/Agent dropdowns and the drawer stay live.
+  // Depends only on date range + filters — not page/sort — so paginating or
+  // sorting doesn't re-issue the facets request.
+  const facetParams = useMemo<CallFacetsParams>(
+    () => ({
+      start_date_time: filterState.dateRange.start ?? undefined,
+      end_date_time: filterState.dateRange.end ?? undefined,
+      filters: filters.length > 0 ? filters : undefined,
+    }),
+    [filterState.dateRange.start, filterState.dateRange.end, filters],
+  );
 
   const refresh = useCallback(async () => {
     try {
@@ -394,15 +280,9 @@ const CallHistory: React.FC = () => {
     refresh();
   }, [refresh]);
 
-  const handleAgentFilter = useCallback((value: string) => {
-    setAgentFilter(value);
-    setPage(1);
-  }, []);
-
-  const handleStatusFilter = useCallback((value: string) => {
-    setStatusFilter(value);
-    setPage(1);
-  }, []);
+  useEffect(() => {
+    doFetchCallFacets(facetParams).catch(handleApiError);
+  }, [facetParams, doFetchCallFacets]);
 
   const handleSortChange = useCallback((sort: CustomTableSortState | null) => {
     if (sort) {
@@ -420,21 +300,55 @@ const CallHistory: React.FC = () => {
     setPageSize(nextPageSize);
   }, []);
 
-  const handleClearDates = useCallback(() => {
-    setStartDateTime('');
-    setEndDateTime('');
+  // The token search reflects the drawer facets (direction/channel/models) as
+  // chips; editing chips writes back to those facet fields (two-way sync), while
+  // leaving the toolbar-only status/agent facets untouched.
+  const searchTokens = useMemo<SearchToken[]>(() => {
+    const out: SearchToken[] = [];
+    for (const s of DRAWER_FACET_SECTIONS) {
+      for (const v of filterState.facets[s.field] ?? []) out.push({ field: s.field, value: v });
+    }
+    return out;
+  }, [filterState.facets]);
+
+  const handleSearchTokensChange = useCallback((next: SearchToken[]) => {
+    setFilterState((prev) => {
+      const facets = { ...prev.facets };
+      // Rebuild only the drawer-owned fields from the token list.
+      for (const s of DRAWER_FACET_SECTIONS) delete facets[s.field];
+      for (const t of next) {
+        if (!DRAWER_FIELD_KEYS.has(t.field)) continue;
+        const current = facets[t.field] ?? [];
+        if (!current.includes(t.value)) facets[t.field] = [...current, t.value];
+      }
+      return { ...prev, facets };
+    });
     setPage(1);
   }, []);
 
-  const hasDates = startDateTime || endDateTime;
+  const handleApplyFilters = useCallback((next: CallFilterState) => {
+    setFilterState(next);
+    setPage(1);
+  }, []);
+
+  const hasActiveFilters = useMemo(
+    () =>
+      !!(filterState.dateRange.start && filterState.dateRange.end) ||
+      Object.values(filterState.facets).some((v) => v?.length) ||
+      filterState.minTurns.trim() !== '' ||
+      filterState.maxTurns.trim() !== '' ||
+      isLatencyActive(filterState.latency),
+    [filterState],
+  );
+
+  const handleClearAll = useCallback(() => {
+    setFilterState((prev) => createEmptyFilterState(prev.dateRange.timeZone));
+    setPage(1);
+  }, []);
 
   // Sticky class applied to the first and last columns so the agent column
   // stays pinned on the left and the quick-view column stays pinned on the
-  // right while the user scrolls the inner columns horizontally. `bg-card`
-  // matches the table surface so scrolling content stays fully masked. The
-  // row-level `hover:bg-muted/50` is translucent (50%), so applying it to
-  // these pinned cells would let scrolled content bleed through — we
-  // intentionally keep the sticky background opaque at all times.
+  // right while the user scrolls the inner columns horizontally.
   const STICKY_LEFT = 'sticky left-0 z-[1] bg-card border-r border-border';
   const STICKY_RIGHT = 'sticky right-0 z-[1] bg-card border-l border-border';
 
@@ -459,8 +373,7 @@ const CallHistory: React.FC = () => {
       render: (value) => {
         const status = (value as string) || 'unknown';
         const classes = STATUS_BADGE_CLASSES[status] ?? 'bg-muted text-muted-foreground';
-        const label = status.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-        return <Badge className={classes}>{label}</Badge>;
+        return <Badge className={classes}>{titleCase(status)}</Badge>;
       },
     },
     {
@@ -598,67 +511,36 @@ const CallHistory: React.FC = () => {
 
   return (
     <div className="animate-page flex h-full flex-col gap-5">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Call History</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          View and filter your voice agent call logs
-        </p>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground">Call History</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            View and filter your voice agent call logs
+          </p>
+        </div>
+        {!data.loading && (
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/40 px-3 py-1 text-[13px] text-muted-foreground">
+            <Phone className="size-3.5" />
+            <span className="font-semibold tabular-nums text-foreground">
+              {data.total.toLocaleString()}
+            </span>
+            {data.total === 1 ? 'call' : 'calls'}
+          </span>
+        )}
       </div>
 
-      <div className="flex flex-wrap items-center gap-3">
-        <SelectInput
-          name="agent-filter"
-          options={agentOptions}
-          value={agentFilter}
-          onValueChange={handleAgentFilter}
-          placeholder="All agents"
-          size="sm"
-          triggerClassName="min-w-[200px]"
-          searchable
-          searchPlaceholder="Search agents..."
+      <div className="flex flex-wrap items-center gap-2">
+        <TokenSearchBar
+          fields={TOKEN_FIELDS}
+          value={searchTokens}
+          onChange={handleSearchTokensChange}
+          onClear={handleClearAll}
+          showClear={hasActiveFilters}
+          placeholder="Filter by field… (e.g. status:completed)"
+          className="min-w-[240px] flex-1"
         />
-        <SelectInput
-          name="status-filter"
-          options={CALL_STATUS_OPTIONS}
-          value={statusFilter}
-          onValueChange={handleStatusFilter}
-          placeholder="All statuses"
-          size="sm"
-          triggerClassName="min-w-[160px]"
-        />
+        <div className="mx-0.5 hidden h-6 w-px shrink-0 bg-border sm:block" />
         <div className="flex items-center gap-2">
-          <div className="relative">
-            <CalendarDays className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-            <input
-              type="datetime-local"
-              value={startDateTime}
-              onChange={(e) => {
-                setStartDateTime(e.target.value);
-                setPage(1);
-              }}
-              className={`h-9 rounded-md border border-input bg-background pl-9 pr-3 text-sm shadow-sm transition-colors placeholder:text-muted-foreground hover:border-ring focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/30 ${startDateTime ? 'text-foreground' : 'text-muted-foreground'}`}
-            />
-          </div>
-          <span className="text-sm text-muted-foreground">to</span>
-          <div className="relative">
-            <CalendarDays className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-            <input
-              type="datetime-local"
-              value={endDateTime}
-              onChange={(e) => {
-                setEndDateTime(e.target.value);
-                setPage(1);
-              }}
-              className={`h-9 rounded-md border border-input bg-background pl-9 pr-3 text-sm shadow-sm transition-colors placeholder:text-muted-foreground hover:border-ring focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/30 ${endDateTime ? 'text-foreground' : 'text-muted-foreground'}`}
-            />
-          </div>
-          {hasDates && (
-            <CustomButton type="text" size="icon-sm" onClick={handleClearDates}>
-              <X className="size-4 text-muted-foreground" />
-            </CustomButton>
-          )}
-        </div>
-        <div className="ml-auto flex items-center gap-2">
           <CustomPopover
             open={columnFilterOpen}
             onOpenChange={setColumnFilterOpen}
@@ -712,8 +594,6 @@ const CallHistory: React.FC = () => {
                       />
                       {group.name}
                     </label>
-                    {/* Tree-line indents the children and visually marks
-                        them as members of the group above. */}
                     <div className="ml-[1.125rem] flex flex-col gap-0.5 border-l border-border pl-5">
                       {group.columns.map(({ key, label }) => (
                         <label
@@ -741,12 +621,17 @@ const CallHistory: React.FC = () => {
             size="sm"
             icon={<SlidersHorizontal className="size-4" />}
             onClick={() => setFilterDrawerOpen(true)}
-            aria-label="Open model filters"
+            aria-label="Open filters"
+            className={
+              drawerFilterCount > 0
+                ? 'border-primary/40 bg-primary/5 text-foreground hover:bg-primary/10'
+                : undefined
+            }
           >
-            Filter
-            {activeModelFilterCount > 0 && (
-              <Badge className="ml-2 bg-primary/15 text-primary hover:bg-primary/15">
-                {activeModelFilterCount}
+            Filters
+            {drawerFilterCount > 0 && (
+              <Badge className="ml-2 bg-primary/15 text-primary tabular-nums hover:bg-primary/15">
+                {drawerFilterCount}
               </Badge>
             )}
           </CustomButton>
@@ -769,148 +654,37 @@ const CallHistory: React.FC = () => {
             onChange: handlePaginationChange,
           }}
           emptyState={
-            <div className="flex flex-col items-center gap-4 py-8">
-              <div className="flex size-12 items-center justify-center rounded-xl bg-muted">
+            <div className="flex flex-col items-center gap-4 py-12">
+              <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-b from-muted to-muted/40 ring-1 ring-border">
                 <Phone className="size-6 text-muted-foreground" />
               </div>
-              <div className="text-center">
+              <div className="max-w-xs text-center">
                 <p className="font-semibold text-foreground">No call logs found</p>
                 <p className="mt-1 text-sm text-muted-foreground">
-                  Call logs will appear here once your agents start handling calls
+                  {hasActiveFilters
+                    ? 'No calls match your current filters. Try adjusting or clearing them.'
+                    : 'Call logs will appear here once your agents start handling calls.'}
                 </p>
               </div>
+              {hasActiveFilters && (
+                <CustomButton type="default" size="sm" onClick={handleClearAll}>
+                  <X className="size-3.5" />
+                  Clear all filters
+                </CustomButton>
+              )}
             </div>
           }
         />
       </div>
 
-      <CustomDrawer
+      <CallHistoryFilterDrawer
         open={filterDrawerOpen}
         onClose={() => setFilterDrawerOpen(false)}
-        title="Pipeline filters"
-        description="Filter calls by the LLM, STT, or TTS model used in the pipeline."
-        side="right"
-        width="w-full sm:max-w-md"
-        footer={
-          <div className="flex items-center justify-between gap-2">
-            <CustomButton
-              type="text"
-              size="sm"
-              onClick={handleResetDrafts}
-              disabled={draftActiveCount === 0}
-            >
-              Reset
-            </CustomButton>
-            <CustomButton type="primary" size="sm" onClick={handleApplyDrafts}>
-              Apply
-            </CustomButton>
-          </div>
-        }
-      >
-        <div className="flex flex-col gap-5 pt-2">
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor="llm-model-filter" className="text-xs font-medium text-muted-foreground">
-              LLM model
-            </label>
-            <SelectInput
-              name="llm-model-filter"
-              options={llmModelOptions}
-              value={draftLlmModel}
-              onValueChange={setDraftLlmModel}
-              placeholder="All LLM models"
-              size="sm"
-              searchable
-              searchPlaceholder="Search LLM models..."
-            />
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor="stt-model-filter" className="text-xs font-medium text-muted-foreground">
-              STT model
-            </label>
-            <SelectInput
-              name="stt-model-filter"
-              options={sttModelOptions}
-              value={draftSttModel}
-              onValueChange={setDraftSttModel}
-              placeholder="All STT models"
-              size="sm"
-              searchable
-              searchPlaceholder="Search STT models..."
-            />
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <label htmlFor="tts-model-filter" className="text-xs font-medium text-muted-foreground">
-              TTS model
-            </label>
-            <SelectInput
-              name="tts-model-filter"
-              options={ttsModelOptions}
-              value={draftTtsModel}
-              onValueChange={setDraftTtsModel}
-              placeholder="All TTS models"
-              size="sm"
-              searchable
-              searchPlaceholder="Search TTS models..."
-            />
-          </div>
-          <div className="flex flex-col gap-1.5">
-            <span className="text-xs font-medium text-muted-foreground">Turns range</span>
-            <div className="flex items-center gap-2">
-              <input
-                id="min-turns-filter"
-                type="number"
-                inputMode="numeric"
-                min={0}
-                value={draftMinTurns}
-                onChange={(e) => setDraftMinTurns(e.target.value)}
-                placeholder="From"
-                aria-label="Minimum turns"
-                className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm transition-colors placeholder:text-muted-foreground hover:border-ring focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/30"
-              />
-              <span className="text-sm text-muted-foreground">to</span>
-              <input
-                id="max-turns-filter"
-                type="number"
-                inputMode="numeric"
-                min={0}
-                value={draftMaxTurns}
-                onChange={(e) => setDraftMaxTurns(e.target.value)}
-                placeholder="To"
-                aria-label="Maximum turns"
-                className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm shadow-sm transition-colors placeholder:text-muted-foreground hover:border-ring focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/30"
-              />
-            </div>
-            <p className="text-[11px] text-muted-foreground">
-              Calls with no metrics record are excluded when this range is set.
-            </p>
-          </div>
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between">
-              <span className="text-xs font-medium text-muted-foreground">Avg latency (s)</span>
-              <span className="text-xs font-medium tabular-nums text-foreground">
-                {draftLatencyRange[0].toFixed(1)}s — {draftLatencyRange[1].toFixed(1)}s
-              </span>
-            </div>
-            <Slider
-              min={MIN_LATENCY_SECONDS}
-              max={MAX_LATENCY_SECONDS}
-              step={LATENCY_STEP}
-              value={draftLatencyRange}
-              onValueChange={(values) => {
-                // Radix Slider sends an array of thumb positions; coerce to a
-                // sorted [min, max] tuple to keep the consumer shape stable.
-                const [a = MIN_LATENCY_SECONDS, b = MAX_LATENCY_SECONDS] = values;
-                setDraftLatencyRange(a <= b ? [a, b] : [b, a]);
-              }}
-              aria-label="Average latency range"
-            />
-            <div className="flex items-center justify-between text-[10px] text-muted-foreground">
-              <span>{MIN_LATENCY_SECONDS}s</span>
-              <span>{MAX_LATENCY_SECONDS}s</span>
-            </div>
-          </div>
-        </div>
-      </CustomDrawer>
+        value={filterState}
+        facets={facetsState.facets}
+        facetsLoading={facetsState.loading}
+        onApply={handleApplyFilters}
+      />
 
       <CallDetailDrawer
         open={!!selectedCallLog}

--- a/frontend/src/components/call-history/filter-drawer/CallHistoryFilterDrawer.tsx
+++ b/frontend/src/components/call-history/filter-drawer/CallHistoryFilterDrawer.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { CustomButton, CustomDrawer, DateRangePicker } from '@/components/shared';
+import { Slider } from '@/components/ui/slider';
+import type { CallFilterState, CallHistoryFilterDrawerProps } from '@/types/callHistoryFilters';
+import React, { useEffect, useState } from 'react';
+
+import {
+  countDrawerFilters,
+  createEmptyFilterState,
+  DRAWER_FACET_SECTIONS,
+  isLatencyActive,
+  LATENCY_STEP,
+  MAX_LATENCY_SECONDS,
+  MIN_LATENCY_SECONDS,
+} from './constants';
+import FacetSection from './FacetSection';
+import FilterSection from './FilterSection';
+
+const CallHistoryFilterDrawer: React.FC<CallHistoryFilterDrawerProps> = ({
+  open,
+  onClose,
+  value,
+  facets,
+  facetsLoading,
+  onApply,
+}) => {
+  const [draft, setDraft] = useState<CallFilterState>(value);
+
+  // Re-seed the draft from the applied value every time the drawer opens.
+  useEffect(() => {
+    if (open) setDraft(value);
+  }, [open, value]);
+
+  const toggleFacet = (field: string, val: string) => {
+    setDraft((prev) => {
+      const current = prev.facets[field] ?? [];
+      const next = current.includes(val) ? current.filter((v) => v !== val) : [...current, val];
+      const facetsNext = { ...prev.facets };
+      if (next.length) facetsNext[field] = next;
+      else delete facetsNext[field];
+      return { ...prev, facets: facetsNext };
+    });
+  };
+
+  // Reset all drawer filters (date, facets, turns, latency).
+  const handleReset = () => setDraft((prev) => createEmptyFilterState(prev.dateRange.timeZone));
+
+  const handleApply = () => {
+    onApply(draft);
+    onClose();
+  };
+
+  const drawerActiveCount = countDrawerFilters(draft);
+
+  return (
+    <CustomDrawer
+      open={open}
+      onClose={onClose}
+      title="Filters"
+      description="Narrow call history by time, status, agent, pipeline and metrics."
+      side="right"
+      width="w-full sm:max-w-[420px]"
+      contentClassName="px-6 pb-6"
+      footer={
+        <div className="flex items-center justify-between gap-2">
+          <CustomButton
+            type="text"
+            size="sm"
+            onClick={handleReset}
+            disabled={drawerActiveCount === 0}
+          >
+            Reset
+          </CustomButton>
+          <CustomButton type="primary" size="sm" onClick={handleApply}>
+            Apply
+          </CustomButton>
+        </div>
+      }
+    >
+      <div className="flex flex-col">
+        <FilterSection
+          title="Timeline"
+          count={draft.dateRange.start && draft.dateRange.end ? 1 : 0}
+          defaultOpen
+        >
+          <DateRangePicker
+            value={draft.dateRange}
+            onChange={(dateRange) => setDraft((p) => ({ ...p, dateRange }))}
+            triggerClassName="w-full"
+          />
+        </FilterSection>
+
+        {DRAWER_FACET_SECTIONS.map((s) => (
+          <FacetSection
+            key={s.field}
+            field={s.field}
+            label={s.label}
+            titleCase={s.titleCase}
+            values={facets[s.field] ?? []}
+            selected={draft.facets[s.field] ?? []}
+            loading={facetsLoading}
+            onToggle={toggleFacet}
+          />
+        ))}
+
+        <FilterSection
+          title="Turns"
+          count={draft.minTurns.trim() !== '' || draft.maxTurns.trim() !== '' ? 1 : 0}
+          defaultOpen={false}
+        >
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              inputMode="numeric"
+              min={0}
+              value={draft.minTurns}
+              onChange={(e) => setDraft((p) => ({ ...p, minTurns: e.target.value }))}
+              placeholder="From"
+              aria-label="Minimum turns"
+              className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm tabular-nums shadow-xs outline-none transition-colors focus:border-ring focus:ring-[3px] focus:ring-ring/30"
+            />
+            <span className="text-sm text-muted-foreground">to</span>
+            <input
+              type="number"
+              inputMode="numeric"
+              min={0}
+              value={draft.maxTurns}
+              onChange={(e) => setDraft((p) => ({ ...p, maxTurns: e.target.value }))}
+              placeholder="To"
+              aria-label="Maximum turns"
+              className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm tabular-nums shadow-xs outline-none transition-colors focus:border-ring focus:ring-[3px] focus:ring-ring/30"
+            />
+          </div>
+          <p className="mt-1.5 text-[11px] text-muted-foreground">
+            Calls with no metrics record are excluded when this range is set.
+          </p>
+        </FilterSection>
+
+        <FilterSection
+          title="Avg latency"
+          count={isLatencyActive(draft.latency) ? 1 : 0}
+          defaultOpen={false}
+        >
+          <div className="flex items-center justify-between pb-2">
+            <span className="text-xs text-muted-foreground">Seconds</span>
+            <span className="text-xs font-medium tabular-nums text-foreground">
+              {draft.latency[0].toFixed(1)}s — {draft.latency[1].toFixed(1)}s
+            </span>
+          </div>
+          <Slider
+            min={MIN_LATENCY_SECONDS}
+            max={MAX_LATENCY_SECONDS}
+            step={LATENCY_STEP}
+            value={draft.latency}
+            onValueChange={(values) => {
+              const [a = MIN_LATENCY_SECONDS, b = MAX_LATENCY_SECONDS] = values;
+              setDraft((p) => ({ ...p, latency: a <= b ? [a, b] : [b, a] }));
+            }}
+            aria-label="Average latency range"
+          />
+          <div className="flex items-center justify-between pt-1 text-[10px] text-muted-foreground">
+            <span>{MIN_LATENCY_SECONDS}s</span>
+            <span>{MAX_LATENCY_SECONDS}s</span>
+          </div>
+        </FilterSection>
+      </div>
+    </CustomDrawer>
+  );
+};
+
+export default CallHistoryFilterDrawer;

--- a/frontend/src/components/call-history/filter-drawer/FacetOptionList.tsx
+++ b/frontend/src/components/call-history/filter-drawer/FacetOptionList.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { Checkbox } from '@/components/ui/checkbox';
+import type { FacetOptionListProps } from '@/types/callHistoryFilters';
+import type { FacetValue } from '@/types/callLog';
+import { cn } from '@/utils/cn';
+import { Search } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+
+import { titleCase } from './constants';
+
+/** Searchable checkbox list of facet values with per-value counts. */
+const FacetOptionList: React.FC<FacetOptionListProps> = ({
+  field,
+  label,
+  titleCase: useTitleCase,
+  values,
+  selected,
+  loading,
+  onToggle,
+}) => {
+  const [query, setQuery] = useState('');
+  const format = (v: string) => (useTitleCase ? titleCase(v) : v);
+
+  const options = useMemo<FacetValue[]>(() => {
+    const present = new Set(values.map((v) => v.value));
+    // Keep selected-but-absent values visible (count 0) so they can be unchecked.
+    const extra = selected.filter((s) => !present.has(s)).map((s) => ({ value: s, count: 0 }));
+    return [...values, ...extra];
+  }, [values, selected]);
+
+  const showSearch = options.length > 8;
+  const filtered = query
+    ? options.filter((o) => format(o.value).toLowerCase().includes(query.toLowerCase()))
+    : options;
+
+  const isLoading = loading && values.length === 0;
+
+  return (
+    <>
+      {showSearch && (
+        <div className="mb-2 flex items-center gap-2 rounded-md border border-input bg-background px-2">
+          <Search className="size-3.5 shrink-0 text-muted-foreground" />
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={`Search ${label.toLowerCase()}…`}
+            aria-label={`Search ${label}`}
+            className="h-7 w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          />
+        </div>
+      )}
+
+      <div className="flex max-h-56 flex-col gap-0.5 overflow-y-auto">
+        {isLoading ? (
+          Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-2.5 px-2 py-1.5">
+              <div className="size-3.5 animate-pulse rounded bg-muted" />
+              <div className="h-3.5 flex-1 animate-pulse rounded bg-muted" />
+            </div>
+          ))
+        ) : filtered.length === 0 ? (
+          <p className="px-2 py-1.5 text-[13px] text-muted-foreground">No values</p>
+        ) : (
+          filtered.map((o) => {
+            const checkboxId = `facet-${field}-${o.value}`;
+            const isSelected = selected.includes(o.value);
+            return (
+              <label
+                key={o.value}
+                htmlFor={checkboxId}
+                className={cn(
+                  'flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 transition-colors hover:bg-muted/50',
+                  isSelected && 'bg-primary/5',
+                )}
+              >
+                <Checkbox
+                  id={checkboxId}
+                  checked={isSelected}
+                  onCheckedChange={() => onToggle(field, o.value)}
+                  className="size-3.5"
+                />
+                <span
+                  className={cn(
+                    'flex-1 truncate text-[13px] text-foreground',
+                    o.count === 0 && !isSelected && 'opacity-50',
+                  )}
+                >
+                  {format(o.value)}
+                </span>
+                <span className="text-xs tabular-nums text-muted-foreground">{o.count}</span>
+              </label>
+            );
+          })
+        )}
+      </div>
+    </>
+  );
+};
+
+export default FacetOptionList;

--- a/frontend/src/components/call-history/filter-drawer/FacetSection.tsx
+++ b/frontend/src/components/call-history/filter-drawer/FacetSection.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import type { FacetSectionProps } from '@/types/callHistoryFilters';
+import React from 'react';
+
+import FacetOptionList from './FacetOptionList';
+import FilterSection from './FilterSection';
+
+/** A faceted checkbox section rendered inside the drawer. */
+const FacetSection: React.FC<FacetSectionProps> = ({
+  field,
+  label,
+  titleCase,
+  values,
+  selected,
+  loading,
+  onToggle,
+}) => (
+  <FilterSection title={label} count={selected.length} defaultOpen={selected.length > 0}>
+    <FacetOptionList
+      field={field}
+      label={label}
+      titleCase={titleCase}
+      values={values}
+      selected={selected}
+      loading={loading}
+      onToggle={onToggle}
+    />
+  </FilterSection>
+);
+
+export default FacetSection;

--- a/frontend/src/components/call-history/filter-drawer/FilterSection.tsx
+++ b/frontend/src/components/call-history/filter-drawer/FilterSection.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { CustomButton } from '@/components/shared';
+import type { FilterSectionProps } from '@/types/callHistoryFilters';
+import { cn } from '@/utils/cn';
+import { ChevronDown } from 'lucide-react';
+import React, { useState } from 'react';
+
+/** Collapsible drawer section with a CustomButton disclosure header. */
+const FilterSection: React.FC<FilterSectionProps> = ({
+  title,
+  count = 0,
+  defaultOpen = true,
+  children,
+}) => {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="border-b border-border last:border-0">
+      <CustomButton
+        type="text"
+        size="sm"
+        fullWidth
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="group h-auto justify-start gap-2 px-0 py-3 hover:bg-transparent"
+      >
+        <ChevronDown
+          className={cn(
+            'size-4 shrink-0 text-muted-foreground transition-[transform,color] group-hover:text-foreground',
+            !open && '-rotate-90',
+          )}
+        />
+        <span className="text-sm font-medium text-foreground">{title}</span>
+        {count > 0 && (
+          <span className="ml-auto rounded-full bg-primary/15 px-1.5 text-[11px] font-medium tabular-nums text-primary">
+            {count}
+          </span>
+        )}
+      </CustomButton>
+      {open && <div className="pb-3">{children}</div>}
+    </div>
+  );
+};
+
+export default FilterSection;

--- a/frontend/src/components/call-history/filter-drawer/constants.ts
+++ b/frontend/src/components/call-history/filter-drawer/constants.ts
@@ -1,0 +1,54 @@
+import type { CallFilterState, FacetSectionConfig } from '@/types/callHistoryFilters';
+
+// Avg-latency slider bounds — shared with the page so "active" detection and
+// the reset baseline stay in one place.
+export const MIN_LATENCY_SECONDS = 0;
+export const MAX_LATENCY_SECONDS = 5;
+export const LATENCY_STEP = 0.1;
+export const DEFAULT_LATENCY_RANGE: [number, number] = [MIN_LATENCY_SECONDS, MAX_LATENCY_SECONDS];
+
+/** Every faceted (checkbox) field, in display order. Used by the token search. */
+export const FACET_SECTIONS: FacetSectionConfig[] = [
+  { field: 'status', label: 'Status', titleCase: true },
+  { field: 'agent_name', label: 'Agent' },
+  { field: 'direction', label: 'Direction', titleCase: true },
+  { field: 'channel_type', label: 'Channel', titleCase: true },
+  { field: 'llm_model', label: 'LLM Model' },
+  { field: 'stt_model', label: 'STT Model' },
+  { field: 'tts_model', label: 'TTS Model' },
+];
+
+// All facets (including Status and Agent) live inside the drawer; the toolbar
+// only keeps the token search + Columns + Filters.
+export const DRAWER_FACET_SECTIONS = FACET_SECTIONS;
+export const DRAWER_FIELD_KEYS = new Set(DRAWER_FACET_SECTIONS.map((s) => s.field));
+
+export const titleCase = (v: string) =>
+  v.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+
+export const isLatencyActive = (r: [number, number]) =>
+  r[0] > MIN_LATENCY_SECONDS || r[1] < MAX_LATENCY_SECONDS;
+
+export const createEmptyFilterState = (timeZone: string): CallFilterState => ({
+  dateRange: { start: null, end: null, timeZone },
+  facets: {},
+  minTurns: '',
+  maxTurns: '',
+  latency: DEFAULT_LATENCY_RANGE,
+});
+
+/** Active filters managed inside the drawer (date + all facets + turns + latency). */
+export function countDrawerFilters(state: CallFilterState): number {
+  const facetCount = DRAWER_FACET_SECTIONS.reduce(
+    (n, s) => n + ((state.facets[s.field]?.length ?? 0) > 0 ? 1 : 0),
+    0,
+  );
+  const turnsActive = state.minTurns.trim() !== '' || state.maxTurns.trim() !== '';
+  const dateActive = !!(state.dateRange.start && state.dateRange.end);
+  return (
+    facetCount +
+    (turnsActive ? 1 : 0) +
+    (isLatencyActive(state.latency) ? 1 : 0) +
+    (dateActive ? 1 : 0)
+  );
+}

--- a/frontend/src/components/call-history/filter-drawer/index.ts
+++ b/frontend/src/components/call-history/filter-drawer/index.ts
@@ -1,0 +1,24 @@
+export { default } from './CallHistoryFilterDrawer';
+export { default as FacetSection } from './FacetSection';
+export { default as FacetOptionList } from './FacetOptionList';
+export { default as FilterSection } from './FilterSection';
+export {
+  countDrawerFilters,
+  createEmptyFilterState,
+  DEFAULT_LATENCY_RANGE,
+  DRAWER_FACET_SECTIONS,
+  DRAWER_FIELD_KEYS,
+  FACET_SECTIONS,
+  isLatencyActive,
+  MAX_LATENCY_SECONDS,
+  MIN_LATENCY_SECONDS,
+  titleCase,
+} from './constants';
+export type {
+  CallFilterState,
+  CallHistoryFilterDrawerProps,
+  FacetOptionListProps,
+  FacetSectionConfig,
+  FacetSectionProps,
+  FilterSectionProps,
+} from '@/types/callHistoryFilters';

--- a/frontend/src/components/shared/CustomPopover.tsx
+++ b/frontend/src/components/shared/CustomPopover.tsx
@@ -22,8 +22,9 @@ const CustomPopover: React.FC<CustomPopoverProps> = ({
   className,
   contentClassName,
   contentProps,
+  modal,
 }) => (
-  <Popover open={open} onOpenChange={onOpenChange}>
+  <Popover open={open} onOpenChange={onOpenChange} modal={modal}>
     <PopoverTrigger asChild>{trigger}</PopoverTrigger>
     <PopoverContent
       align={align}

--- a/frontend/src/components/shared/DateRangePicker.tsx
+++ b/frontend/src/components/shared/DateRangePicker.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+import { TZDate } from '@date-fns/tz';
+import { CalendarDays, ChevronDown, Clock } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from 'react';
+import type { DateRange } from 'react-day-picker';
+
+import CustomButton from '@/components/shared/CustomButton';
+import CustomPopover from '@/components/shared/CustomPopover';
+import SearchableSelect, {
+  type SearchableSelectOption,
+} from '@/components/shared/SearchableSelect';
+import { Calendar } from '@/components/ui/calendar';
+import type { DateRangePickerProps } from '@/types/components';
+import { cn } from '@/utils/cn';
+import { formatTzDateTime, getBrowserTimeZone } from '@/utils/date';
+
+export type { DateRangePickerProps, DateRangeValue } from '@/types/components';
+
+const BROWSER_TZ = getBrowserTimeZone();
+
+const PRESETS: Array<{ key: string; label: string; title: string; ms: number }> = [
+  { key: '15m', label: '15m', title: 'Last 15 minutes', ms: 15 * 60_000 },
+  { key: '30m', label: '30m', title: 'Last 30 minutes', ms: 30 * 60_000 },
+  { key: '1h', label: '1h', title: 'Last 1 hour', ms: 60 * 60_000 },
+  { key: '24h', label: '24h', title: 'Last 24 hours', ms: 24 * 60 * 60_000 },
+  { key: '7d', label: '7d', title: 'Last 7 days', ms: 7 * 24 * 60 * 60_000 },
+];
+
+const pad = (n: number) => String(n).padStart(2, '0');
+
+/** `Jun 5, 2026` for the Start/End summary rows. */
+function formatDayLabel(day?: Date): string {
+  if (!day) return 'Select a day';
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(day);
+}
+
+/**
+ * Combine a calendar day + `HH:mm` time, interpreted in `tz`, into a `Z`-normalized
+ * UTC ISO instant (e.g. `2026-06-05T11:14:00.000Z`) — the form the backend's
+ * `started_at` comparison expects.
+ */
+function combineToIso(day: Date, time: string, tz: string): string {
+  const [h, m] = time.split(':').map((s) => parseInt(s, 10));
+  const tzDate = TZDate.tz(
+    tz,
+    day.getFullYear(),
+    day.getMonth(),
+    day.getDate(),
+    Number.isFinite(h) ? h : 0,
+    Number.isFinite(m) ? m : 0,
+  );
+  return new Date(tzDate.getTime()).toISOString();
+}
+
+/** Split a UTC ISO instant into its wall-clock day + `HH:mm` time within `tz`. */
+function splitFromIso(iso: string, tz: string): { day: Date; time: string } {
+  const d = new TZDate(new Date(iso), tz);
+  return {
+    day: new Date(d.getFullYear(), d.getMonth(), d.getDate()),
+    time: `${pad(d.getHours())}:${pad(d.getMinutes())}`,
+  };
+}
+
+function getTimeZones(): string[] {
+  try {
+    const supported = (Intl as unknown as { supportedValuesOf?: (k: string) => string[] })
+      .supportedValuesOf;
+    if (typeof supported === 'function') return supported('timeZone');
+  } catch {
+    /* older runtimes — fall through */
+  }
+  return ['UTC', BROWSER_TZ];
+}
+
+/**
+ * Shared, timezone-aware date-range picker (calendar + start/end date & time +
+ * relative presets + IANA timezone). Emits `{ start, end, timeZone }` where
+ * start/end are UTC ISO instants. Drafts live inside the popover until Apply.
+ */
+const DateRangePicker: React.FC<DateRangePickerProps> = ({
+  value,
+  onChange,
+  placeholder = 'Select date range',
+  presets = true,
+  align = 'start',
+  className,
+  triggerClassName,
+  disabled,
+}) => {
+  const [open, setOpen] = useState(false);
+  const [range, setRange] = useState<DateRange | undefined>(undefined);
+  const [startTime, setStartTime] = useState('00:00');
+  const [endTime, setEndTime] = useState('23:59');
+  const [timeZone, setTimeZone] = useState(value?.timeZone || BROWSER_TZ);
+  const [activePreset, setActivePreset] = useState<string | null>(null);
+
+  // Seed the draft from the applied value every time the popover opens.
+  useEffect(() => {
+    if (!open) return;
+    const tz = value?.timeZone || BROWSER_TZ;
+    setTimeZone(tz);
+    setActivePreset(null);
+    if (value?.start && value?.end) {
+      const s = splitFromIso(value.start, tz);
+      const e = splitFromIso(value.end, tz);
+      setRange({ from: s.day, to: e.day });
+      setStartTime(s.time);
+      setEndTime(e.time);
+    } else {
+      setRange(undefined);
+      setStartTime('00:00');
+      setEndTime('23:59');
+    }
+  }, [open, value?.start, value?.end, value?.timeZone]);
+
+  const tzOptions = useMemo<SearchableSelectOption[]>(() => {
+    const zones = getTimeZones();
+    if (!zones.includes(BROWSER_TZ)) zones.unshift(BROWSER_TZ);
+    return zones.map((z) => ({ value: z, label: z.replace(/_/g, ' ') }));
+  }, []);
+
+  // Manual edits to the calendar/time clear the highlighted preset.
+  const handleSelectRange = (next: DateRange | undefined) => {
+    setRange(next);
+    setActivePreset(null);
+  };
+
+  const applyPreset = (key: string, ms: number) => {
+    const now = new Date();
+    const from = new Date(now.getTime() - ms);
+    const s = splitFromIso(from.toISOString(), timeZone);
+    const e = splitFromIso(now.toISOString(), timeZone);
+    setRange({ from: s.day, to: e.day });
+    setStartTime(s.time);
+    setEndTime(e.time);
+    setActivePreset(key);
+  };
+
+  const handleApply = () => {
+    if (!range?.from) {
+      onChange?.({ start: null, end: null, timeZone });
+      setOpen(false);
+      return;
+    }
+    const to = range.to ?? range.from;
+    onChange?.({
+      start: combineToIso(range.from, startTime, timeZone),
+      end: combineToIso(to, endTime, timeZone),
+      timeZone,
+    });
+    setOpen(false);
+  };
+
+  const handleClear = () => {
+    setRange(undefined);
+    onChange?.({ start: null, end: null, timeZone });
+    setOpen(false);
+  };
+
+  const hasValue = !!(value?.start && value?.end);
+  const triggerLabel = hasValue
+    ? `${formatTzDateTime(value!.start!, value!.timeZone)} – ${formatTzDateTime(
+        value!.end!,
+        value!.timeZone,
+      )}`
+    : placeholder;
+
+  return (
+    <CustomPopover
+      open={open}
+      onOpenChange={setOpen}
+      modal
+      align={align}
+      width="w-[360px]"
+      className={cn(
+        'flex max-h-[min(85vh,var(--radix-popover-content-available-height))] flex-col overflow-hidden',
+        className,
+      )}
+      contentClassName="min-h-0 max-h-none flex-1 space-y-2.5 px-2 py-2.5"
+      trigger={
+        <CustomButton
+          type="default"
+          size="sm"
+          disabled={disabled}
+          aria-label="Select date range"
+          className={cn(
+            'justify-start gap-2 font-normal',
+            hasValue
+              ? 'border-solid border-primary/40 bg-primary/5 text-foreground hover:bg-primary/10'
+              : 'border-dashed text-muted-foreground',
+            triggerClassName,
+          )}
+        >
+          <CalendarDays
+            className={cn('size-4 shrink-0', hasValue ? 'text-primary' : 'text-muted-foreground')}
+          />
+          <span className="truncate">{triggerLabel}</span>
+          <ChevronDown className="ml-auto size-4 shrink-0 opacity-60" />
+        </CustomButton>
+      }
+      footer={
+        <>
+          <CustomButton type="text" size="sm" onClick={handleClear} disabled={!range?.from}>
+            Clear
+          </CustomButton>
+          <CustomButton type="primary" size="sm" onClick={handleApply}>
+            Apply
+          </CustomButton>
+        </>
+      }
+    >
+      {presets && (
+        <div className="flex flex-wrap gap-1.5 border-b border-border pb-2.5">
+          {PRESETS.map((p) => (
+            <CustomButton
+              key={p.key}
+              type="default"
+              size="xs"
+              title={p.title}
+              onClick={() => applyPreset(p.key, p.ms)}
+              className={cn(
+                'rounded-full px-2.5 font-medium transition-colors',
+                activePreset === p.key
+                  ? 'border-primary/40 bg-primary/10 text-primary hover:bg-primary/15'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {p.label}
+            </CustomButton>
+          ))}
+        </div>
+      )}
+
+      <div className="flex justify-center">
+        <Calendar
+          mode="range"
+          selected={range}
+          onSelect={handleSelectRange}
+          numberOfMonths={1}
+          defaultMonth={range?.from}
+        />
+      </div>
+
+      <div className="divide-y divide-border overflow-hidden rounded-lg border border-border">
+        {(['start', 'end'] as const).map((which) => {
+          const day = which === 'start' ? range?.from : (range?.to ?? range?.from);
+          const time = which === 'start' ? startTime : endTime;
+          const setTime = which === 'start' ? setStartTime : setEndTime;
+          return (
+            <div key={which} className="flex items-center gap-2 px-2.5 py-2">
+              <span className="w-10 shrink-0 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                {which}
+              </span>
+              <div className="flex min-w-0 flex-1 items-center gap-1.5 text-sm">
+                <CalendarDays className="size-3.5 shrink-0 text-muted-foreground" />
+                <span className={cn('truncate tabular-nums', !day && 'text-muted-foreground')}>
+                  {formatDayLabel(day)}
+                </span>
+              </div>
+              <div className="flex shrink-0 items-center gap-1.5 rounded-md border border-input bg-background pl-2 transition-colors focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/30">
+                <Clock className="size-3.5 shrink-0 text-muted-foreground" />
+                <input
+                  type="time"
+                  value={time}
+                  onChange={(e) => {
+                    setTime(e.target.value);
+                    setActivePreset(null);
+                  }}
+                  aria-label={`${which} time`}
+                  className="h-8 w-[104px] bg-transparent pr-2 text-sm tabular-nums outline-none"
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center justify-between gap-3">
+        <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Timezone
+        </span>
+        <div className="min-w-0 flex-1">
+          <SearchableSelect
+            name="drp-timezone"
+            options={tzOptions}
+            value={timeZone}
+            onValueChange={setTimeZone}
+            searchPlaceholder="Search timezone..."
+          />
+        </div>
+      </div>
+    </CustomPopover>
+  );
+};
+
+export default React.memo(DateRangePicker);

--- a/frontend/src/components/shared/TokenSearchBar.tsx
+++ b/frontend/src/components/shared/TokenSearchBar.tsx
@@ -1,0 +1,332 @@
+'use client';
+
+import { Search, X } from 'lucide-react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import type { TokenSearchBarProps, TokenSearchField } from '@/types/components';
+import { cn } from '@/utils/cn';
+
+export type { SearchToken, TokenSearchBarProps, TokenSearchField } from '@/types/components';
+
+interface Suggestion {
+  kind: 'field' | 'value' | 'hint';
+  key: string;
+  label: string;
+}
+
+/**
+ * Tokenized `field:value` search bar with autocomplete chips (Vercel-style).
+ * Typing shows the field list; picking a field fetches its values (for `enum`
+ * fields) and shows a value list; confirmed filters render as removable chips.
+ * Emits a normalized `SearchToken[]`.
+ */
+const TokenSearchBar: React.FC<TokenSearchBarProps> = ({
+  fields,
+  value,
+  onChange,
+  placeholder = 'Filter by field… (e.g. status:completed)',
+  className,
+  hideChips = false,
+  onClear,
+  showClear,
+}) => {
+  const [query, setQuery] = useState('');
+  const [activeField, setActiveField] = useState<TokenSearchField | null>(null);
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(0);
+  const [valuesCache, setValuesCache] = useState<Record<string, string[]>>({});
+  const [loadingValues, setLoadingValues] = useState(false);
+  const [liveMsg, setLiveMsg] = useState('');
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const fieldByKey = useMemo(() => new Map(fields.map((f) => [f.key, f])), [fields]);
+
+  // Close the dropdown when clicking outside the component.
+  useEffect(() => {
+    const onDoc = (e: MouseEvent) => {
+      const target = e.target as Node;
+      // A node already detached by a re-render (e.g. an option we just replaced)
+      // is not a genuine outside click — ignore it so the panel stays open.
+      if (!document.contains(target)) return;
+      if (containerRef.current && !containerRef.current.contains(target)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, []);
+
+  // Lazily load + cache distinct values for the active enum field.
+  useEffect(() => {
+    if (!activeField || activeField.type === 'text' || !activeField.fetchValues) return;
+    if (valuesCache[activeField.key]) return;
+    let cancelled = false;
+    setLoadingValues(true);
+    activeField
+      .fetchValues()
+      .then((vals) => {
+        if (!cancelled) setValuesCache((p) => ({ ...p, [activeField.key]: vals }));
+      })
+      .catch(() => {
+        if (!cancelled) setValuesCache((p) => ({ ...p, [activeField.key]: [] }));
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingValues(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeField, valuesCache]);
+
+  // Typing "status:" auto-activates that field (matches the chip syntax).
+  useEffect(() => {
+    if (activeField) return;
+    const m = query.match(/^([a-zA-Z_]+):$/);
+    if (m) {
+      const f = fieldByKey.get(m[1].toLowerCase());
+      if (f) {
+        setActiveField(f);
+        setQuery('');
+      }
+    }
+  }, [query, activeField, fieldByKey]);
+
+  const suggestions = useMemo<Suggestion[]>(() => {
+    const q = query.trim().toLowerCase();
+    if (!activeField) {
+      return fields
+        .filter((f) => f.label.toLowerCase().includes(q) || f.key.toLowerCase().includes(q))
+        .map((f) => ({ kind: 'field', key: f.key, label: f.label }));
+    }
+    if (activeField.type === 'text') {
+      return q ? [{ kind: 'hint', key: query.trim(), label: query.trim() }] : [];
+    }
+    const all = valuesCache[activeField.key] ?? [];
+    const taken = new Set(value.filter((t) => t.field === activeField.key).map((t) => t.value));
+    return all
+      .filter((v) => !taken.has(v) && v.toLowerCase().includes(q))
+      .map((v) => ({
+        kind: 'value',
+        key: v,
+        label: activeField.formatValue ? activeField.formatValue(v) : v,
+      }));
+  }, [activeField, query, fields, valuesCache, value]);
+
+  // Reset the highlight whenever the visible list changes.
+  useEffect(() => setHighlight(0), [activeField, query, open]);
+
+  const isLoadingActiveValues =
+    !!activeField && activeField.type !== 'text' && loadingValues && !valuesCache[activeField.key];
+
+  const addToken = useCallback(
+    (field: string, raw: string) => {
+      const val = raw.trim();
+      if (!val) return;
+      if (!value.some((t) => t.field === field && t.value === val)) {
+        onChange([...value, { field, value: val }]);
+        setLiveMsg(`Added filter ${field} ${val}`);
+      }
+      setActiveField(null);
+      setQuery('');
+      // Keep the panel open (showing the field list) so the user can chain
+      // filters; don't rely on a focus event, which won't fire if the input
+      // never lost focus during the controlled re-render.
+      setOpen(true);
+      inputRef.current?.focus();
+    },
+    [value, onChange],
+  );
+
+  const removeToken = useCallback(
+    (index: number) => {
+      const removed = value[index];
+      onChange(value.filter((_, i) => i !== index));
+      if (removed) setLiveMsg(`Removed filter ${removed.field} ${removed.value}`);
+    },
+    [value, onChange],
+  );
+
+  const selectSuggestion = useCallback(
+    (s: Suggestion) => {
+      if (s.kind === 'field') {
+        const f = fieldByKey.get(s.key);
+        if (f) {
+          setActiveField(f);
+          setQuery('');
+          // Force the panel open for the value list — focus() alone won't
+          // re-open it when the input is already focused.
+          setOpen(true);
+          inputRef.current?.focus();
+        }
+      } else if (activeField) {
+        addToken(activeField.key, s.key);
+      }
+    },
+    [activeField, addToken, fieldByKey],
+  );
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setOpen(true);
+      setHighlight((h) => Math.min(h + 1, suggestions.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlight((h) => Math.max(h - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const s = suggestions[highlight];
+      if (s) selectSuggestion(s);
+      else if (activeField && activeField.type === 'text' && query.trim())
+        addToken(activeField.key, query);
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+    } else if (e.key === 'Backspace' && query === '') {
+      if (activeField) setActiveField(null);
+      else if (value.length) removeToken(value.length - 1);
+    }
+  };
+
+  const showDropdown =
+    open &&
+    (isLoadingActiveValues ||
+      suggestions.length > 0 ||
+      (!!activeField && activeField.type !== 'text'));
+
+  const showClearButton = !!onClear && (showClear ?? value.length > 0);
+
+  return (
+    <div ref={containerRef} className={cn('relative', className)}>
+      <div
+        className="flex min-h-9 w-full flex-wrap items-center gap-1.5 rounded-md border border-input bg-background px-2 py-1 shadow-xs transition-colors focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/30"
+        onClick={() => inputRef.current?.focus()}
+      >
+        <Search className="size-4 shrink-0 text-muted-foreground" />
+
+        {!hideChips &&
+          value.map((t, i) => {
+            const f = fieldByKey.get(t.field);
+            const fieldLabel = f?.label ?? t.field;
+            const valueLabel = f?.formatValue ? f.formatValue(t.value) : t.value;
+            return (
+              <span
+                key={`${t.field}-${t.value}-${i}`}
+                className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/50 py-1 pl-2.5 pr-1 text-xs"
+              >
+                <span className="text-muted-foreground">{fieldLabel}</span>
+                <span className="max-w-[160px] truncate font-medium text-foreground">
+                  {valueLabel}
+                </span>
+                <button
+                  type="button"
+                  aria-label={`Remove ${fieldLabel} ${valueLabel}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    removeToken(i);
+                  }}
+                  className="inline-flex size-4 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
+                >
+                  <X className="size-3" />
+                </button>
+              </span>
+            );
+          })}
+
+        {activeField && (
+          <span className="inline-flex items-center rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
+            {activeField.label}
+          </span>
+        )}
+
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={handleKeyDown}
+          role="combobox"
+          aria-expanded={showDropdown}
+          aria-controls="token-search-listbox"
+          aria-autocomplete="list"
+          aria-label="Filter call history"
+          placeholder={
+            value.length === 0 && !activeField ? placeholder : activeField ? 'Value…' : ''
+          }
+          className="h-7 min-w-[140px] flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+        />
+
+        {showClearButton && (
+          <button
+            type="button"
+            aria-label="Clear all filters"
+            title="Clear all filters"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={(e) => {
+              e.stopPropagation();
+              setActiveField(null);
+              setQuery('');
+              setOpen(false);
+              onClear?.();
+            }}
+            className="ml-auto inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <X className="size-4" />
+          </button>
+        )}
+      </div>
+
+      {showDropdown && (
+        <div className="absolute z-50 mt-1 w-full overflow-hidden rounded-md border border-border bg-popover shadow-md">
+          <div className="border-b border-border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            {activeField ? `${activeField.label} value` : 'Filters'}
+          </div>
+          <div id="token-search-listbox" role="listbox" className="max-h-60 overflow-y-auto p-1">
+            {isLoadingActiveValues ? (
+              <div className="px-2 py-2 text-sm text-muted-foreground">Loading…</div>
+            ) : suggestions.length === 0 ? (
+              <div className="px-2 py-2 text-sm text-muted-foreground">No matches</div>
+            ) : (
+              suggestions.map((s, i) => (
+                <div
+                  key={`${s.kind}-${s.key}`}
+                  role="option"
+                  aria-selected={i === highlight}
+                  onMouseEnter={() => setHighlight(i)}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    selectSuggestion(s);
+                  }}
+                  className={cn(
+                    'flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground',
+                    i === highlight && 'bg-accent',
+                  )}
+                >
+                  {s.kind === 'field' && (
+                    <span className="font-mono text-xs text-muted-foreground">{s.key}:</span>
+                  )}
+                  {s.kind === 'hint' ? (
+                    <span className="text-muted-foreground">
+                      Add{' '}
+                      <span className="font-mono text-foreground">{`${activeField?.key}:${s.label}`}</span>
+                    </span>
+                  ) : (
+                    <span className="truncate">{s.label}</span>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+
+      <span className="sr-only" aria-live="polite">
+        {liveMsg}
+      </span>
+    </div>
+  );
+};
+
+export default React.memo(TokenSearchBar);

--- a/frontend/src/components/shared/index.tsx
+++ b/frontend/src/components/shared/index.tsx
@@ -10,6 +10,7 @@ import CustomPopover from './CustomPopover';
 import CustomTab from './CustomTab';
 import CustomTable from './CustomTable';
 import CustomTooltip from './CustomTooltip';
+import DateRangePicker from './DateRangePicker';
 import Divider from './Divider';
 import ErrorBoundary from './ErrorBoundary';
 import Form from './Form';
@@ -25,6 +26,7 @@ import SliderField from './SliderField';
 import TextAreaField from './TextAreaField';
 import TextInput from './TextInput';
 import { ThemeToggle } from './ThemeToggle';
+import TokenSearchBar from './TokenSearchBar';
 
 export type {
   CheckboxFieldBaseProps,
@@ -34,6 +36,8 @@ export type {
   CustomTableColumn,
   CustomTablePagination,
   CustomTableProps,
+  DateRangePickerProps,
+  DateRangeValue,
   FormCheckboxFieldProps,
   FormMultiSelectFieldProps,
   FormRadioGroupFieldProps,
@@ -44,11 +48,14 @@ export type {
   MultiSelectFieldBaseProps,
   MultiSelectOption,
   RadioGroupOption,
+  SearchToken,
   SelectInputBaseProps,
   SelectOption,
   SliderFieldBaseProps,
   TextAreaFieldBaseProps,
   TextInputBaseProps,
+  TokenSearchBarProps,
+  TokenSearchField,
 } from '@/types/components';
 export type { CustomCardProps } from './CustomCard';
 export type { SearchableSelectOption } from './SearchableSelect';
@@ -68,6 +75,7 @@ export {
   CustomTab,
   CustomTable,
   CustomTooltip,
+  DateRangePicker,
   Divider,
   ErrorBoundary,
   Form,
@@ -83,4 +91,5 @@ export {
   TextAreaField,
   TextInput,
   ThemeToggle,
+  TokenSearchBar,
 };

--- a/frontend/src/components/ui/calendar.tsx
+++ b/frontend/src/components/ui/calendar.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import * as React from 'react';
+import { DayPicker } from 'react-day-picker';
+
+import { cn } from '@/utils/cn';
+
+export type CalendarProps = React.ComponentProps<typeof DayPicker>;
+
+/**
+ * Thin shadcn-style wrapper around react-day-picker v9, themed with the
+ * project's design tokens (no external stylesheet — every class is supplied
+ * via `classNames` so light/dark parity comes from CSS variables).
+ *
+ * Range styling: `range_start`/`range_end` paint the inner day button primary,
+ * `range_middle` tints the cell with `accent`. `selected` intentionally adds no
+ * button colour so it never fights the range modifiers on the same cell.
+ */
+function Calendar({ className, classNames, showOutsideDays = true, ...props }: CalendarProps) {
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn('p-0', className)}
+      classNames={{
+        months: 'flex flex-col gap-4',
+        month: 'flex flex-col gap-3',
+        month_caption: 'relative flex h-8 items-center pt-1',
+        caption_label: 'text-sm font-semibold text-foreground',
+        nav: 'absolute right-0 top-0 flex items-center gap-1',
+        button_previous:
+          'inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-40',
+        button_next:
+          'inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-40',
+        month_grid: 'border-collapse',
+        weekdays: 'flex',
+        weekday: 'w-11 text-[0.68rem] font-medium uppercase tracking-wide text-muted-foreground/70',
+        week: 'mt-1 flex',
+        // Cell width must match the weekday width (w-11) so the header and dates
+        // stay column-aligned; the day button is centered inside the cell.
+        day: 'relative flex w-11 items-center justify-center p-0 text-center text-sm focus-within:relative focus-within:z-20',
+        day_button:
+          'inline-flex size-10 cursor-pointer items-center justify-center rounded-full p-0 font-normal tabular-nums text-foreground transition-colors hover:bg-accent hover:text-foreground',
+        // Continuous brand band: endpoints are solid-primary circles, the days
+        // between get a soft primary tint with rounded outer ends.
+        range_start:
+          'rounded-l-full bg-primary/10 [&>button]:bg-primary [&>button]:text-primary-foreground [&>button]:shadow-sm [&>button]:hover:bg-primary',
+        range_end:
+          'rounded-r-full bg-primary/10 [&>button]:bg-primary [&>button]:text-primary-foreground [&>button]:shadow-sm [&>button]:hover:bg-primary',
+        range_middle:
+          'bg-primary/10 [&>button]:bg-transparent [&>button]:text-foreground [&>button]:hover:bg-primary/20',
+        today:
+          '[&>button]:font-semibold [&>button]:ring-1 [&>button]:ring-inset [&>button]:ring-ring/50',
+        outside: 'text-muted-foreground/40',
+        disabled: 'text-muted-foreground opacity-40',
+        hidden: 'invisible',
+        ...classNames,
+      }}
+      components={{
+        Chevron: ({ orientation, className: chevronClass, ...chevronProps }) =>
+          orientation === 'left' ? (
+            <ChevronLeft className={cn('size-4', chevronClass)} {...chevronProps} />
+          ) : (
+            <ChevronRight className={cn('size-4', chevronClass)} {...chevronProps} />
+          ),
+      }}
+      {...props}
+    />
+  );
+}
+
+Calendar.displayName = 'Calendar';
+
+export { Calendar };

--- a/frontend/src/services/callLogService.ts
+++ b/frontend/src/services/callLogService.ts
@@ -1,8 +1,13 @@
-import type { CallLogQueryParams, CallLogRow } from '@/types/callLog';
+import type { CallFacets, CallFacetsParams, CallLogQueryParams, CallLogRow } from '@/types/callLog';
 import axiosInstance from '@/utils/axios';
 
 export const getCallLogs = async (params: CallLogQueryParams) => {
   const res = await axiosInstance.post('/call-log/list', params);
+  return res.data;
+};
+
+export const getCallFacets = async (params: CallFacetsParams): Promise<CallFacets> => {
+  const res = await axiosInstance.post('/call-log/facets', params);
   return res.data;
 };
 

--- a/frontend/src/types/callHistoryFilters.ts
+++ b/frontend/src/types/callHistoryFilters.ts
@@ -1,0 +1,62 @@
+import type { ReactNode } from 'react';
+
+import type { CallFacets, FacetValue } from '@/types/callLog';
+import type { DateRangeValue } from '@/types/components';
+
+/** Config for one faceted (checkbox) filter field. */
+export interface FacetSectionConfig {
+  field: string;
+  label: string;
+  /** Title-case the values for display (e.g. `in_progress` → `In Progress`). */
+  titleCase?: boolean;
+}
+
+/** The full applied/draft filter state for the Call History page. */
+export interface CallFilterState {
+  dateRange: DateRangeValue;
+  /** facet field → selected values */
+  facets: Record<string, string[]>;
+  minTurns: string;
+  maxTurns: string;
+  latency: [number, number];
+}
+
+/** Shared checkbox-list of facet values (with counts + search), used by the
+ * drawer sections and the toolbar quick-filter dropdowns. */
+export interface FacetOptionListProps {
+  field: string;
+  label: string;
+  titleCase?: boolean;
+  values: FacetValue[];
+  selected: string[];
+  loading: boolean;
+  onToggle: (field: string, value: string) => void;
+}
+
+/** Collapsible section inside the filter drawer. */
+export interface FilterSectionProps {
+  title: string;
+  count?: number;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}
+
+/** A faceted checkbox section inside the drawer (FilterSection + FacetOptionList). */
+export interface FacetSectionProps {
+  field: string;
+  label: string;
+  titleCase?: boolean;
+  values: FacetValue[];
+  selected: string[];
+  loading: boolean;
+  onToggle: (field: string, value: string) => void;
+}
+
+export interface CallHistoryFilterDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  value: CallFilterState;
+  facets: CallFacets;
+  facetsLoading: boolean;
+  onApply: (next: CallFilterState) => void;
+}

--- a/frontend/src/types/callLog.ts
+++ b/frontend/src/types/callLog.ts
@@ -91,3 +91,23 @@ export interface CallLogQueryParams {
   sort_order?: 'asc' | 'desc';
   filters?: CallLogFilterParam[];
 }
+
+/** A single faceted value + its count, from `POST /call-log/facets`. */
+export interface FacetValue {
+  value: string;
+  count: number;
+}
+
+/** Map of facet field → its values with counts (e.g. `{ status: [{value, count}] }`). */
+export type CallFacets = Record<string, FacetValue[]>;
+
+export interface CallFacetsParams {
+  start_date_time?: string;
+  end_date_time?: string;
+  filters?: CallLogFilterParam[];
+}
+
+export interface CallFacetsState {
+  facets: CallFacets;
+  loading: boolean;
+}

--- a/frontend/src/types/components.ts
+++ b/frontend/src/types/components.ts
@@ -283,9 +283,70 @@ export interface CustomDrawerProps {
   showCloseButton?: boolean;
 }
 
+/**
+ * Emitted value of the shared {@link DateRangePicker}. `start`/`end` are UTC ISO
+ * instants (or null when cleared); `timeZone` is the IANA zone the user picked
+ * the wall-clock time in (defaults to the browser zone).
+ */
+export interface DateRangeValue {
+  start: string | null;
+  end: string | null;
+  timeZone: string;
+}
+
+export interface DateRangePickerProps {
+  value?: DateRangeValue;
+  onChange?: (value: DateRangeValue) => void;
+  placeholder?: string;
+  /** Show the relative-range preset rail (Last 15m / 30m / 1h / 24h / 7d). */
+  presets?: boolean;
+  align?: 'start' | 'center' | 'end';
+  className?: string;
+  triggerClassName?: string;
+  disabled?: boolean;
+}
+
+/** A single `field:value` token in the {@link TokenSearchBar}. */
+export interface SearchToken {
+  field: string;
+  value: string;
+}
+
+/** Field definition consumed by {@link TokenSearchBar}. */
+export interface TokenSearchField {
+  key: string;
+  label: string;
+  /** `enum` fields autocomplete from `fetchValues`; `text` fields accept free input. */
+  type?: 'enum' | 'text';
+  /** Lazily fetch distinct values for an `enum` field (cached after first load). */
+  fetchValues?: () => Promise<string[]>;
+  /** Map a stored value to its display label (defaults to the raw value). */
+  formatValue?: (value: string) => string;
+}
+
+export interface TokenSearchBarProps {
+  fields: TokenSearchField[];
+  value: SearchToken[];
+  onChange: (tokens: SearchToken[]) => void;
+  placeholder?: string;
+  className?: string;
+  /** Hide the inline chips (e.g. when applied filters are shown in a separate row). */
+  hideChips?: boolean;
+  /** Render a trailing "clear" control inside the bar; called when clicked. */
+  onClear?: () => void;
+  /** Force-show the clear control. Defaults to showing whenever there are tokens. */
+  showClear?: boolean;
+}
+
 export interface CustomPopoverProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /**
+   * Radix modal mode. Enable when the popover has its own scrollable content and
+   * lives inside another scroll-locking layer (e.g. a Drawer/Sheet) — modal gives
+   * the popover its own scroll lock so wheel/trackpad scrolling works inside it.
+   */
+  modal?: boolean;
   /** The element that toggles the popover. Rendered with Radix `asChild`. */
   trigger: React.ReactNode;
   title?: React.ReactNode;

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -30,6 +30,34 @@ export function formatTimestamp(ts: string | null): string {
   return new Date(ts).toLocaleString();
 }
 
+/**
+ * The browser's resolved IANA timezone (e.g. `Asia/Kolkata`), falling back to
+ * `UTC` on older runtimes that don't expose it. Shared by the DateRangePicker
+ * and Call History so the default zone is resolved in one place.
+ */
+export function getBrowserTimeZone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  } catch {
+    return 'UTC';
+  }
+}
+
+/**
+ * Format a UTC ISO instant for display in a specific IANA timezone
+ * (e.g. `Jun 5, 4:44 PM`). Used by the shared DateRangePicker trigger so the
+ * label always reflects the user's chosen zone, not the browser default.
+ */
+export function formatTzDateTime(iso: string, timeZone: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone,
+  }).format(new Date(iso));
+}
+
 /** Compact `<m>m <s>s` / `<s>s` rendering for a call duration in seconds. */
 export function formatDuration(seconds: number | null): string {
   if (seconds == null) return '-';

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -31,7 +31,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz"
   integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0-0", "@babel/core@^7.28.0", "@babel/core@>=7.0.0":
+"@babel/core@^7.28.0":
   version "7.29.0"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz"
   integrity sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==
@@ -227,7 +227,7 @@
     "@babel/plugin-transform-modules-commonjs" "^7.27.1"
     "@babel/plugin-transform-typescript" "^7.28.5"
 
-"@babel/template@^7.28.6", "@babel/template@>=7.0.0":
+"@babel/template@^7.28.6":
   version "7.28.6"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz"
   integrity sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==
@@ -257,6 +257,11 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
 
+"@date-fns/tz@^1.4.1", "@date-fns/tz@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@date-fns/tz/-/tz-1.5.0.tgz#e9e79b7583f0b1322c53db884a0112551095e3f3"
+  integrity sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==
+
 "@dotenvx/dotenvx@^1.48.4":
   version "1.54.1"
   resolved "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.54.1.tgz"
@@ -276,6 +281,28 @@
   version "0.2.5"
   resolved "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.5.tgz"
   integrity sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A==
+
+"@emnapi/core@^1.4.3", "@emnapi/core@^1.8.1":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.10.0.tgz#380ccc8f2412ea22d1d972df7f8ee23a3b9c7467"
+  integrity sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==
+  dependencies:
+    "@emnapi/wasi-threads" "1.2.1"
+    tslib "^2.4.0"
+
+"@emnapi/runtime@^1.4.3", "@emnapi/runtime@^1.4.4", "@emnapi/runtime@^1.8.1":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.10.0.tgz#4b260c0d3534204e98c6110b8db1a987d26ec87c"
+  integrity sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@1.2.1", "@emnapi/wasi-threads@^1.1.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz#28fed21a1ba1ce797c44a070abc94d42f3ae8548"
+  integrity sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==
+  dependencies:
+    tslib "^2.4.0"
 
 "@eslint-community/eslint-utils@^4.7.0", "@eslint-community/eslint-utils@^4.8.0":
   version "4.8.0"
@@ -413,7 +440,7 @@
     "@firebase/util" "1.13.0"
     tslib "^2.1.0"
 
-"@firebase/app-compat@0.5.2", "@firebase/app-compat@0.x":
+"@firebase/app-compat@0.5.2":
   version "0.5.2"
   resolved "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.2.tgz"
   integrity sha512-cn+U27GDaBS/irsbvrfnPZdcCzeZPRGKieSlyb7vV6LSOL6mdECnB86PgYjYGxSNg8+U48L/NeevTV1odU+mOQ==
@@ -424,12 +451,12 @@
     "@firebase/util" "1.13.0"
     tslib "^2.1.0"
 
-"@firebase/app-types@0.9.3", "@firebase/app-types@0.x":
+"@firebase/app-types@0.9.3":
   version "0.9.3"
   resolved "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz"
   integrity sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==
 
-"@firebase/app@0.14.2", "@firebase/app@0.x":
+"@firebase/app@0.14.2":
   version "0.14.2"
   resolved "https://registry.npmjs.org/@firebase/app/-/app-0.14.2.tgz"
   integrity sha512-Ecx2ig/JLC9ayIQwZHqm41Tzlf4c1WUuFhFUZB1y+JIJqDRE579x7Uil7tKT8MwDpOPwrK5ZtpxdSsrfy/LF8Q==
@@ -722,7 +749,7 @@
     "@firebase/util" "1.13.0"
     tslib "^2.1.0"
 
-"@firebase/util@1.13.0", "@firebase/util@1.x":
+"@firebase/util@1.13.0":
   version "1.13.0"
   resolved "https://registry.npmjs.org/@firebase/util/-/util-1.13.0.tgz"
   integrity sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==
@@ -821,10 +848,128 @@
   optionalDependencies:
     "@img/sharp-libvips-darwin-arm64" "1.2.0"
 
+"@img/sharp-darwin-x64@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.3.tgz#edf93fb01479604f14ad6a64a716e2ef2bb23100"
+  integrity sha512-yHpJYynROAj12TA6qil58hmPmAwxKKC7reUqtGLzsOHfP7/rniNGTL8tjWX6L3CTV4+5P4ypcS7Pp+7OB+8ihA==
+  optionalDependencies:
+    "@img/sharp-libvips-darwin-x64" "1.2.0"
+
 "@img/sharp-libvips-darwin-arm64@1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.0.tgz"
   integrity sha512-sBZmpwmxqwlqG9ueWFXtockhsxefaV6O84BMOrhtg/YqbTaRdqDE7hxraVE3y6gVM4eExmfzW4a8el9ArLeEiQ==
+
+"@img/sharp-libvips-darwin-x64@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.0.tgz#918ca81c5446f31114834cb908425a7532393185"
+  integrity sha512-M64XVuL94OgiNHa5/m2YvEQI5q2cl9d/wk0qFTDVXcYzi43lxuiFTftMR1tOnFQovVXNZJ5TURSDK2pNe9Yzqg==
+
+"@img/sharp-libvips-linux-arm64@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.0.tgz#1a5beafc857b43f378c3030427aa981ee3edbc54"
+  integrity sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==
+
+"@img/sharp-libvips-linux-arm@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.0.tgz#bff51182d5238ca35c5fe9e9f594a18ad6a5480d"
+  integrity sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==
+
+"@img/sharp-libvips-linux-ppc64@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.0.tgz#10c53ccf6f2d47d71fb3fa282697072c8fe9e40e"
+  integrity sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==
+
+"@img/sharp-libvips-linux-s390x@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.0.tgz#392fd7557ddc5c901f1bed7ab3c567c08833ef3b"
+  integrity sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==
+
+"@img/sharp-libvips-linux-x64@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.0.tgz#9315cf90a2fdcdc0e29ea7663cbd8b0f15254400"
+  integrity sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==
+
+"@img/sharp-libvips-linuxmusl-arm64@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.0.tgz#705e03e67d477f6f842f37eb7f66285b1150dc06"
+  integrity sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==
+
+"@img/sharp-libvips-linuxmusl-x64@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.0.tgz#ec905071cc538df64848d5900e0d386d77c55f13"
+  integrity sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==
+
+"@img/sharp-linux-arm64@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.3.tgz#476f8f13ce192555391ae9d4bc658637a6acf3e5"
+  integrity sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-arm64" "1.2.0"
+
+"@img/sharp-linux-arm@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.3.tgz#9898cd68ea3e3806b94fe25736d5d7ecb5eac121"
+  integrity sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-arm" "1.2.0"
+
+"@img/sharp-linux-ppc64@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.3.tgz#6a7cd4c608011333a0ddde6d96e03ac042dd9079"
+  integrity sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-ppc64" "1.2.0"
+
+"@img/sharp-linux-s390x@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.3.tgz#48e27ab969efe97d270e39297654c0e0c9b42919"
+  integrity sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-s390x" "1.2.0"
+
+"@img/sharp-linux-x64@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.3.tgz#5aa77ad4aa447ddf6d642e2a2c5599eb1292dfaa"
+  integrity sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-x64" "1.2.0"
+
+"@img/sharp-linuxmusl-arm64@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.3.tgz#62053a9d77c7d4632c677619325b741254689dd7"
+  integrity sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==
+  optionalDependencies:
+    "@img/sharp-libvips-linuxmusl-arm64" "1.2.0"
+
+"@img/sharp-linuxmusl-x64@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.3.tgz#5107c7709c7e0a44fe5abef59829f1de86fa0a3a"
+  integrity sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==
+  optionalDependencies:
+    "@img/sharp-libvips-linuxmusl-x64" "1.2.0"
+
+"@img/sharp-wasm32@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-wasm32/-/sharp-wasm32-0.34.3.tgz#c1dcabb834ec2f71308a810b399bb6e6e3b79619"
+  integrity sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==
+  dependencies:
+    "@emnapi/runtime" "^1.4.4"
+
+"@img/sharp-win32-arm64@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.3.tgz#3e8654e368bb349d45799a0d7aeb29db2298628e"
+  integrity sha512-MjnHPnbqMXNC2UgeLJtX4XqoVHHlZNd+nPt1kRPmj63wURegwBhZlApELdtxM2OIZDRv/DFtLcNhVbd1z8GYXQ==
+
+"@img/sharp-win32-ia32@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.3.tgz#9d4c105e8d5074a351a81a0b6d056e0af913bf76"
+  integrity sha512-xuCdhH44WxuXgOM714hn4amodJMZl3OEvf0GVTm0BEyMeA2to+8HEdRPShH0SLYptJY1uBw+SCFP9WVQi1Q/cw==
+
+"@img/sharp-win32-x64@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.3.tgz#d20c89bd41b1dd3d76d8575714aaaa3c43204b6a"
+  integrity sha512-OWwz05d++TxzLEv4VnsTz5CmZ6mI6S05sfQGEMrNrQcOEERbX46332IvE7pO/EUiw7jUrrS40z/M7kPyjfl04g==
 
 "@inquirer/ansi@^1.0.2":
   version "1.0.2"
@@ -932,6 +1077,22 @@
     outvariant "^1.4.3"
     strict-event-emitter "^0.5.1"
 
+"@napi-rs/wasm-runtime@^0.2.11":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz#3e78a8b96e6c33a6c517e1894efbd5385a7cb6f2"
+  integrity sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==
+  dependencies:
+    "@emnapi/core" "^1.4.3"
+    "@emnapi/runtime" "^1.4.3"
+    "@tybys/wasm-util" "^0.10.0"
+
+"@napi-rs/wasm-runtime@^1.1.1":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz#a46bbfedc29751b7170c5d23bc1d8ee8c7e3c1e1"
+  integrity sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==
+  dependencies:
+    "@tybys/wasm-util" "^0.10.1"
+
 "@next/env@15.5.19":
   version "15.5.19"
   resolved "https://registry.npmjs.org/@next/env/-/env-15.5.19.tgz"
@@ -949,7 +1110,42 @@
   resolved "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.19.tgz"
   integrity sha512-jx9wWlTKueHKPvVOndyr7WuaevWCkuYqsQ8gC0TMPKAVWG3MhcdMrjfo9tvIZNXd0QOUYXXvAcZ325y8Uq7uzg==
 
-"@noble/ciphers@^1.0.0", "@noble/ciphers@^1.3.0":
+"@next/swc-darwin-x64@15.5.19":
+  version "15.5.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.19.tgz#fd36d8a74eace4ee50d37dd41d3d6355c92ed661"
+  integrity sha512-291KFcsIQ3OenRdiUDFOR6W3wezzH4auENXm1gbm1Bjd4ANMMRgxPrWTUztQN43BnVoVuMnHCrLeECIMwgFKbA==
+
+"@next/swc-linux-arm64-gnu@15.5.19":
+  version "15.5.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.19.tgz#a812c64be14475b9d5d10fc34b4aea66d384e387"
+  integrity sha512-WeH+nelQyyMeE2f8FxBRZNrGipya5zHZV2vjzfCOAYyiI6am+NbnWAAldOBFQBB2w0DjJcsvrKqoFT2b7+5YoA==
+
+"@next/swc-linux-arm64-musl@15.5.19":
+  version "15.5.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.19.tgz#a61c81f227358a25918e0c27847a28cfda743f1c"
+  integrity sha512-5xTOE0lDlDCSSfp+BAif7j17VRRCjWp//ZPZy6NI0QpdrhxtQnsZguSx0xAAZ0c9XZLrLLwCe/XVe5YPrRilKw==
+
+"@next/swc-linux-x64-gnu@15.5.19":
+  version "15.5.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.19.tgz#38a9ba9a7ff388592adc9abd6394b749e35ba21b"
+  integrity sha512-LTxRmMgqqMv05Had879W00Fm53quiJd3Zuz8h1JSNJ3nGSlbZ/7Tjs1tKyScgN3Au3t3MyPsjPlq60fMmSHLsg==
+
+"@next/swc-linux-x64-musl@15.5.19":
+  version "15.5.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.19.tgz#ca1c0319aef657109c3466ca0fc70e3cab14008b"
+  integrity sha512-eoNQSpA5PQfB9wBO4RA47MTDXWz1fizy9Y3Z6e4DetYIF3dvjuu8sj7aIGn/bFCU6lnFzTK34NtCaffP4NsQ7Q==
+
+"@next/swc-win32-arm64-msvc@15.5.19":
+  version "15.5.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.19.tgz#bc18eb3301245851472a699ed622952f6e3aa3f2"
+  integrity sha512-6UNt2dFuCHOe446sm/Kp69nUe8/wIhnh9bm6Xcqw4qEWCOppLMOvhTBVgvM7invVUNr4SPpP6NOQsACtn2IN9Q==
+
+"@next/swc-win32-x64-msvc@15.5.19":
+  version "15.5.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.19.tgz#5f4c849f10c5907ad595611de0b29ae6c8a73ec9"
+  integrity sha512-PhmojAHyqMne56HBLGu9dhDnHPuFmEjrXSQMM/nW0J6j849lk3ESrVtqNJcCk8CKOV7brpTTbaYAjwKPzKM69w==
+
+"@noble/ciphers@^1.3.0":
   version "1.3.0"
   resolved "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz"
   integrity sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==
@@ -961,7 +1157,7 @@
   dependencies:
     "@noble/hashes" "1.8.0"
 
-"@noble/hashes@^1.8.0", "@noble/hashes@1.8.0":
+"@noble/hashes@1.8.0", "@noble/hashes@^1.8.0":
   version "1.8.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
@@ -974,7 +1170,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -1010,10 +1206,70 @@
   resolved "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz"
   integrity sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==
 
+"@parcel/watcher-android-arm64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz#507f836d7e2042f798c7d07ad19c3546f9848ac1"
+  integrity sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==
+
 "@parcel/watcher-darwin-arm64@2.5.1":
   version "2.5.1"
   resolved "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz"
   integrity sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==
+
+"@parcel/watcher-darwin-x64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz#99f3af3869069ccf774e4ddfccf7e64fd2311ef8"
+  integrity sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==
+
+"@parcel/watcher-freebsd-x64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz#14d6857741a9f51dfe51d5b08b7c8afdbc73ad9b"
+  integrity sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==
+
+"@parcel/watcher-linux-arm-glibc@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz#43c3246d6892381db473bb4f663229ad20b609a1"
+  integrity sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==
+
+"@parcel/watcher-linux-arm-musl@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz#663750f7090bb6278d2210de643eb8a3f780d08e"
+  integrity sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==
+
+"@parcel/watcher-linux-arm64-glibc@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz#ba60e1f56977f7e47cd7e31ad65d15fdcbd07e30"
+  integrity sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==
+
+"@parcel/watcher-linux-arm64-musl@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz#f7fbcdff2f04c526f96eac01f97419a6a99855d2"
+  integrity sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==
+
+"@parcel/watcher-linux-x64-glibc@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz#4d2ea0f633eb1917d83d483392ce6181b6a92e4e"
+  integrity sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==
+
+"@parcel/watcher-linux-x64-musl@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz#277b346b05db54f55657301dd77bdf99d63606ee"
+  integrity sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==
+
+"@parcel/watcher-win32-arm64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz#7e9e02a26784d47503de1d10e8eab6cceb524243"
+  integrity sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==
+
+"@parcel/watcher-win32-ia32@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz#2d0f94fa59a873cdc584bf7f6b1dc628ddf976e6"
+  integrity sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==
+
+"@parcel/watcher-win32-x64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz#ae52693259664ba6f2228fa61d7ee44b64ea0947"
+  integrity sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==
 
 "@parcel/watcher@^2.4.1":
   version "2.5.1"
@@ -1044,7 +1300,7 @@
   resolved "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@playwright/test@^1.50.0", "@playwright/test@^1.51.1":
+"@playwright/test@^1.50.0":
   version "1.58.2"
   resolved "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz"
   integrity sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==
@@ -1805,6 +2061,11 @@
   dependencies:
     tslib "^2.8.0"
 
+"@tabby_ai/hijri-converter@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz#b664994892348a402ae7529e648c819eee39208b"
+  integrity sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==
+
 "@tailwindcss/node@4.2.1":
   version "4.2.1"
   resolved "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.1.tgz"
@@ -1818,10 +2079,72 @@
     source-map-js "^1.2.1"
     tailwindcss "4.2.1"
 
+"@tailwindcss/oxide-android-arm64@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.1.tgz#a7c24919b607e7f884e6ab97799d12c7fb5b47bd"
+  integrity sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg==
+
 "@tailwindcss/oxide-darwin-arm64@4.2.1":
   version "4.2.1"
   resolved "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.1.tgz"
   integrity sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw==
+
+"@tailwindcss/oxide-darwin-x64@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.1.tgz#1e59ef0665f6cb9e658bf0ebcb3cb50f21b2c175"
+  integrity sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw==
+
+"@tailwindcss/oxide-freebsd-x64@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.1.tgz#6b0c75e9dac7f1a241cb9a5eaa89f0d9664835b6"
+  integrity sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA==
+
+"@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.1.tgz#717044d8fe746b1f0760485946c0c9a900174f7b"
+  integrity sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw==
+
+"@tailwindcss/oxide-linux-arm64-gnu@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.1.tgz#f544b0faf166d80791347911b2dd4372a893129d"
+  integrity sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ==
+
+"@tailwindcss/oxide-linux-arm64-musl@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.1.tgz#9fbaf8dc00b858a2b955526abb15d88f5678d1ef"
+  integrity sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==
+
+"@tailwindcss/oxide-linux-x64-gnu@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.1.tgz#6ab4e6b8d308d037a1155b8443df5941dbfa6aa1"
+  integrity sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==
+
+"@tailwindcss/oxide-linux-x64-musl@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.1.tgz#52c55593394dff85f1fa88172f69f8fdcde182b6"
+  integrity sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==
+
+"@tailwindcss/oxide-wasm32-wasi@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.1.tgz#7401e35f881d3654b6180badd1243d75a2702ea5"
+  integrity sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==
+  dependencies:
+    "@emnapi/core" "^1.8.1"
+    "@emnapi/runtime" "^1.8.1"
+    "@emnapi/wasi-threads" "^1.1.0"
+    "@napi-rs/wasm-runtime" "^1.1.1"
+    "@tybys/wasm-util" "^0.10.1"
+    tslib "^2.8.1"
+
+"@tailwindcss/oxide-win32-arm64-msvc@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.1.tgz#63a502e7b696dcd976aa356b94ce0f4f8f832c44"
+  integrity sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA==
+
+"@tailwindcss/oxide-win32-x64-msvc@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.1.tgz#8cc59b28ebc4dc866c0c14d7057f07f0ed04c4a8"
+  integrity sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ==
 
 "@tailwindcss/oxide@4.2.1":
   version "4.2.1"
@@ -2085,6 +2408,13 @@
     minimatch "^10.0.1"
     path-browserify "^1.0.1"
 
+"@tybys/wasm-util@^0.10.0", "@tybys/wasm-util@^0.10.1":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.2.tgz#12b3a1b33db1f9cad4ddff1f604ab7dd00bf464e"
+  integrity sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==
+  dependencies:
+    tslib "^2.4.0"
+
 "@types/estree@^1.0.6":
   version "1.0.8"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz"
@@ -2128,19 +2458,19 @@
   resolved "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz"
   integrity sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==
 
-"@types/node@^20", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@>=18":
+"@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^20":
   version "20.19.12"
   resolved "https://registry.npmjs.org/@types/node/-/node-20.19.12.tgz"
   integrity sha512-lSOjyS6vdO2G2g2CWrETTV3Jz2zlCXHpu1rcubLKpz9oj+z/1CceHlj+yq53W+9zgb98nSov/wjEKYDNauD+Hw==
   dependencies:
     undici-types "~6.21.0"
 
-"@types/react-dom@*", "@types/react-dom@^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom@^19":
+"@types/react-dom@^19":
   version "19.1.9"
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz"
   integrity sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==
 
-"@types/react@*", "@types/react@^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react@^19", "@types/react@^19.0.0", "@types/react@>=17.0.0", "@types/react@>=18.0.0":
+"@types/react@^19":
   version "19.1.12"
   resolved "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz"
   integrity sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==
@@ -2205,7 +2535,7 @@
     "@typescript-eslint/types" "8.44.0"
     "@typescript-eslint/visitor-keys" "8.44.0"
 
-"@typescript-eslint/tsconfig-utils@^8.44.0", "@typescript-eslint/tsconfig-utils@8.44.0":
+"@typescript-eslint/tsconfig-utils@8.44.0", "@typescript-eslint/tsconfig-utils@^8.44.0":
   version "8.44.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz"
   integrity sha512-x5Y0+AuEPqAInc6yd0n5DAcvtoQ/vyaGwuX5HE9n6qAefk1GaedqrLQF8kQGylLUb9pnZyLf+iEiL9fr8APDtQ==
@@ -2221,7 +2551,7 @@
     debug "^4.3.4"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/types@^8.44.0", "@typescript-eslint/types@8.44.0":
+"@typescript-eslint/types@8.44.0", "@typescript-eslint/types@^8.44.0":
   version "8.44.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.0.tgz"
   integrity sha512-ZSl2efn44VsYM0MfDQe68RKzBz75NPgLQXuGypmym6QVOWL5kegTZuZ02xRAT9T+onqvM6T8CdQk0OwYMB6ZvA==
@@ -2260,10 +2590,102 @@
     "@typescript-eslint/types" "8.44.0"
     eslint-visitor-keys "^4.2.1"
 
+"@unrs/resolver-binding-android-arm-eabi@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz#9f5b04503088e6a354295e8ea8fe3cb99e43af81"
+  integrity sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==
+
+"@unrs/resolver-binding-android-arm64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz#7414885431bd7178b989aedc4d25cccb3865bc9f"
+  integrity sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==
+
 "@unrs/resolver-binding-darwin-arm64@1.11.1":
   version "1.11.1"
   resolved "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz"
   integrity sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==
+
+"@unrs/resolver-binding-darwin-x64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz#fd4d81257b13f4d1a083890a6a17c00de571f0dc"
+  integrity sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==
+
+"@unrs/resolver-binding-freebsd-x64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz#d2513084d0f37c407757e22f32bd924a78cfd99b"
+  integrity sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==
+
+"@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz#844d2605d057488d77fab09705f2866b86164e0a"
+  integrity sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==
+
+"@unrs/resolver-binding-linux-arm-musleabihf@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz#204892995cefb6bd1d017d52d097193bc61ddad3"
+  integrity sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==
+
+"@unrs/resolver-binding-linux-arm64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz#023eb0c3aac46066a10be7a3f362e7b34f3bdf9d"
+  integrity sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==
+
+"@unrs/resolver-binding-linux-arm64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz#9e6f9abb06424e3140a60ac996139786f5d99be0"
+  integrity sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==
+
+"@unrs/resolver-binding-linux-ppc64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz#b111417f17c9d1b02efbec8e08398f0c5527bb44"
+  integrity sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==
+
+"@unrs/resolver-binding-linux-riscv64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz#92ffbf02748af3e99873945c9a8a5ead01d508a9"
+  integrity sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==
+
+"@unrs/resolver-binding-linux-riscv64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz#0bec6f1258fc390e6b305e9ff44256cb207de165"
+  integrity sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==
+
+"@unrs/resolver-binding-linux-s390x-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz#577843a084c5952f5906770633ccfb89dac9bc94"
+  integrity sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==
+
+"@unrs/resolver-binding-linux-x64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz#36fb318eebdd690f6da32ac5e0499a76fa881935"
+  integrity sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==
+
+"@unrs/resolver-binding-linux-x64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz#bfb9af75f783f98f6a22c4244214efe4df1853d6"
+  integrity sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==
+
+"@unrs/resolver-binding-wasm32-wasi@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz#752c359dd875684b27429500d88226d7cc72f71d"
+  integrity sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==
+  dependencies:
+    "@napi-rs/wasm-runtime" "^0.2.11"
+
+"@unrs/resolver-binding-win32-arm64-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz#ce5735e600e4c2fbb409cd051b3b7da4a399af35"
+  integrity sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==
+
+"@unrs/resolver-binding-win32-ia32-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz#72fc57bc7c64ec5c3de0d64ee0d1810317bc60a6"
+  integrity sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==
+
+"@unrs/resolver-binding-win32-x64-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
+  integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
 accepts@^2.0.0:
   version "2.0.0"
@@ -2278,15 +2700,10 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.15.0:
+acorn@^8.15.0:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
-
-agent-base@^7.1.2:
-  version "7.1.4"
-  resolved "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz"
-  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
 agent-base@6:
   version "6.0.2"
@@ -2294,6 +2711,11 @@ agent-base@6:
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
+
+agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
 ajv-formats@^3.0.1:
   version "3.0.1"
@@ -2312,17 +2734,7 @@ ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0:
-  version "8.18.0"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz"
-  integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
-  dependencies:
-    fast-deep-equal "^3.1.3"
-    fast-uri "^3.0.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-
-ajv@^8.17.1:
+ajv@^8.0.0, ajv@^8.17.1:
   version "8.18.0"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz"
   integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
@@ -2345,11 +2757,6 @@ ansi-regex@^5.0.1:
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-regex@^6.0.1:
-  version "6.2.2"
-  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz"
-  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
-
-ansi-regex@^6.2.2:
   version "6.2.2"
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz"
   integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
@@ -2604,7 +3011,7 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0, browserslist@^4.24.4, browserslist@^4.26.2, "browserslist@>= 4.21.0":
+browserslist@^4.24.0, browserslist@^4.24.4, browserslist@^4.26.2:
   version "4.28.1"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz"
   integrity sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==
@@ -2694,12 +3101,7 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^5.3.0:
-  version "5.6.2"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz"
-  integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
-
-chalk@^5.6.0:
+chalk@^5.3.0, chalk@^5.6.0:
   version "5.6.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz"
   integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
@@ -2948,7 +3350,12 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-date-fns@^4.2.1:
+date-fns-jalali@4.1.0-0:
+  version "4.1.0-0"
+  resolved "https://registry.yarnpkg.com/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz#9c7fb286004fab267a300d3e9f1ada9f10b4b6b0"
+  integrity sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==
+
+date-fns@^4.1.0, date-fns@^4.2.1:
   version "4.4.0"
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz"
   integrity sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==
@@ -2958,19 +3365,19 @@ dayjs@^1.11.19:
   resolved "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz"
   integrity sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==
 
+debug@4, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0, debug@^4.4.1, debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0, debug@^4.4.1, debug@^4.4.3, debug@4:
-  version "4.4.3"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
 
 dedent@^1.6.0:
   version "1.7.2"
@@ -3300,7 +3707,7 @@ eslint-config-next@^15.5.9:
     eslint-plugin-react "^7.37.0"
     eslint-plugin-react-hooks "^5.0.0"
 
-eslint-config-prettier@^10.1.8, "eslint-config-prettier@>= 7.0.0 <10.0.0 || >=10.1.0":
+eslint-config-prettier@^10.1.8:
   version "10.1.8"
   resolved "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz"
   integrity sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==
@@ -3334,7 +3741,7 @@ eslint-module-utils@^2.12.1:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-import@*, eslint-plugin-import@^2.31.0:
+eslint-plugin-import@^2.31.0:
   version "2.32.0"
   resolved "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz"
   integrity sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==
@@ -3435,7 +3842,7 @@ eslint-visitor-keys@^4.2.1:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz"
   integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
 
-eslint@*, "eslint@^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7", "eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^7.23.0 || ^8.0.0 || ^9.0.0", "eslint@^8.57.0 || ^9.0.0", eslint@^9.35.0, eslint@>=7.0.0, eslint@>=8.0.0:
+eslint@^9.35.0:
   version "9.35.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz"
   integrity sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==
@@ -3576,7 +3983,7 @@ express-rate-limit@^8.2.1:
   dependencies:
     ip-address "^10.2.0"
 
-express@^5.2.1, "express@>= 4.11":
+express@^5.2.1:
   version "5.2.1"
   resolved "https://registry.npmjs.org/express/-/express-5.2.1.tgz"
   integrity sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==
@@ -3625,28 +4032,6 @@ fast-equals@^5.3.3:
   resolved "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz"
   integrity sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==
 
-fast-glob@^3.3.2:
-  version "3.3.3"
-  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz"
-  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.8"
-
-fast-glob@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz"
-  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.8"
-
 fast-glob@3.3.1:
   version "3.3.1"
   resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz"
@@ -3657,6 +4042,17 @@ fast-glob@3.3.1:
     glob-parent "^5.1.2"
     merge2 "^1.3.0"
     micromatch "^4.0.4"
+
+fast-glob@^3.3.2, fast-glob@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz"
+  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.8"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
@@ -3687,12 +4083,7 @@ faye-websocket@0.11.4:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fdir@^6.2.0:
-  version "6.5.0"
-  resolved "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz"
-  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
-
-fdir@^6.4.4:
+fdir@^6.2.0, fdir@^6.4.4:
   version "6.5.0"
   resolved "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
@@ -4071,7 +4462,7 @@ headers-polyfill@^4.0.2:
   resolved "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz"
   integrity sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==
 
-hono@^4, hono@^4.11.4:
+hono@^4.11.4:
   version "4.12.23"
   resolved "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz"
   integrity sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==
@@ -4504,7 +4895,7 @@ iterator.prototype@^1.1.4:
     has-symbols "^1.1.0"
     set-function-name "^2.0.2"
 
-jiti@*, jiti@^2.6.1:
+jiti@^2.6.1:
   version "2.6.1"
   resolved "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz"
   integrity sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==
@@ -4578,12 +4969,7 @@ json5@^1.0.2:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.2.2:
-  version "2.2.3"
-  resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz"
-  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
-
-json5@^2.2.3:
+json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -4644,10 +5030,60 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+lightningcss-android-arm64@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.31.1.tgz#609ff48332adff452a8157a7c2842fd692a8eac4"
+  integrity sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==
+
 lightningcss-darwin-arm64@1.31.1:
   version "1.31.1"
   resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.31.1.tgz"
   integrity sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==
+
+lightningcss-darwin-x64@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.31.1.tgz#f7482c311273571ec0c2bd8277c1f5f6e90e03a4"
+  integrity sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==
+
+lightningcss-freebsd-x64@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.31.1.tgz#91df1bb290f1cb7bb2af832d7d0d8809225e0124"
+  integrity sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==
+
+lightningcss-linux-arm-gnueabihf@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.31.1.tgz#c3cad5ae8b70045f21600dc95295ab6166acf57e"
+  integrity sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==
+
+lightningcss-linux-arm64-gnu@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.31.1.tgz#a5c4f6a5ac77447093f61b209c0bd7fef1f0a3e3"
+  integrity sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==
+
+lightningcss-linux-arm64-musl@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.31.1.tgz#af26ab8f829b727ada0a200938a6c8796ff36900"
+  integrity sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==
+
+lightningcss-linux-x64-gnu@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.31.1.tgz#a891d44e84b71c0d88959feb9a7522bbf61450ee"
+  integrity sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==
+
+lightningcss-linux-x64-musl@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.31.1.tgz#8c8b21def851f4d477fa897b80cb3db2b650bc6e"
+  integrity sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==
+
+lightningcss-win32-arm64-msvc@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.31.1.tgz#79000fb8c57e94a91b8fc643e74d5a54407d7080"
+  integrity sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==
+
+lightningcss-win32-x64-msvc@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.31.1.tgz#7f025274c81c7d659829731e09c8b6f442209837"
+  integrity sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==
 
 lightningcss@1.31.1:
   version "1.31.1"
@@ -4790,7 +5226,7 @@ magic-string@^0.30.21:
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.5"
 
-map-obj@^5.0.2, map-obj@5.0.2:
+map-obj@5.0.2, map-obj@^5.0.2:
   version "5.0.2"
   resolved "https://registry.npmjs.org/map-obj/-/map-obj-5.0.2.tgz"
   integrity sha512-K6K2NgKnTXimT3779/4KxSvobxOtMmx1LBZ3NwRxT/MDIR3Br/fQ4Q+WCX5QxjyUR8zg5+RV9Tbf2c5pAWTD2A==
@@ -4845,15 +5281,15 @@ micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.8:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
-mime-db@^1.54.0:
-  version "1.54.0"
-  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz"
-  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
-
 mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-db@^1.54.0:
+  version "1.54.0"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz"
+  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
 
 mime-types@^2.1.12:
   version "2.1.35"
@@ -4862,14 +5298,7 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "1.52.0"
 
-mime-types@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz"
-  integrity sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==
-  dependencies:
-    mime-db "^1.54.0"
-
-mime-types@^3.0.2:
+mime-types@^3.0.0, mime-types@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz"
   integrity sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==
@@ -4988,7 +5417,7 @@ next-themes@^0.4.6:
   resolved "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz"
   integrity sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==
 
-next@^15.5.12, next@>=13.2.0, next@>=15.0.0:
+next@^15.5.12:
   version "15.5.19"
   resolved "https://registry.npmjs.org/next/-/next-15.5.19.tgz"
   integrity sha512-xNOW6tYshGX1/Oi3F8uuk4gpDeWsSUE/1Z0G5uUMekIxaQ0xc03UXd9II0VQHYMWviMeA0OHpJFAKsHf8bTYVg==
@@ -5301,7 +5730,7 @@ picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz"
   integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
-"picomatch@^3 || ^4", picomatch@^4.0.2:
+picomatch@^4.0.2:
   version "4.0.4"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
@@ -5348,15 +5777,6 @@ postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.1.0, postcss@^8.5.6:
-  version "8.5.12"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz"
-  integrity sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==
-  dependencies:
-    nanoid "^3.3.11"
-    picocolors "^1.1.1"
-    source-map-js "^1.2.1"
-
 postcss@8.4.31:
   version "8.4.31"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz"
@@ -5365,6 +5785,15 @@ postcss@8.4.31:
     nanoid "^3.3.6"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
+
+postcss@^8.5.6:
+  version "8.5.12"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz"
+  integrity sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==
+  dependencies:
+    nanoid "^3.3.11"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
 
 powershell-utils@^0.1.0:
   version "0.1.0"
@@ -5383,7 +5812,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^3.6.2, prettier@>=3.0.0:
+prettier@^3.6.2:
   version "3.6.2"
   resolved "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz"
   integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==
@@ -5499,7 +5928,7 @@ prosemirror-menu@^1.2.4:
     prosemirror-history "^1.0.0"
     prosemirror-state "^1.0.0"
 
-prosemirror-model@^1.0.0, prosemirror-model@^1.20.0, prosemirror-model@^1.21.0, prosemirror-model@^1.22.1, prosemirror-model@^1.24.1, prosemirror-model@^1.25.0, prosemirror-model@^1.25.4:
+prosemirror-model@^1.0.0, prosemirror-model@^1.20.0, prosemirror-model@^1.21.0, prosemirror-model@^1.24.1, prosemirror-model@^1.25.0, prosemirror-model@^1.25.4:
   version "1.25.4"
   resolved "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz"
   integrity sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==
@@ -5522,7 +5951,7 @@ prosemirror-schema-list@^1.5.0:
     prosemirror-state "^1.0.0"
     prosemirror-transform "^1.7.3"
 
-prosemirror-state@^1.0.0, prosemirror-state@^1.2.2, prosemirror-state@^1.4.2, prosemirror-state@^1.4.3, prosemirror-state@^1.4.4:
+prosemirror-state@^1.0.0, prosemirror-state@^1.2.2, prosemirror-state@^1.4.3, prosemirror-state@^1.4.4:
   version "1.4.4"
   resolved "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz"
   integrity sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==
@@ -5557,7 +5986,7 @@ prosemirror-transform@^1.0.0, prosemirror-transform@^1.1.0, prosemirror-transfor
   dependencies:
     prosemirror-model "^1.21.0"
 
-prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.27.0, prosemirror-view@^1.31.0, prosemirror-view@^1.33.8, prosemirror-view@^1.38.1, prosemirror-view@^1.41.4:
+prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.27.0, prosemirror-view@^1.31.0, prosemirror-view@^1.38.1, prosemirror-view@^1.41.4:
   version "1.41.6"
   resolved "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.6.tgz"
   integrity sha512-mxpcDG4hNQa/CPtzxjdlir5bJFDlm0/x5nGBbStB2BWX+XOQ9M8ekEG+ojqB5BcVu2Rc80/jssCMZzSstJuSYg==
@@ -5700,14 +6129,24 @@ raw-body@^3.0.0, raw-body@^3.0.1:
     iconv-lite "~0.7.0"
     unpipe "~1.0.0"
 
-"react-dom@^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom@^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^18.0.0 || ^19.0.0", "react-dom@^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react-dom@>=16.8, react-dom@>=16.8.0, react-dom@19.1.0:
+react-day-picker@^9:
+  version "9.14.0"
+  resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-9.14.0.tgz#b2975b48366d0c3a180520e1a4063b5a7d6c5a57"
+  integrity sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==
+  dependencies:
+    "@date-fns/tz" "^1.4.1"
+    "@tabby_ai/hijri-converter" "1.0.5"
+    date-fns "^4.1.0"
+    date-fns-jalali "4.1.0-0"
+
+react-dom@19.1.0:
   version "19.1.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz"
   integrity sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==
   dependencies:
     scheduler "^0.26.0"
 
-react-hook-form@^7.55.0, react-hook-form@^7.71.2:
+react-hook-form@^7.71.2:
   version "7.71.2"
   resolved "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.2.tgz"
   integrity sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==
@@ -5744,7 +6183,7 @@ react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
     get-nonce "^1.0.0"
     tslib "^2.0.0"
 
-"react@^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react@^16.8.0 || ^17 || ^18 || ^19", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^17.0.0 || ^18.0.0 || ^19.0.0", "react@^18 || ^19", "react@^18.0.0 || ^19.0.0", "react@^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react@^19.1.0, "react@>= 16.8.0", "react@>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0", react@>=16.8, react@>=16.8.0, react@>=17.0.0, react@>=18.0.0, react@19.1.0:
+react@19.1.0:
   version "19.1.0"
   resolved "https://registry.npmjs.org/react/-/react-19.1.0.tgz"
   integrity sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==
@@ -5918,7 +6357,7 @@ safe-regex-test@^1.0.3, safe-regex-test@^1.1.0:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass@^1.3.0, sass@^1.91.0:
+sass@^1.91.0:
   version "1.92.1"
   resolved "https://registry.npmjs.org/sass/-/sass-1.92.1.tgz"
   integrity sha512-ffmsdbwqb3XeyR8jJR6KelIXARM9bFQe8A6Q3W4Klmwy5Ckd5gz7jgUNHo4UOqutU5Sk1DtKLbpDP0nLCg1xqQ==
@@ -6176,7 +6615,7 @@ sonner@^2.0.7:
   resolved "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz"
   integrity sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==
 
-source-map-js@^1.0.2, source-map-js@^1.2.1, "source-map-js@>=0.6.2 <2.0.0":
+"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -6228,16 +6667,7 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^7.0.0:
-  version "7.2.0"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz"
-  integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
-  dependencies:
-    emoji-regex "^10.3.0"
-    get-east-asian-width "^1.0.0"
-    strip-ansi "^7.1.0"
-
-string-width@^7.2.0:
+string-width@^7.0.0, string-width@^7.2.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz"
   integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
@@ -6401,7 +6831,7 @@ tailwind-merge@^3.0.1, tailwind-merge@^3.5.0:
   resolved "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz"
   integrity sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==
 
-tailwindcss@^4.2.1, tailwindcss@4.2.1:
+tailwindcss@4.2.1, tailwindcss@^4.2.1:
   version "4.2.1"
   resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz"
   integrity sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==
@@ -6492,9 +6922,9 @@ tsconfig-paths@^4.2.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.8.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.8.0, tslib@^2.8.1:
   version "2.8.1"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 type-check@^0.4.0, type-check@~0.4.0:
@@ -6570,7 +7000,7 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.0.0"
     reflect.getprototypeof "^1.0.6"
 
-typescript@^5, "typescript@>= 4.8.x", typescript@>=3.3.1, typescript@>=4.8.4, "typescript@>=4.8.4 <6.0.0", typescript@>=4.9.5:
+typescript@^5:
   version "5.9.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz"
   integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
@@ -6672,7 +7102,7 @@ use-sidecar@^1.1.3:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
 
-use-sync-external-store@^1.4.0, use-sync-external-store@^1.5.0, use-sync-external-store@>=1.2.0:
+use-sync-external-store@^1.4.0, use-sync-external-store@^1.5.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz"
   integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
@@ -6891,7 +7321,7 @@ zod@^3.24.1:
   resolved "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
 
-"zod@^3.25 || ^4", "zod@^3.25 || ^4.0", zod@^4.3.6:
+"zod@^3.25 || ^4.0", zod@^4.3.6:
   version "4.3.6"
   resolved "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz"
   integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==

--- a/test-cases/core/test_call_logs.py
+++ b/test-cases/core/test_call_logs.py
@@ -182,6 +182,74 @@ class TestGetCallLogs:
 
 
 # ---------------------------------------------------------------------------
+# POST /api/v1/call-log/facets
+# ---------------------------------------------------------------------------
+
+PATCH_CALL_SERVICE = "core.api.v1.call_logs.CallService"
+
+
+@pytest.fixture
+def sample_facets():
+    return {
+        "status": [
+            {"value": "completed", "count": 12},
+            {"value": "in_progress", "count": 3},
+            {"value": "failed", "count": 1},
+        ],
+        "agent_name": [{"value": "Sales Agent", "count": 9}],
+        "direction": [{"value": "inbound", "count": 10}],
+        "channel_type": [{"value": "twilio", "count": 16}],
+        "llm_model": [{"value": "gpt-4o", "count": 16}],
+        "stt_model": [{"value": "nova-2", "count": 16}],
+        "tts_model": [{"value": "eleven_turbo_v2", "count": 16}],
+    }
+
+
+class TestGetFacets:
+    """Tests for POST /api/v1/call-log/facets"""
+
+    @patch(PATCH_CALL_SERVICE)
+    def test_success_empty_body(self, mock_service_cls, client_as_member, sample_facets):
+        mock_service_cls.return_value.get_facets.return_value = sample_facets
+        resp = client_as_member.post("/api/v1/call-log/facets", json={})
+        assert resp.status_code == 200
+        assert resp.json()["status"][0]["value"] == "completed"
+        mock_service_cls.return_value.get_facets.assert_called_once_with(
+            start_date_time=None,
+            end_date_time=None,
+            filters=None,
+        )
+
+    @patch(PATCH_CALL_SERVICE)
+    def test_passes_filters_and_dates(self, mock_service_cls, client_as_member, sample_facets):
+        mock_service_cls.return_value.get_facets.return_value = sample_facets
+        payload = {
+            "start_date_time": "2026-01-01T00:00:00",
+            "end_date_time": "2026-12-31T23:59:59",
+            "filters": [{"field": "status", "operator": "in", "value": ["completed"]}],
+        }
+        resp = client_as_member.post("/api/v1/call-log/facets", json=payload)
+        assert resp.status_code == 200
+        mock_service_cls.return_value.get_facets.assert_called_once_with(
+            start_date_time="2026-01-01T00:00:00",
+            end_date_time="2026-12-31T23:59:59",
+            filters=[{"field": "status", "operator": "in", "value": ["completed"]}],
+        )
+
+    def test_unauthenticated(self, client_unauthenticated):
+        resp = client_unauthenticated.post("/api/v1/call-log/facets", json={})
+        assert resp.status_code in (401, 403)
+
+    @patch(PATCH_CALL_SERVICE)
+    def test_service_error(self, mock_service_cls, client_as_member):
+        mock_service_cls.return_value.get_facets.side_effect = HTTPException(
+            status_code=500, detail="DB error"
+        )
+        resp = client_as_member.post("/api/v1/call-log/facets", json={})
+        assert resp.status_code in (500, 422, 400)
+
+
+# ---------------------------------------------------------------------------
 # GET /api/v1/call-log/{call_id}
 # ---------------------------------------------------------------------------
 

--- a/test-cases/ee/test_call_logs.py
+++ b/test-cases/ee/test_call_logs.py
@@ -106,6 +106,68 @@ class TestListCallLogs:
         assert response.status_code in (401, 403)
 
 
+# --- POST /api/v1/call-log/facets ---
+
+class TestGetFacets:
+    """Tests for POST /api/v1/call-log/facets (faceted filter counts)."""
+
+    def test_facets_success_empty_body(self, client_as_member):
+        """Empty body returns a dict of facet -> [{value, count}] lists."""
+        response = client_as_member.post("/api/v1/call-log/facets", json={})
+        assert response.status_code == 200
+        data = response.json()
+        # Every faceted field is present, each mapping to a list.
+        for field in (
+            "status", "agent_name", "direction", "channel_type",
+            "llm_model", "stt_model", "tts_model",
+        ):
+            assert field in data
+            assert isinstance(data[field], list)
+
+    def test_facets_status_is_fixed_enum(self, client_as_member):
+        """Status facet always emits the three derived states (even at zero)."""
+        response = client_as_member.post("/api/v1/call-log/facets", json={})
+        assert response.status_code == 200
+        status = {row["value"]: row["count"] for row in response.json()["status"]}
+        assert set(status.keys()) == {"completed", "in_progress", "failed"}
+        assert all(isinstance(c, int) and c >= 0 for c in status.values())
+
+    def test_facets_with_date_range(self, client_as_member):
+        response = client_as_member.post("/api/v1/call-log/facets", json={
+            "start_date_time": "2026-01-01T00:00:00",
+            "end_date_time": "2026-12-31T23:59:59",
+        })
+        assert response.status_code == 200
+
+    def test_facets_excludes_own_field(self, client_as_member):
+        """A status selection must not collapse the status facet's own counts.
+
+        With status filtered to 'completed', the status facet should still
+        report all three states (its own field is excluded from its counts),
+        while remaining a valid response.
+        """
+        response = client_as_member.post("/api/v1/call-log/facets", json={
+            "filters": [
+                {"field": "status", "operator": "in", "value": ["completed"]},
+            ],
+        })
+        assert response.status_code == 200
+        status = {row["value"] for row in response.json()["status"]}
+        assert status == {"completed", "in_progress", "failed"}
+
+    def test_facets_value_rows_shape(self, client_as_member):
+        """Each non-status facet row is {value: str, count: int}."""
+        response = client_as_member.post("/api/v1/call-log/facets", json={})
+        assert response.status_code == 200
+        for row in response.json()["agent_name"]:
+            assert set(row.keys()) == {"value", "count"}
+            assert isinstance(row["count"], int)
+
+    def test_unauthenticated(self, client_unauthenticated):
+        response = client_unauthenticated.post("/api/v1/call-log/facets", json={})
+        assert response.status_code in (401, 403)
+
+
 # --- GET /api/v1/call-log/{call_id} ---
 
 class TestGetCallLogById:


### PR DESCRIPTION
…r (#437)

* Split monolithic AgentFactoryService into layered pipeline package (#378) (#383)

* Split monolithic AgentFactoryService into layered pipeline package

Extract the voice pipeline out of the 1700-line AgentFactoryService into a 3-layer core/services/pipeline/ package (params -> builder -> runner, each a framework-agnostic base + Pipecat child), with service_resolver (the only DB access) and service_factory (pure construction). AgentFactoryService is kept as a thin back-compat facade; BotRunnerService is renamed to AgentRunnerService with reusable agent-lookup helpers. Wires bot.py and the telephony routers to the new engine registry.


(cherry picked from commit 89ca9b4f53b6150d846da4acbe994434324b2e46)

* Port call_engines telephony voice fixes onto the new pipeline design

Re-wire the three telephony-resilience processors that Parandhama added in the call_engines/pipeline_builders work (and that adopting 89ca9b4's pipeline package left orphaned) into PipecatPipelineBuilder, keeping the new design's Smart Turn as the primary turn detector:

- VADSpeakingTimeoutProcessor(8s) before STT: caps a stuck Silero VAD "speaking" segment on phone-line noise so segmented STTs flush.
- DuplicateTranscriptionFilter after STT: drops repeated final transcripts that otherwise trigger a duplicate LLM response (the turn-stop race).
- TranscriptionTimeoutUserTurnStopStrategy(1.5s) added to the turn-stop list as a VAD-independent fallback alongside the Smart Turn analyzer.

The processor files already existed; only the wiring was lost. Provider coverage (service_factory) and transport VAD setup are unchanged.



* Refresh GitNexus index metadata in AGENTS.md and CLAUDE.md

Regenerated by `npx gitnexus analyze` after the pipeline refactor — updates symbol/relationship counts and the repo label.



* Remove typo'd venu/ entry from .gitignore

Drop the misspelled "venu/" ignore line (intended venv/, already covered).



* Address PR review on pipeline revamp

- Restore configurable BOT_DISPLAY_NAME for Daily transport (was hardcoded)
- Revert no-agent fallback LLM to gpt-4o-mini
- Re-apply current-date preamble at build time (fresh per call, applies to both in-process and subprocess paths) via PipelineParams.messages_with_date_anchor()
- Extract shared core/utils/telephony.provider_call_id(), de-duplicating the call_id/call_control_id/stream_id logic across bot.py, bot_worker.py, and the runner



* chore: refresh GitNexus index counts in AGENTS.md / CLAUDE.md



* Address pipeline-revamp PR review + add transport package

- Introduce core/services/transport package (CallTransport / TelephonyProvider registry) replacing the isinstance chain in bot()
- service_factory: convert leftover TTS print() debug to logger.debug; create aiohttp sessions lazily per HTTP provider and close them on failure paths (fixes "Unclosed client session" leak on import/init failure)
- runner: assemble call metrics via one helper so the fallback completion path persists user_bot_latency + turns like on_audio_data
- DRY: make telephony_credentials.channel_config the single channel-decryption path; AgentRunnerService and service_resolver now delegate to it



* Merge origin/dev into feature/staging/agent-pipeline-revamp

Resolve modify/delete conflicts in favor of this branch's pipeline revamp:
- Keep deletion of core/services/agent_runtime_resolver.py and core/services/pipeline_builders/ (replaced by core/services/pipeline/). dev's versions were resurrected by the merge but import pipeline_builders modules that no longer exist and nothing references them at runtime.
- Take dev's model meta_data_schema feature (models/seed/services/frontend), alembic migrations, and dev tooling as-is (clean merge).



* fix: S2S Gemini system_instruction + STT init error handling

- service_resolver: set both system_prompt and system_instruction for S2S agents so Gemini Live (reads system_instruction) gets its prompt, not just OpenAI Realtime (reads system_prompt).
- service_factory: build_stt now catches broad Exception (log + return None), matching build_llm/build_tts, so a non-import STT init failure degrades gracefully instead of crashing the pipeline build.



---------



* Version-stamped agent pipeline cache with DB-free rebuild + Grafana call logs (#388) (#391)

* Split monolithic AgentFactoryService into layered pipeline package (#378) (#383)

* Split monolithic AgentFactoryService into layered pipeline package

Extract the voice pipeline out of the 1700-line AgentFactoryService into a 3-layer core/services/pipeline/ package (params -> builder -> runner, each a framework-agnostic base + Pipecat child), with service_resolver (the only DB access) and service_factory (pure construction). AgentFactoryService is kept as a thin back-compat facade; BotRunnerService is renamed to AgentRunnerService with reusable agent-lookup helpers. Wires bot.py and the telephony routers to the new engine registry.


(cherry picked from commit 89ca9b4f53b6150d846da4acbe994434324b2e46)

* Port call_engines telephony voice fixes onto the new pipeline design

Re-wire the three telephony-resilience processors that Parandhama added in the call_engines/pipeline_builders work (and that adopting 89ca9b4's pipeline package left orphaned) into PipecatPipelineBuilder, keeping the new design's Smart Turn as the primary turn detector:

- VADSpeakingTimeoutProcessor(8s) before STT: caps a stuck Silero VAD "speaking" segment on phone-line noise so segmented STTs flush.
- DuplicateTranscriptionFilter after STT: drops repeated final transcripts that otherwise trigger a duplicate LLM response (the turn-stop race).
- TranscriptionTimeoutUserTurnStopStrategy(1.5s) added to the turn-stop list as a VAD-independent fallback alongside the Smart Turn analyzer.

The processor files already existed; only the wiring was lost. Provider coverage (service_factory) and transport VAD setup are unchanged.



* Refresh GitNexus index metadata in AGENTS.md and CLAUDE.md

Regenerated by `npx gitnexus analyze` after the pipeline refactor — updates symbol/relationship counts and the repo label.



* Remove typo'd venu/ entry from .gitignore

Drop the misspelled "venu/" ignore line (intended venv/, already covered).



* Address PR review on pipeline revamp

- Restore configurable BOT_DISPLAY_NAME for Daily transport (was hardcoded)
- Revert no-agent fallback LLM to gpt-4o-mini
- Re-apply current-date preamble at build time (fresh per call, applies to both in-process and subprocess paths) via PipelineParams.messages_with_date_anchor()
- Extract shared core/utils/telephony.provider_call_id(), de-duplicating the call_id/call_control_id/stream_id logic across bot.py, bot_worker.py, and the runner



* chore: refresh GitNexus index counts in AGENTS.md / CLAUDE.md



* Address pipeline-revamp PR review + add transport package

- Introduce core/services/transport package (CallTransport / TelephonyProvider registry) replacing the isinstance chain in bot()
- service_factory: convert leftover TTS print() debug to logger.debug; create aiohttp sessions lazily per HTTP provider and close them on failure paths (fixes "Unclosed client session" leak on import/init failure)
- runner: assemble call metrics via one helper so the fallback completion path persists user_bot_latency + turns like on_audio_data
- DRY: make telephony_credentials.channel_config the single channel-decryption path; AgentRunnerService and service_resolver now delegate to it



* Merge origin/dev into feature/staging/agent-pipeline-revamp

Resolve modify/delete conflicts in favor of this branch's pipeline revamp:
- Keep deletion of core/services/agent_runtime_resolver.py and core/services/pipeline_builders/ (replaced by core/services/pipeline/). dev's versions were resurrected by the merge but import pipeline_builders modules that no longer exist and nothing references them at runtime.
- Take dev's model meta_data_schema feature (models/seed/services/frontend), alembic migrations, and dev tooling as-is (clean merge).



* fix: S2S Gemini system_instruction + STT init error handling

- service_resolver: set both system_prompt and system_instruction for S2S agents so Gemini Live (reads system_instruction) gets its prompt, not just OpenAI Realtime (reads system_prompt).
- service_factory: build_stt now catches broad Exception (log + return None), matching build_llm/build_tts, so a non-import STT init failure degrades gracefully instead of crashing the pipeline build.



---------



* Version-stamped agent pipeline cache with DB-free tool/KB rebuild

Replace transport-keyed, TTL-based pipeline caching with a single transport-independent key guarded by a recomputed version stamp, so a call never runs on stale config. Serialize tools/KB into the cached payload so the builder rebuilds handlers without per-call DB queries (MCP stays live). Invalidate the phone->agent cache on number remapping.

Add a shared _config_service_ids helper so the spec builder and the cache stamp extract provider/model/voice ids from one place, and fold a PAYLOAD_FORMAT_VERSION into the stamp so a payload-shape change on deploy invalidates persisted (now TTL-less) entries.



* feat(call-logs): expose trace_id for Grafana Loki per-call logs

Surface call.trace_id in the call detail payload and CallLogRow type, and add environment-configurable Grafana base URL and Loki app label constants so Call History can deep-link to per-call logs.



* feat(call-history): add Grafana Loki logs link per call

Add a "View logs" action in the Quick View column that opens the call's logs in Grafana Loki, filtered by the call's trace_id with the time window derived from the call's start/end. Disabled for calls with no trace_id. Completes the trace_id exposure from 0d2841c.



* feat(call-history): hide Grafana logs button when not configured

Drop the staging defaults for the Grafana env vars and hide the "View logs" button entirely unless both NEXT_PUBLIC_GRAFANA_BASE_URL and NEXT_PUBLIC_GRAFANA_LOG_APP are set. buildGrafanaLogsUrl now also returns null when either is missing so it never builds a broken URL.



---------





* Version-stamped agent pipeline cache with DB-free rebuild (#393)

* Version-stamped agent pipeline cache with DB-free rebuild + Grafana call logs (#388)

* Split monolithic AgentFactoryService into layered pipeline package (#378) (#383)

* Split monolithic AgentFactoryService into layered pipeline package

Extract the voice pipeline out of the 1700-line AgentFactoryService into a 3-layer core/services/pipeline/ package (params -> builder -> runner, each a framework-agnostic base + Pipecat child), with service_resolver (the only DB access) and service_factory (pure construction). AgentFactoryService is kept as a thin back-compat facade; BotRunnerService is renamed to AgentRunnerService with reusable agent-lookup helpers. Wires bot.py and the telephony routers to the new engine registry.


(cherry picked from commit 89ca9b4f53b6150d846da4acbe994434324b2e46)

* Port call_engines telephony voice fixes onto the new pipeline design

Re-wire the three telephony-resilience processors that Parandhama added in the call_engines/pipeline_builders work (and that adopting 89ca9b4's pipeline package left orphaned) into PipecatPipelineBuilder, keeping the new design's Smart Turn as the primary turn detector:

- VADSpeakingTimeoutProcessor(8s) before STT: caps a stuck Silero VAD "speaking" segment on phone-line noise so segmented STTs flush.
- DuplicateTranscriptionFilter after STT: drops repeated final transcripts that otherwise trigger a duplicate LLM response (the turn-stop race).
- TranscriptionTimeoutUserTurnStopStrategy(1.5s) added to the turn-stop list as a VAD-independent fallback alongside the Smart Turn analyzer.

The processor files already existed; only the wiring was lost. Provider coverage (service_factory) and transport VAD setup are unchanged.



* Refresh GitNexus index metadata in AGENTS.md and CLAUDE.md

Regenerated by `npx gitnexus analyze` after the pipeline refactor — updates symbol/relationship counts and the repo label.



* Remove typo'd venu/ entry from .gitignore

Drop the misspelled "venu/" ignore line (intended venv/, already covered).



* Address PR review on pipeline revamp

- Restore configurable BOT_DISPLAY_NAME for Daily transport (was hardcoded)
- Revert no-agent fallback LLM to gpt-4o-mini
- Re-apply current-date preamble at build time (fresh per call, applies to both in-process and subprocess paths) via PipelineParams.messages_with_date_anchor()
- Extract shared core/utils/telephony.provider_call_id(), de-duplicating the call_id/call_control_id/stream_id logic across bot.py, bot_worker.py, and the runner



* chore: refresh GitNexus index counts in AGENTS.md / CLAUDE.md



* Address pipeline-revamp PR review + add transport package

- Introduce core/services/transport package (CallTransport / TelephonyProvider registry) replacing the isinstance chain in bot()
- service_factory: convert leftover TTS print() debug to logger.debug; create aiohttp sessions lazily per HTTP provider and close them on failure paths (fixes "Unclosed client session" leak on import/init failure)
- runner: assemble call metrics via one helper so the fallback completion path persists user_bot_latency + turns like on_audio_data
- DRY: make telephony_credentials.channel_config the single channel-decryption path; AgentRunnerService and service_resolver now delegate to it



* Merge origin/dev into feature/staging/agent-pipeline-revamp

Resolve modify/delete conflicts in favor of this branch's pipeline revamp:
- Keep deletion of core/services/agent_runtime_resolver.py and core/services/pipeline_builders/ (replaced by core/services/pipeline/). dev's versions were resurrected by the merge but import pipeline_builders modules that no longer exist and nothing references them at runtime.
- Take dev's model meta_data_schema feature (models/seed/services/frontend), alembic migrations, and dev tooling as-is (clean merge).



* fix: S2S Gemini system_instruction + STT init error handling

- service_resolver: set both system_prompt and system_instruction for S2S agents so Gemini Live (reads system_instruction) gets its prompt, not just OpenAI Realtime (reads system_prompt).
- service_factory: build_stt now catches broad Exception (log + return None), matching build_llm/build_tts, so a non-import STT init failure degrades gracefully instead of crashing the pipeline build.



---------



* Version-stamped agent pipeline cache with DB-free tool/KB rebuild

Replace transport-keyed, TTL-based pipeline caching with a single transport-independent key guarded by a recomputed version stamp, so a call never runs on stale config. Serialize tools/KB into the cached payload so the builder rebuilds handlers without per-call DB queries (MCP stays live). Invalidate the phone->agent cache on number remapping.

Add a shared _config_service_ids helper so the spec builder and the cache stamp extract provider/model/voice ids from one place, and fold a PAYLOAD_FORMAT_VERSION into the stamp so a payload-shape change on deploy invalidates persisted (now TTL-less) entries.



* feat(call-logs): expose trace_id for Grafana Loki per-call logs

Surface call.trace_id in the call detail payload and CallLogRow type, and add environment-configurable Grafana base URL and Loki app label constants so Call History can deep-link to per-call logs.



* feat(call-history): add Grafana Loki logs link per call

Add a "View logs" action in the Quick View column that opens the call's logs in Grafana Loki, filtered by the call's trace_id with the time window derived from the call's start/end. Disabled for calls with no trace_id. Completes the trace_id exposure from 0d2841c.



* feat(call-history): hide Grafana logs button when not configured

Drop the staging defaults for the Grafana env vars and hide the "View logs" button entirely unless both NEXT_PUBLIC_GRAFANA_BASE_URL and NEXT_PUBLIC_GRAFANA_LOG_APP are set. buildGrafanaLogsUrl now also returns null when either is missing so it never builds a broken URL.



---------





* Feature/staging/cache key sync agent data (#392)

* Split monolithic AgentFactoryService into layered pipeline package (#378) (#383)

* Split monolithic AgentFactoryService into layered pipeline package

Extract the voice pipeline out of the 1700-line AgentFactoryService into a 3-layer core/services/pipeline/ package (params -> builder -> runner, each a framework-agnostic base + Pipecat child), with service_resolver (the only DB access) and service_factory (pure construction). AgentFactoryService is kept as a thin back-compat facade; BotRunnerService is renamed to AgentRunnerService with reusable agent-lookup helpers. Wires bot.py and the telephony routers to the new engine registry.


(cherry picked from commit 89ca9b4f53b6150d846da4acbe994434324b2e46)

* Port call_engines telephony voice fixes onto the new pipeline design

Re-wire the three telephony-resilience processors that Parandhama added in the call_engines/pipeline_builders work (and that adopting 89ca9b4's pipeline package left orphaned) into PipecatPipelineBuilder, keeping the new design's Smart Turn as the primary turn detector:

- VADSpeakingTimeoutProcessor(8s) before STT: caps a stuck Silero VAD "speaking" segment on phone-line noise so segmented STTs flush.
- DuplicateTranscriptionFilter after STT: drops repeated final transcripts that otherwise trigger a duplicate LLM response (the turn-stop race).
- TranscriptionTimeoutUserTurnStopStrategy(1.5s) added to the turn-stop list as a VAD-independent fallback alongside the Smart Turn analyzer.

The processor files already existed; only the wiring was lost. Provider coverage (service_factory) and transport VAD setup are unchanged.



* Refresh GitNexus index metadata in AGENTS.md and CLAUDE.md

Regenerated by `npx gitnexus analyze` after the pipeline refactor — updates symbol/relationship counts and the repo label.



* Remove typo'd venu/ entry from .gitignore

Drop the misspelled "venu/" ignore line (intended venv/, already covered).



* Address PR review on pipeline revamp

- Restore configurable BOT_DISPLAY_NAME for Daily transport (was hardcoded)
- Revert no-agent fallback LLM to gpt-4o-mini
- Re-apply current-date preamble at build time (fresh per call, applies to both in-process and subprocess paths) via PipelineParams.messages_with_date_anchor()
- Extract shared core/utils/telephony.provider_call_id(), de-duplicating the call_id/call_control_id/stream_id logic across bot.py, bot_worker.py, and the runner



* chore: refresh GitNexus index counts in AGENTS.md / CLAUDE.md



* Address pipeline-revamp PR review + add transport package

- Introduce core/services/transport package (CallTransport / TelephonyProvider registry) replacing the isinstance chain in bot()
- service_factory: convert leftover TTS print() debug to logger.debug; create aiohttp sessions lazily per HTTP provider and close them on failure paths (fixes "Unclosed client session" leak on import/init failure)
- runner: assemble call metrics via one helper so the fallback completion path persists user_bot_latency + turns like on_audio_data
- DRY: make telephony_credentials.channel_config the single channel-decryption path; AgentRunnerService and service_resolver now delegate to it



* Merge origin/dev into feature/staging/agent-pipeline-revamp

Resolve modify/delete conflicts in favor of this branch's pipeline revamp:
- Keep deletion of core/services/agent_runtime_resolver.py and core/services/pipeline_builders/ (replaced by core/services/pipeline/). dev's versions were resurrected by the merge but import pipeline_builders modules that no longer exist and nothing references them at runtime.
- Take dev's model meta_data_schema feature (models/seed/services/frontend), alembic migrations, and dev tooling as-is (clean merge).



* fix: S2S Gemini system_instruction + STT init error handling

- service_resolver: set both system_prompt and system_instruction for S2S agents so Gemini Live (reads system_instruction) gets its prompt, not just OpenAI Realtime (reads system_prompt).
- service_factory: build_stt now catches broad Exception (log + return None), matching build_llm/build_tts, so a non-import STT init failure degrades gracefully instead of crashing the pipeline build.



---------



* Version-stamped agent pipeline cache with DB-free tool/KB rebuild

Replace transport-keyed, TTL-based pipeline caching with a single transport-independent key guarded by a recomputed version stamp, so a call never runs on stale config. Serialize tools/KB into the cached payload so the builder rebuilds handlers without per-call DB queries (MCP stays live). Invalidate the phone->agent cache on number remapping.

Add a shared _config_service_ids helper so the spec builder and the cache stamp extract provider/model/voice ids from one place, and fold a PAYLOAD_FORMAT_VERSION into the stamp so a payload-shape change on deploy invalidates persisted (now TTL-less) entries.



* feat(call-logs): expose trace_id for Grafana Loki per-call logs

Surface call.trace_id in the call detail payload and CallLogRow type, and add environment-configurable Grafana base URL and Loki app label constants so Call History can deep-link to per-call logs.



* feat(call-history): add Grafana Loki logs link per call

Add a "View logs" action in the Quick View column that opens the call's logs in Grafana Loki, filtered by the call's trace_id with the time window derived from the call's start/end. Disabled for calls with no trace_id. Completes the trace_id exposure from 0d2841c.



* feat(call-history): hide Grafana logs button when not configured

Drop the staging defaults for the Grafana env vars and hide the "View logs" button entirely unless both NEXT_PUBLIC_GRAFANA_BASE_URL and NEXT_PUBLIC_GRAFANA_LOG_APP are set. buildGrafanaLogsUrl now also returns null when either is missing so it never builds a broken URL.



---------





---------





* fix(dashboard): stop /dashboard/stats 500 and show stats loader (#431) (#432)

* Split monolithic AgentFactoryService into layered pipeline package (#378) (#383)

* Split monolithic AgentFactoryService into layered pipeline package

Extract the voice pipeline out of the 1700-line AgentFactoryService into a 3-layer core/services/pipeline/ package (params -> builder -> runner, each a framework-agnostic base + Pipecat child), with service_resolver (the only DB access) and service_factory (pure construction). AgentFactoryService is kept as a thin back-compat facade; BotRunnerService is renamed to AgentRunnerService with reusable agent-lookup helpers. Wires bot.py and the telephony routers to the new engine registry.


(cherry picked from commit 89ca9b4f53b6150d846da4acbe994434324b2e46)

* Port call_engines telephony voice fixes onto the new pipeline design

Re-wire the three telephony-resilience processors that Parandhama added in the call_engines/pipeline_builders work (and that adopting 89ca9b4's pipeline package left orphaned) into PipecatPipelineBuilder, keeping the new design's Smart Turn as the primary turn detector:

- VADSpeakingTimeoutProcessor(8s) before STT: caps a stuck Silero VAD "speaking" segment on phone-line noise so segmented STTs flush.
- DuplicateTranscriptionFilter after STT: drops repeated final transcripts that otherwise trigger a duplicate LLM response (the turn-stop race).
- TranscriptionTimeoutUserTurnStopStrategy(1.5s) added to the turn-stop list as a VAD-independent fallback alongside the Smart Turn analyzer.

The processor files already existed; only the wiring was lost. Provider coverage (service_factory) and transport VAD setup are unchanged.



* Refresh GitNexus index metadata in AGENTS.md and CLAUDE.md

Regenerated by `npx gitnexus analyze` after the pipeline refactor — updates symbol/relationship counts and the repo label.



* Remove typo'd venu/ entry from .gitignore

Drop the misspelled "venu/" ignore line (intended venv/, already covered).



* Address PR review on pipeline revamp

- Restore configurable BOT_DISPLAY_NAME for Daily transport (was hardcoded)
- Revert no-agent fallback LLM to gpt-4o-mini
- Re-apply current-date preamble at build time (fresh per call, applies to both in-process and subprocess paths) via PipelineParams.messages_with_date_anchor()
- Extract shared core/utils/telephony.provider_call_id(), de-duplicating the call_id/call_control_id/stream_id logic across bot.py, bot_worker.py, and the runner



* chore: refresh GitNexus index counts in AGENTS.md / CLAUDE.md



* Address pipeline-revamp PR review + add transport package

- Introduce core/services/transport package (CallTransport / TelephonyProvider registry) replacing the isinstance chain in bot()
- service_factory: convert leftover TTS print() debug to logger.debug; create aiohttp sessions lazily per HTTP provider and close them on failure paths (fixes "Unclosed client session" leak on import/init failure)
- runner: assemble call metrics via one helper so the fallback completion path persists user_bot_latency + turns like on_audio_data
- DRY: make telephony_credentials.channel_config the single channel-decryption path; AgentRunnerService and service_resolver now delegate to it



* Merge origin/dev into feature/staging/agent-pipeline-revamp

Resolve modify/delete conflicts in favor of this branch's pipeline revamp:
- Keep deletion of core/services/agent_runtime_resolver.py and core/services/pipeline_builders/ (replaced by core/services/pipeline/). dev's versions were resurrected by the merge but import pipeline_builders modules that no longer exist and nothing references them at runtime.
- Take dev's model meta_data_schema feature (models/seed/services/frontend), alembic migrations, and dev tooling as-is (clean merge).



* fix: S2S Gemini system_instruction + STT init error handling

- service_resolver: set both system_prompt and system_instruction for S2S agents so Gemini Live (reads system_instruction) gets its prompt, not just OpenAI Realtime (reads system_prompt).
- service_factory: build_stt now catches broad Exception (log + return None), matching build_llm/build_tts, so a non-import STT init failure degrades gracefully instead of crashing the pipeline build.



---------



* Version-stamped agent pipeline cache with DB-free rebuild + Grafana call logs (#388) (#391)

* Split monolithic AgentFactoryService into layered pipeline package (#378) (#383)

* Split monolithic AgentFactoryService into layered pipeline package

Extract the voice pipeline out of the 1700-line AgentFactoryService into a 3-layer core/services/pipeline/ package (params -> builder -> runner, each a framework-agnostic base + Pipecat child), with service_resolver (the only DB access) and service_factory (pure construction). AgentFactoryService is kept as a thin back-compat facade; BotRunnerService is renamed to AgentRunnerService with reusable agent-lookup helpers. Wires bot.py and the telephony routers to the new engine registry.


(cherry picked from commit 89ca9b4f53b6150d846da4acbe994434324b2e46)

* Port call_engines telephony voice fixes onto the new pipeline design

Re-wire the three telephony-resilience processors that Parandhama added in the call_engines/pipeline_builders work (and that adopting 89ca9b4's pipeline package left orphaned) into PipecatPipelineBuilder, keeping the new design's Smart Turn as the primary turn detector:

- VADSpeakingTimeoutProcessor(8s) before STT: caps a stuck Silero VAD "speaking" segment on phone-line noise so segmented STTs flush.
- DuplicateTranscriptionFilter after STT: drops repeated final transcripts that otherwise trigger a duplicate LLM response (the turn-stop race).
- TranscriptionTimeoutUserTurnStopStrategy(1.5s) added to the turn-stop list as a VAD-independent fallback alongside the Smart Turn analyzer.

The processor files already existed; only the wiring was lost. Provider coverage (service_factory) and transport VAD setup are unchanged.



* Refresh GitNexus index metadata in AGENTS.md and CLAUDE.md

Regenerated by `npx gitnexus analyze` after the pipeline refactor — updates symbol/relationship counts and the repo label.



* Remove typo'd venu/ entry from .gitignore

Drop the misspelled "venu/" ignore line (intended venv/, already covered).



* Address PR review on pipeline revamp

- Restore configurable BOT_DISPLAY_NAME for Daily transport (was hardcoded)
- Revert no-agent fallback LLM to gpt-4o-mini
- Re-apply current-date preamble at build time (fresh per call, applies to both in-process and subprocess paths) via PipelineParams.messages_with_date_anchor()
- Extract shared core/utils/telephony.provider_call_id(), de-duplicating the call_id/call_control_id/stream_id logic across bot.py, bot_worker.py, and the runner



* chore: refresh GitNexus index counts in AGENTS.md / CLAUDE.md



* Address pipeline-revamp PR review + add transport package

- Introduce core/services/transport package (CallTransport / TelephonyProvider registry) replacing the isinstance chain in bot()
- service_factory: convert leftover TTS print() debug to logger.debug; create aiohttp sessions lazily per HTTP provider and close them on failure paths (fixes "Unclosed client session" leak on import/init failure)
- runner: assemble call metrics via one helper so the fallback completion path persists user_bot_latency + turns like on_audio_data
- DRY: make telephony_credentials.channel_config the single channel-decryption path; AgentRunnerService and service_resolver now delegate to it



* Merge origin/dev into feature/staging/agent-pipeline-revamp

Resolve modify/delete conflicts in favor of this branch's pipeline revamp:
- Keep deletion of core/services/agent_runtime_resolver.py and core/services/pipeline_builders/ (replaced by core/services/pipeline/). dev's versions were resurrected by the merge but import pipeline_builders modules that no longer exist and nothing references them at runtime.
- Take dev's model meta_data_schema feature (models/seed/services/frontend), alembic migrations, and dev tooling as-is (clean merge).



* fix: S2S Gemini system_instruction + STT init error handling

- service_resolver: set both system_prompt and system_instruction for S2S agents so Gemini Live (reads system_instruction) gets its prompt, not just OpenAI Realtime (reads system_prompt).
- service_factory: build_stt now catches broad Exception (log + return None), matching build_llm/build_tts, so a non-import STT init failure degrades gracefully instead of crashing the pipeline build.



---------



* Version-stamped agent pipeline cache with DB-free tool/KB rebuild

Replace transport-keyed, TTL-based pipeline caching with a single transport-independent key guarded by a recomputed version stamp, so a call never runs on stale config. Serialize tools/KB into the cached payload so the builder rebuilds handlers without per-call DB queries (MCP stays live). Invalidate the phone->agent cache on number remapping.

Add a shared _config_service_ids helper so the spec builder and the cache stamp extract provider/model/voice ids from one place, and fold a PAYLOAD_FORMAT_VERSION into the stamp so a payload-shape change on deploy invalidates persisted (now TTL-less) entries.



* feat(call-logs): expose trace_id for Grafana Loki per-call logs

Surface call.trace_id in the call detail payload and CallLogRow type, and add environment-configurable Grafana base URL and Loki app label constants so Call History can deep-link to per-call logs.



* feat(call-history): add Grafana Loki logs link per call

Add a "View logs" action in the Quick View column that opens the call's logs in Grafana Loki, filtered by the call's trace_id with the time window derived from the call's start/end. Disabled for calls with no trace_id. Completes the trace_id exposure from 0d2841c.



* feat(call-history): hide Grafana logs button when not configured

Drop the staging defaults for the Grafana env vars and hide the "View logs" button entirely unless both NEXT_PUBLIC_GRAFANA_BASE_URL and NEXT_PUBLIC_GRAFANA_LOG_APP are set. buildGrafanaLogsUrl now also returns null when either is missing so it never builds a broken URL.



---------





* Version-stamped agent pipeline cache with DB-free rebuild (#393)

* Version-stamped agent pipeline cache with DB-free rebuild + Grafana call logs (#388)

* Split monolithic AgentFactoryService into layered pipeline package (#378) (#383)

* Split monolithic AgentFactoryService into layered pipeline package

Extract the voice pipeline out of the 1700-line AgentFactoryService into a 3-layer core/services/pipeline/ package (params -> builder -> runner, each a framework-agnostic base + Pipecat child), with service_resolver (the only DB access) and service_factory (pure construction). AgentFactoryService is kept as a thin back-compat facade; BotRunnerService is renamed to AgentRunnerService with reusable agent-lookup helpers. Wires bot.py and the telephony routers to the new engine registry.


(cherry picked from commit 89ca9b4f53b6150d846da4acbe994434324b2e46)

* Port call_engines telephony voice fixes onto the new pipeline design

Re-wire the three telephony-resilience processors that Parandhama added in the call_engines/pipeline_builders work (and that adopting 89ca9b4's pipeline package left orphaned) into PipecatPipelineBuilder, keeping the new design's Smart Turn as the primary turn detector:

- VADSpeakingTimeoutProcessor(8s) before STT: caps a stuck Silero VAD "speaking" segment on phone-line noise so segmented STTs flush.
- DuplicateTranscriptionFilter after STT: drops repeated final transcripts that otherwise trigger a duplicate LLM response (the turn-stop race).
- TranscriptionTimeoutUserTurnStopStrategy(1.5s) added to the turn-stop list as a VAD-independent fallback alongside the Smart Turn analyzer.

The processor files already existed; only the wiring was lost. Provider coverage (service_factory) and transport VAD setup are unchanged.



* Refresh GitNexus index metadata in AGENTS.md and CLAUDE.md

Regenerated by `npx gitnexus analyze` after the pipeline refactor — updates symbol/relationship counts and the repo label.



* Remove typo'd venu/ entry from .gitignore

Drop the misspelled "venu/" ignore line (intended venv/, already covered).



* Address PR review on pipeline revamp

- Restore configurable BOT_DISPLAY_NAME for Daily transport (was hardcoded)
- Revert no-agent fallback LLM to gpt-4o-mini
- Re-apply current-date preamble at build time (fresh per call, applies to both in-process and subprocess paths) via PipelineParams.messages_with_date_anchor()
- Extract shared core/utils/telephony.provider_call_id(), de-duplicating the call_id/call_control_id/stream_id logic across bot.py, bot_worker.py, and the runner



* chore: refresh GitNexus index counts in AGENTS.md / CLAUDE.md



* Address pipeline-revamp PR review + add transport package

- Introduce core/services/transport package (CallTransport / TelephonyProvider registry) replacing the isinstance chain in bot()
- service_factory: convert leftover TTS print() debug to logger.debug; create aiohttp sessions lazily per HTTP provider and close them on failure paths (fixes "Unclosed client session" leak on import/init failure)
- runner: assemble call metrics via one helper so the fallback completion path persists user_bot_latency + turns like on_audio_data
- DRY: make telephony_credentials.channel_config the single channel-decryption path; AgentRunnerService and service_resolver now delegate to it



* Merge origin/dev into feature/staging/agent-pipeline-revamp

Resolve modify/delete conflicts in favor of this branch's pipeline revamp:
- Keep deletion of core/services/agent_runtime_resolver.py and core/services/pipeline_builders/ (replaced by core/services/pipeline/). dev's versions were resurrected by the merge but import pipeline_builders modules that no longer exist and nothing references them at runtime.
- Take dev's model meta_data_schema feature (models/seed/services/frontend), alembic migrations, and dev tooling as-is (clean merge).



* fix: S2S Gemini system_instruction + STT init error handling

- service_resolver: set both system_prompt and system_instruction for S2S agents so Gemini Live (reads system_instruction) gets its prompt, not just OpenAI Realtime (reads system_prompt).
- service_factory: build_stt now catches broad Exception (log + return None), matching build_llm/build_tts, so a non-import STT init failure degrades gracefully instead of crashing the pipeline build.



---------



* Version-stamped agent pipeline cache with DB-free tool/KB rebuild

Replace transport-keyed, TTL-based pipeline caching with a single transport-independent key guarded by a recomputed version stamp, so a call never runs on stale config. Serialize tools/KB into the cached payload so the builder rebuilds handlers without per-call DB queries (MCP stays live). Invalidate the phone->agent cache on number remapping.

Add a shared _config_service_ids helper so the spec builder and the cache stamp extract provider/model/voice ids from one place, and fold a PAYLOAD_FORMAT_VERSION into the stamp so a payload-shape change on deploy invalidates persisted (now TTL-less) entries.



* feat(call-logs): expose trace_id for Grafana Loki per-call logs

Surface call.trace_id in the call detail payload and CallLogRow type, and add environment-configurable Grafana base URL and Loki app label constants so Call History can deep-link to per-call logs.



* feat(call-history): add Grafana Loki logs link per call

Add a "View logs" action in the Quick View column that opens the call's logs in Grafana Loki, filtered by the call's trace_id with the time window derived from the call's start/end. Disabled for calls with no trace_id. Completes the trace_id exposure from 0d2841c.



* feat(call-history): hide Grafana logs button when not configured

Drop the staging defaults for the Grafana env vars and hide the "View logs" button entirely unless both NEXT_PUBLIC_GRAFANA_BASE_URL and NEXT_PUBLIC_GRAFANA_LOG_APP are set. buildGrafanaLogsUrl now also returns null when either is missing so it never builds a broken URL.



---------





* Feature/staging/cache key sync agent data (#392)

* Split monolithic AgentFactoryService into layered pipeline package (#378) (#383)

* Split monolithic AgentFactoryService into layered pipeline package

Extract the voice pipeline out of the 1700-line AgentFactoryService into a 3-layer core/services/pipeline/ package (params -> builder -> runner, each a framework-agnostic base + Pipecat child), with service_resolver (the only DB access) and service_factory (pure construction). AgentFactoryService is kept as a thin back-compat facade; BotRunnerService is renamed to AgentRunnerService with reusable agent-lookup helpers. Wires bot.py and the telephony routers to the new engine registry.


(cherry picked from commit 89ca9b4f53b6150d846da4acbe994434324b2e46)

* Port call_engines telephony voice fixes onto the new pipeline design

Re-wire the three telephony-resilience processors that Parandhama added in the call_engines/pipeline_builders work (and that adopting 89ca9b4's pipeline package left orphaned) into PipecatPipelineBuilder, keeping the new design's Smart Turn as the primary turn detector:

- VADSpeakingTimeoutProcessor(8s) before STT: caps a stuck Silero VAD "speaking" segment on phone-line noise so segmented STTs flush.
- DuplicateTranscriptionFilter after STT: drops repeated final transcripts that otherwise trigger a duplicate LLM response (the turn-stop race).
- TranscriptionTimeoutUserTurnStopStrategy(1.5s) added to the turn-stop list as a VAD-independent fallback alongside the Smart Turn analyzer.

The processor files already existed; only the wiring was lost. Provider coverage (service_factory) and transport VAD setup are unchanged.



* Refresh GitNexus index metadata in AGENTS.md and CLAUDE.md

Regenerated by `npx gitnexus analyze` after the pipeline refactor — updates symbol/relationship counts and the repo label.



* Remove typo'd venu/ entry from .gitignore

Drop the misspelled "venu/" ignore line (intended venv/, already covered).



* Address PR review on pipeline revamp

- Restore configurable BOT_DISPLAY_NAME for Daily transport (was hardcoded)
- Revert no-agent fallback LLM to gpt-4o-mini
- Re-apply current-date preamble at build time (fresh per call, applies to both in-process and subprocess paths) via PipelineParams.messages_with_date_anchor()
- Extract shared core/utils/telephony.provider_call_id(), de-duplicating the call_id/call_control_id/stream_id logic across bot.py, bot_worker.py, and the runner



* chore: refresh GitNexus index counts in AGENTS.md / CLAUDE.md



* Address pipeline-revamp PR review + add transport package

- Introduce core/services/transport package (CallTransport / TelephonyProvider registry) replacing the isinstance chain in bot()
- service_factory: convert leftover TTS print() debug to logger.debug; create aiohttp sessions lazily per HTTP provider and close them on failure paths (fixes "Unclosed client session" leak on import/init failure)
- runner: assemble call metrics via one helper so the fallback completion path persists user_bot_latency + turns like on_audio_data
- DRY: make telephony_credentials.channel_config the single channel-decryption path; AgentRunnerService and service_resolver now delegate to it



* Merge origin/dev into feature/staging/agent-pipeline-revamp

Resolve modify/delete conflicts in favor of this branch's pipeline revamp:
- Keep deletion of core/services/agent_runtime_resolver.py and core/services/pipeline_builders/ (replaced by core/services/pipeline/). dev's versions were resurrected by the merge but import pipeline_builders modules that no longer exist and nothing references them at runtime.
- Take dev's model meta_data_schema feature (models/seed/services/frontend), alembic migrations, and dev tooling as-is (clean merge).



* fix: S2S Gemini system_instruction + STT init error handling

- service_resolver: set both system_prompt and system_instruction for S2S agents so Gemini Live (reads system_instruction) gets its prompt, not just OpenAI Realtime (reads system_prompt).
- service_factory: build_stt now catches broad Exception (log + return None), matching build_llm/build_tts, so a non-import STT init failure degrades gracefully instead of crashing the pipeline build.



---------



* Version-stamped agent pipeline cache with DB-free tool/KB rebuild

Replace transport-keyed, TTL-based pipeline caching with a single transport-independent key guarded by a recomputed version stamp, so a call never runs on stale config. Serialize tools/KB into the cached payload so the builder rebuilds handlers without per-call DB queries (MCP stays live). Invalidate the phone->agent cache on number remapping.

Add a shared _config_service_ids helper so the spec builder and the cache stamp extract provider/model/voice ids from one place, and fold a PAYLOAD_FORMAT_VERSION into the stamp so a payload-shape change on deploy invalidates persisted (now TTL-less) entries.



* feat(call-logs): expose trace_id for Grafana Loki per-call logs

Surface call.trace_id in the call detail payload and CallLogRow type, and add environment-configurable Grafana base URL and Loki app label constants so Call History can deep-link to per-call logs.



* feat(call-history): add Grafana Loki logs link per call

Add a "View logs" action in the Quick View column that opens the call's logs in Grafana Loki, filtered by the call's trace_id with the time window derived from the call's start/end. Disabled for calls with no trace_id. Completes the trace_id exposure from 0d2841c.



* feat(call-history): hide Grafana logs button when not configured

Drop the staging defaults for the Grafana env vars and hide the "View logs" button entirely unless both NEXT_PUBLIC_GRAFANA_BASE_URL and NEXT_PUBLIC_GRAFANA_LOG_APP are set. buildGrafanaLogsUrl now also returns null when either is missing so it never builds a broken URL.



---------





---------





* fix(dashboard): stop 500 on /dashboard/stats + show loader while stats load

Backend: DashboardService.get_stats counted Call rows with Query.count(), which wraps a "SELECT <all Call columns>" subquery and references calls.pipeline_config — a model column absent from the live DB — causing "UndefinedColumn: column calls.pipeline_config does not exist". Switched the three counts to with_entities(func.count(Call.id)).scalar() (matching the existing total_seconds query) so only count(calls.id) is selected while tenant scoping is preserved.

Frontend: home stat cards now render a skeleton loader while the stats request is in flight instead of a static dash, falling back to "—" only when it resolves empty.



---------





* feat(call-history): add filterable call-history with faceted filter drawer

Frontend:
- New filter drawer (status, agent, direction, channel, LLM/STT/TTS models, turns, avg latency) plus a Vercel-style tokenized search bar and a shared, timezone-aware DateRangePicker + calendar.
- Live facet counts via POST /call-log/facets, kept in sync with the drawer and token search; column-visibility popover.

Backend:
- get_facets() returns per-value counts per facet field, excluding each facet's own selection (Vercel semantics); shared _apply_filters/_filter column map between list and facets.
- Extract _status_predicates() shared by the status filter and status facet counts; collapse the status facet to a single filtered-aggregate query; add Query type hints to _apply_filters.
- Fix migration down_revision to restore a linear chain.

Tests: cover POST /call-log/facets in core and ee.



---------