### PR TITLE
Add Vercel-style faceted filtering to Tools, MCP, KB, Agents & Model …

### DIFF
--- a/core/api/v1/agents.py
+++ b/core/api/v1/agents.py
@@ -4,22 +4,48 @@ from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, Query, status
 from pydantic import BaseModel, Field
-from sqlalchemy import or_
+from sqlalchemy import and_, case, exists, or_
 from sqlalchemy.orm import Session
 
+from core.api.v1.faceted_schemas import FacetsRequest
 from core.database.session import get_db
 from core.middleware.auth import JWTClaims, require_org_member
 from core.models.agent import Agent
 from core.models.channel import Channel
 from core.models.phone_number import PhoneNumber
 from core.services.agent_service import AgentService
-from core.services.crud import list_records
+from core.utils.faceted_query import apply_filters, apply_sort, build_facets, distinct_values
+from core.utils.list_params import resolve_sort
 from shared.config import settings
 
 router = APIRouter()
 
 
-ALLOWED_SORT_FIELDS = {"name", "agent_type", "is_active", "created_at", "updated_at"}
+AGENT_FACET_FIELDS = ["agent_type", "status"]
+
+
+def _agent_column_map(org_id: UUID) -> Dict[str, Any]:
+    # ``status`` mirrors the list UI, where an agent is "active" when it has at
+    # least one phone number attached. A CASE over an EXISTS subquery lets it
+    # flow through the generic faceted-query helpers as a string facet.
+    has_phone = exists().where(
+        and_(PhoneNumber.agent_id == Agent.id, PhoneNumber.organization_id == org_id)
+    )
+    return {
+        "name": Agent.name,
+        "agent_type": Agent.agent_type,
+        "status": case((has_phone, "active"), else_="inactive"),
+        "is_active": Agent.is_active,
+        "created_at": Agent.created_at,
+        "updated_at": Agent.updated_at,
+    }
+
+
+def _agent_base_query(db: Session, org_id: UUID):
+    """Org-scoped base query for agents (excludes soft-deleted rows)."""
+    return db.query(Agent).filter(
+        Agent.organization_id == org_id, Agent.deleted_at.is_(None)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -139,28 +165,29 @@ def list_agents_for_org(db: Session, org_id: UUID, body: dict) -> dict:
     page = max(int(body.get("page") or 1), 1)
     page_size = min(max(int(body.get("page_size") or 20), 1), 100)
     search = body.get("search")
-    sort_by = body.get("sort_by")
     is_active = body.get("is_active")
     agent_type = body.get("agent_type")
 
-    filters = []
+    column_map = _agent_column_map(org_id)
+    query = _agent_base_query(db, org_id)
+
+    # Named params (back-compat).
     if search:
         like = f"%{search}%"
-        filters.append(or_(Agent.name.ilike(like), Agent.description.ilike(like)))
+        query = query.filter(or_(Agent.name.ilike(like), Agent.description.ilike(like)))
     if is_active is not None:
-        filters.append(Agent.is_active == bool(is_active))
+        query = query.filter(Agent.is_active == bool(is_active))
     if agent_type:
-        filters.append(Agent.agent_type == agent_type)
+        query = query.filter(Agent.agent_type == agent_type)
 
-    order_by = Agent.updated_at.desc()
-    if sort_by:
-        desc = sort_by.startswith("-")
-        field_name = sort_by.lstrip("-")
-        if field_name in ALLOWED_SORT_FIELDS:
-            col = getattr(Agent, field_name)
-            order_by = col.desc() if desc else col.asc()
+    # Generic faceted filters + sort.
+    query = apply_filters(query, body.get("filters"), column_map)
+    total = query.count()
+    sort_by, sort_order = resolve_sort(body, "updated_at")
+    query = apply_sort(query, column_map, sort_by, sort_order, Agent.updated_at)
 
-    items, total = list_records(db, Agent, org_id, page, page_size, filters, order_by)
+    offset = (page - 1) * page_size
+    items = query.offset(offset).limit(page_size).all()
     phone_map = _phone_numbers_for(db, org_id, [a.id for a in items])
     return {
         "items": [_serialize_agent(a, phone_map) for a in items],
@@ -168,6 +195,23 @@ def list_agents_for_org(db: Session, org_id: UUID, body: dict) -> dict:
         "page": page,
         "page_size": page_size,
     }
+
+
+def agent_facets_for_org(db: Session, org_id: UUID, filters=None) -> dict:
+    """Per-value facet counts for the agent filter drawer."""
+    return build_facets(
+        lambda: _agent_base_query(db, org_id),
+        _agent_column_map(org_id),
+        AGENT_FACET_FIELDS,
+        filters,
+    )
+
+
+def agent_filter_values_for_org(db: Session, org_id: UUID, column_name: str) -> dict:
+    """Distinct values of a column for token-search autocomplete."""
+    column_map = _agent_column_map(org_id)
+    allowed = {k: column_map[k] for k in ("name", "agent_type", "status")}
+    return distinct_values(_agent_base_query(db, org_id), allowed, column_name)
 
 
 # ---------------------------------------------------------------------------
@@ -244,6 +288,27 @@ def list_agents(
 ):
     org_id = UUID(str(claims.org_id)) if claims.org_id else UUID(settings.DEFAULT_ORG_ID)
     return list_agents_for_org(db, org_id, body)
+
+
+@router.post("/facets")
+def get_agent_facets(
+    body: FacetsRequest,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    org_id = UUID(str(claims.org_id)) if claims.org_id else UUID(settings.DEFAULT_ORG_ID)
+    filters = [f.model_dump() for f in body.filters] if body.filters else None
+    return agent_facets_for_org(db, org_id, filters)
+
+
+@router.get("/filter-values")
+def get_agent_filter_values(
+    column_name: str = Query(...),
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    org_id = UUID(str(claims.org_id)) if claims.org_id else UUID(settings.DEFAULT_ORG_ID)
+    return agent_filter_values_for_org(db, org_id, column_name)
 
 
 # ---------------------------------------------------------------------------

--- a/core/api/v1/faceted_schemas.py
+++ b/core/api/v1/faceted_schemas.py
@@ -1,0 +1,20 @@
+"""Shared Pydantic request schemas for faceted list endpoints.
+
+Used by the Tool / MCP Server / Knowledge Base / Agent routers (Core and EE)
+so the ``{field, operator, value}`` filter shape and the facets request body are
+defined once. Mirrors ``core.api.v1.call_logs.CallFilterParam`` / ``FacetsRequest``.
+"""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class FilterParam(BaseModel):
+    field: str
+    operator: str
+    value: object
+
+
+class FacetsRequest(BaseModel):
+    filters: Optional[List[FilterParam]] = None

--- a/core/api/v1/knowledge_base_routes.py
+++ b/core/api/v1/knowledge_base_routes.py
@@ -24,16 +24,41 @@ from fastapi import (
 )
 from sqlalchemy.orm import Session
 
+from core.api.v1.faceted_schemas import FacetsRequest
 from core.database.session import get_db
 from core.models.agent import Agent
 from core.models.agent_knowledge_base import AgentKnowledgeBase
 from core.models.knowledge_base import KnowledgeBase
 from core.models.upload import Upload
-from core.services.crud import list_records
 from core.services.document_processing_service import DocumentProcessingService
 from core.services.ingestion_queue import enqueue_reprocess, enqueue_upload
 from core.services.r2_storage_service import R2StorageService
+from core.utils.faceted_query import apply_filters, apply_sort, build_facets, distinct_values
+from core.utils.list_params import resolve_sort
 from shared.config import settings
+
+# Knowledge-base documents are ``Upload`` rows scoped to the kb_document purpose.
+KB_FACET_FIELDS = ["status"]
+
+
+def _kb_column_map() -> dict:
+    """Scalar columns exposed for filtering / sorting / faceting on documents."""
+    return {
+        "file_name": Upload.file_name,
+        "status": Upload.status,
+        "size_bytes": Upload.size_bytes,
+        "created_at": Upload.created_at,
+        "updated_at": Upload.updated_at,
+    }
+
+
+def _kb_base_query(db: Session, org_id: UUID):
+    """Org-scoped base query for kb documents (excludes soft-deleted rows)."""
+    return db.query(Upload).filter(
+        Upload.organization_id == org_id,
+        Upload.purpose == "kb_document",
+        Upload.deleted_at.is_(None),
+    )
 
 
 def _signed_url(file_path: str | None, r2: R2StorageService | None = None) -> str | None:
@@ -74,13 +99,15 @@ def build_knowledge_base_router(
         page = max(int(body.get("page") or 1), 1)
         page_size = min(max(int(body.get("page_size") or 20), 1), 100)
         search = body.get("search")
-        sort_by = body.get("sort_by")
         agent_id = body.get("agent_id")
         status_filter = body.get("status")
 
-        filters = [Upload.purpose == "kb_document"]
+        column_map = _kb_column_map()
+        query = _kb_base_query(db, org_id)
+
+        # Named params (back-compat): free-text search, owning-agent and status.
         if search:
-            filters.append(Upload.file_name.ilike(f"%{search}%"))
+            query = query.filter(Upload.file_name.ilike(f"%{search}%"))
         if agent_id:
             try:
                 agent_uuid = UUID(str(agent_id))
@@ -96,20 +123,18 @@ def build_knowledge_base_router(
                     AgentKnowledgeBase.organization_id == org_id,
                 )
             )
-            filters.append(Upload.id.in_(upload_ids_q))
+            query = query.filter(Upload.id.in_(upload_ids_q))
         if status_filter:
-            filters.append(Upload.status == status_filter)
+            query = query.filter(Upload.status == status_filter)
 
-        allowed_sort_fields = {"file_name", "size_bytes", "created_at", "updated_at", "status"}
-        order_by = Upload.updated_at.desc()
-        if sort_by:
-            desc = sort_by.startswith("-")
-            field_name = sort_by.lstrip("-")
-            if field_name in allowed_sort_fields:
-                col = getattr(Upload, field_name)
-                order_by = col.desc() if desc else col.asc()
+        # Generic faceted filters + sort.
+        query = apply_filters(query, body.get("filters"), column_map)
+        total = query.count()
+        sort_by, sort_order = resolve_sort(body, "updated_at")
+        query = apply_sort(query, column_map, sort_by, sort_order, Upload.updated_at)
 
-        items, total = list_records(db, Upload, org_id, page, page_size, filters, order_by)
+        offset = (page - 1) * page_size
+        items = query.offset(offset).limit(page_size).all()
         r2 = R2StorageService()
 
         # Map each upload to its linked agent (if any) so the UI can show the
@@ -445,5 +470,28 @@ def build_knowledge_base_router(
                 pass
 
         return {"ok": True}
+
+    @router.post("/facets")
+    def get_document_facets(
+        body: FacetsRequest,
+        claims=Depends(auth_dependency),
+        db: Session = Depends(get_db),
+    ):
+        org_id = resolve_org_id(claims)
+        filters = [f.model_dump() for f in body.filters] if body.filters else None
+        return build_facets(
+            lambda: _kb_base_query(db, org_id), _kb_column_map(), KB_FACET_FIELDS, filters
+        )
+
+    @router.get("/filter-values")
+    def get_document_filter_values(
+        column_name: str,
+        claims=Depends(auth_dependency),
+        db: Session = Depends(get_db),
+    ):
+        org_id = resolve_org_id(claims)
+        column_map = _kb_column_map()
+        allowed = {k: column_map[k] for k in ("status", "file_name")}
+        return distinct_values(_kb_base_query(db, org_id), allowed, column_name)
 
     return router

--- a/core/api/v1/mcp_servers.py
+++ b/core/api/v1/mcp_servers.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from core.database.session import get_db
 from core.services.mcp_server_service import McpServerService
+from core.api.v1.faceted_schemas import FacetsRequest
 from core.middleware.auth import require_org_member, JWTClaims
 from core.utils.pagination import parse_sort, parse_page
 from shared.config import settings
@@ -47,7 +48,12 @@ def list_mcp_servers(
       page_size?: int,         # None/0 means "all"
     }
     """
-    sort_by, sort_order = parse_sort(data.get("sort"), _ALLOWED_SORT_FIELDS)
+    # Prefer the new sort_by/sort_order contract; fall back to legacy "-field" sort.
+    if data.get("sort_by") or data.get("sort_order"):
+        sort_by = data.get("sort_by") or "created_at"
+        sort_order = data.get("sort_order") or "desc"
+    else:
+        sort_by, sort_order = parse_sort(data.get("sort"), _ALLOWED_SORT_FIELDS)
     page, page_size = parse_page(data)
 
     is_active = data.get("is_active")
@@ -62,7 +68,27 @@ def list_mcp_servers(
         sort_order=sort_order,
         page=page,
         page_size=page_size,
+        filters=data.get("filters"),
     )
+
+
+@router.post("/facets")
+def get_mcp_facets(
+    body: FacetsRequest,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    filters = [f.model_dump() for f in body.filters] if body.filters else None
+    return _get_service(claims, db).get_facets(filters=filters)
+
+
+@router.get("/filter-values")
+def get_mcp_filter_values(
+    column_name: str = Query(...),
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    return _get_service(claims, db).get_filter_values(column_name=column_name)
 
 
 @router.post("/upsert_mcp_server", status_code=status.HTTP_200_OK)

--- a/core/api/v1/services.py
+++ b/core/api/v1/services.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from fastapi import APIRouter, Body, Depends, Query, status
 from sqlalchemy.orm import Session
 
+from core.api.v1.faceted_schemas import FacetsRequest
 from core.database.session import get_db
 from core.middleware.auth import JWTClaims, require_admin_or_owner, require_org_member
 from core.services.model_provider_service import ModelProviderService
@@ -34,6 +35,25 @@ def list_services(
     db: Session = Depends(get_db),
 ):
     return _service(claims, db).list_services(body)
+
+
+@router.post("/facets")
+def get_service_facets(
+    body: FacetsRequest,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    filters = [f.model_dump() for f in body.filters] if body.filters else None
+    return _service(claims, db).get_service_facets(filters)
+
+
+@router.get("/filter-values")
+def get_service_filter_values(
+    column_name: str = Query(...),
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    return _service(claims, db).get_service_filter_values(column_name)
 
 
 @router.post("", status_code=status.HTTP_201_CREATED)
@@ -109,6 +129,19 @@ def list_provider_keys(
     return _service(claims, db).list_provider_keys(provider_id, body)
 
 
+@router.get("/providers/{provider_id}/keys/filter-values")
+def get_provider_key_filter_values(
+    provider_id: str,
+    column_name: str = Query(...),
+    service_type: Optional[str] = None,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    return _service(claims, db).get_provider_key_filter_values(
+        provider_id, column_name, service_type
+    )
+
+
 @router.post("/providers/{provider_id}/models")
 def list_provider_models(
     provider_id: str,
@@ -117,6 +150,19 @@ def list_provider_models(
     db: Session = Depends(get_db),
 ):
     return _service(claims, db).list_provider_models(provider_id, body)
+
+
+@router.get("/providers/{provider_id}/models/filter-values")
+def get_provider_model_filter_values(
+    provider_id: str,
+    column_name: str = Query(...),
+    service_type: Optional[str] = None,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    return _service(claims, db).get_provider_model_filter_values(
+        provider_id, column_name, service_type
+    )
 
 
 # The `models` table is a global catalog (no organization_id) referenced by

--- a/core/api/v1/tools.py
+++ b/core/api/v1/tools.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 from core.database.session import get_db
 from core.models.tool import Tool
 from core.services.tool_service import ToolService
+from core.api.v1.faceted_schemas import FacetsRequest
 from core.middleware.auth import require_org_member, JWTClaims
 from shared.config import settings
 
@@ -62,46 +63,26 @@ def list_tools(
     claims: JWTClaims = Depends(require_org_member),
     db: Session = Depends(get_db),
 ):
-    from sqlalchemy import or_
-    from core.services.crud import list_records
+    return _get_service(claims, db).list_tools(body)
 
-    org_id = UUID(str(claims.org_id)) if claims.org_id else UUID(settings.DEFAULT_ORG_ID)
 
-    page = max(int(body.get("page") or 1), 1)
-    page_size = min(max(int(body.get("page_size") or 20), 1), 100)
-    search = body.get("search")
-    sort_by = body.get("sort_by")
-    tool_type = body.get("tool_type")
-    is_active = body.get("is_active")
+@router.post("/facets")
+def get_tool_facets(
+    body: FacetsRequest,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    filters = [f.model_dump() for f in body.filters] if body.filters else None
+    return _get_service(claims, db).get_facets(filters=filters)
 
-    filters = [Tool.tool_type != 'mcp', Tool.is_template != True]
-    if search:
-        filters.append(or_(
-            Tool.name.ilike(f"%{search}%"),
-            Tool.description.ilike(f"%{search}%"),
-        ))
-    if tool_type:
-        filters.append(Tool.tool_type == tool_type)
-    if is_active is not None:
-        filters.append(Tool.is_active == is_active)
 
-    allowed_sort_fields = {"name", "tool_type", "is_active", "created_at", "updated_at"}
-    order_by = Tool.updated_at.desc()
-    if sort_by:
-        desc = sort_by.startswith("-")
-        field_name = sort_by.lstrip("-")
-        if field_name in allowed_sort_fields:
-            col = getattr(Tool, field_name)
-            order_by = col.desc() if desc else col.asc()
-
-    svc = ToolService(db, org_id=org_id)
-    items, total = list_records(db, Tool, org_id, page, page_size, filters, order_by)
-    return {
-        "items": [svc.tool_response(t) for t in items],
-        "total": total,
-        "page": page,
-        "page_size": page_size,
-    }
+@router.get("/filter-values")
+def get_tool_filter_values(
+    column_name: str = Query(...),
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    return _get_service(claims, db).get_filter_values(column_name=column_name)
 
 
 @router.get("/get_all_tools")

--- a/core/services/mcp_server_service.py
+++ b/core/services/mcp_server_service.py
@@ -4,13 +4,14 @@ from typing import Dict, Any, List
 
 from fastapi import HTTPException, status
 
-from sqlalchemy import asc, desc, or_
+from sqlalchemy import case, or_
 
 from core.services.base import BaseService
 from core.models.mcp_server import McpServer
 from core.models.agent_mcp_server import AgentMcpServer
 from core.models.tool import Tool
 from core.utils.encryption import encrypt, decrypt
+from core.utils.faceted_query import apply_filters, apply_sort, build_facets, distinct_values
 
 
 def encrypt_auth_config(auth_config):
@@ -294,6 +295,20 @@ class McpServerService(BaseService):
         self._sync_mcp_tools(mcp_server, validation_result["tools"])
         return mcp_server
 
+    # ``status`` is derived from the boolean ``is_active`` via a CASE expression
+    # so it flows through the generic faceted-query helpers as a string facet.
+    MCP_FACET_FIELDS = ["status", "transport_type"]
+
+    def _mcp_column_map(self) -> Dict[str, Any]:
+        return {
+            "name": McpServer.name,
+            "status": case((McpServer.is_active.is_(True), "active"), else_="inactive"),
+            "is_active": McpServer.is_active,
+            "transport_type": McpServer.transport_type,
+            "created_at": McpServer.created_at,
+            "updated_at": McpServer.updated_at,
+        }
+
     def list_mcp_servers(
         self,
         search: str = None,
@@ -302,11 +317,13 @@ class McpServerService(BaseService):
         sort_order: str = "desc",
         page: int = 1,
         page_size: int = None,
+        filters: List[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """List MCP servers with search, filter, sort, and pagination.
 
         Returns {"data": [...], "pagination": {...}}.
         """
+        column_map = self._mcp_column_map()
         query = self.query(McpServer)
 
         if search:
@@ -321,16 +338,14 @@ class McpServerService(BaseService):
         if is_active is not None:
             query = query.filter(McpServer.is_active == is_active)
 
+        query = apply_filters(query, filters, column_map)
+
         total = query.count()
 
-        sort_column_map = {
-            "created_at": McpServer.created_at,
-            "updated_at": McpServer.updated_at,
-            "name": McpServer.name,
-        }
-        sort_column = sort_column_map.get(sort_by, McpServer.created_at)
-        order_func = asc if sort_order == "asc" else desc
-        ordered_query = query.order_by(order_func(sort_column), McpServer.id)
+        # Secondary order by id keeps pagination stable across equal sort keys.
+        ordered_query = apply_sort(
+            query, column_map, sort_by, sort_order, McpServer.created_at
+        ).order_by(McpServer.id)
 
         if page_size is not None:
             offset = (page - 1) * page_size
@@ -354,6 +369,19 @@ class McpServerService(BaseService):
                 "total_pages": total_pages,
             },
         }
+
+    def get_facets(self, filters: List[Dict[str, Any]] = None) -> Dict[str, Any]:
+        return build_facets(
+            lambda: self.query(McpServer),
+            self._mcp_column_map(),
+            self.MCP_FACET_FIELDS,
+            filters,
+        )
+
+    def get_filter_values(self, column_name: str) -> Dict[str, Any]:
+        column_map = self._mcp_column_map()
+        allowed = {k: column_map[k] for k in ("name", "status", "transport_type")}
+        return distinct_values(self.query(McpServer), allowed, column_name)
 
     def get_mcp_server(self, mcp_server_id) -> McpServer:
         mcp_server = self.query(McpServer).filter(McpServer.id == mcp_server_id).first()

--- a/core/services/model_provider_service.py
+++ b/core/services/model_provider_service.py
@@ -17,6 +17,7 @@ from core.models.model_voice import ModelVoice
 from core.services.base import BaseService
 from core.services.crud import list_records
 from core.utils.encryption import encrypt
+from core.utils.faceted_query import apply_filters
 
 
 ALLOWED_SERVICE_TYPES = {"llm", "stt", "tts"}
@@ -243,6 +244,67 @@ class ModelProviderService(BaseService):
             )
         return record
 
+    # ─── faceted list helpers ──────────────────────────────────────────────
+
+    # Faceted (drawer) fields for the aggregated usage list. ``name`` is a
+    # token-bar-only multi-select (provider display name); ``service_type`` is
+    # the drawer facet.
+    USAGE_FACET_FIELDS = ["service_type"]
+
+    def _usage_base_query(self):
+        """Org-scoped base for the usage list — one ApiKey row per key, joined to
+        its provider, excluding legacy NULL service_type rows."""
+        return (
+            self.db.query(ApiKey)
+            .join(ModelProvider, ModelProvider.id == ApiKey.provider_id)
+            .filter(
+                ApiKey.organization_id == self.org_id,
+                ApiKey.service_type.isnot(None),
+            )
+        )
+
+    def _usage_column_map(self) -> dict:
+        return {
+            "service_type": ApiKey.service_type,
+            "name": ModelProvider.display_name,
+            "status": case((ApiKey.is_active.is_(True), "active"), else_="inactive"),
+        }
+
+    def get_service_facets(self, filters: list | None = None) -> dict:
+        """Per-value facet counts for the Model Providers filter drawer. Counts
+        are by distinct (provider, service_type) card, not raw ApiKey rows."""
+        column_map = self._usage_column_map()
+        result: dict = {}
+        for field in self.USAGE_FACET_FIELDS:
+            col = column_map.get(field)
+            if col is None:
+                continue
+            scoped = apply_filters(
+                self._usage_base_query(), filters, column_map, exclude_field=field
+            )
+            rows = (
+                scoped.with_entities(col, func.count(distinct(ApiKey.provider_id)))
+                .group_by(col)
+                .all()
+            )
+            result[field] = [{"value": v, "count": int(c)} for v, c in rows if v]
+        return result
+
+    def get_service_filter_values(self, column_name: str) -> dict:
+        """Distinct values for token-search autocomplete."""
+        base = self._usage_base_query()
+        if column_name == "service_type":
+            rows = base.with_entities(ApiKey.service_type).distinct().all()
+        elif column_name == "name":
+            rows = base.with_entities(ModelProvider.display_name).distinct().all()
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid column: {column_name}. Allowed: name, service_type",
+            )
+        values = sorted([r[0] for r in rows if r[0]])
+        return {"column": column_name, "values": values}
+
     # ─── list / aggregate ──────────────────────────────────────────────────
 
     def list_services(self, body: dict) -> dict:
@@ -297,6 +359,11 @@ class ModelProviderService(BaseService):
             q = q.filter(ApiKey.is_active.is_(True))
         elif status_filter == "inactive":
             q = q.filter(ApiKey.is_active.is_(False))
+
+        # Generic faceted filters (token bar Name multi-select + Type facet).
+        generic_filters = body.get("filters")
+        if generic_filters:
+            q = apply_filters(q, generic_filters, self._usage_column_map())
 
         q = q.group_by(
             ApiKey.provider_id,
@@ -745,6 +812,45 @@ class ModelProviderService(BaseService):
             "page": page,
             "page_size": page_size,
         }
+
+    def get_provider_key_filter_values(
+        self, provider_id: str, column_name: str, service_type: str | None = None
+    ) -> dict:
+        """Distinct API-key names (labels) for token-search autocomplete."""
+        prov_uuid = _parse_uuid(provider_id, field="provider id")
+        self._provider_or_404(prov_uuid)
+        if column_name not in ("name", "label"):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid column: {column_name}. Allowed: name",
+            )
+        q = self.db.query(ApiKey.label).filter(
+            ApiKey.organization_id == self.org_id,
+            ApiKey.provider_id == prov_uuid,
+        )
+        if service_type and service_type != "all":
+            _validate_service_type(service_type, required=False)
+            q = q.filter(ApiKey.service_type == service_type)
+        values = sorted([r[0] for r in q.distinct().all() if r[0]])
+        return {"column": column_name, "values": values}
+
+    def get_provider_model_filter_values(
+        self, provider_id: str, column_name: str, service_type: str | None = None
+    ) -> dict:
+        """Distinct model names for token-search autocomplete."""
+        prov_uuid = _parse_uuid(provider_id, field="provider id")
+        self._provider_or_404(prov_uuid)
+        if column_name != "name":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid column: {column_name}. Allowed: name",
+            )
+        q = self.db.query(Model.name).filter(Model.provider_id == prov_uuid)
+        service_type = _validate_service_type(service_type, required=False)
+        if service_type:
+            q = q.filter(Model.kind == service_type)
+        values = sorted([r[0] for r in q.distinct().all() if r[0]])
+        return {"column": column_name, "values": values}
 
     # ─── model CRUD ────────────────────────────────────────────────────────
 

--- a/core/services/tool_service.py
+++ b/core/services/tool_service.py
@@ -6,11 +6,14 @@ from uuid import UUID
 
 from fastapi import HTTPException, status
 from loguru import logger
+from sqlalchemy import case, or_
 
 from core.services.base import BaseService
 from core.models.tool import Tool
 from core.models.agent_tool import AgentTool
 from core.utils.encryption import encrypt, decrypt
+from core.utils.faceted_query import apply_filters, apply_sort, build_facets, distinct_values
+from core.utils.list_params import resolve_sort
 
 
 def encrypt_auth_config(auth_config: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
@@ -317,6 +320,76 @@ class ToolService(BaseService):
             .filter(AgentTool.agent_id == agent_id, Tool.is_active == True)
             .all()
         )
+
+    # ------------------------------------------------------------------
+    # Faceted list / facets / filter-values
+    # ------------------------------------------------------------------
+
+    # ``status`` is derived from the boolean ``is_active`` via a CASE expression
+    # so it flows through the generic faceted-query helpers as a string facet.
+    TOOL_FACET_FIELDS = ["tool_type", "status"]
+
+    def _tool_column_map(self) -> Dict[str, Any]:
+        return {
+            "name": Tool.name,
+            "tool_type": Tool.tool_type,
+            "status": case((Tool.is_active.is_(True), "active"), else_="inactive"),
+            "is_active": Tool.is_active,
+            "created_at": Tool.created_at,
+            "updated_at": Tool.updated_at,
+        }
+
+    def _tool_base_query(self):
+        """Org-scoped base query for the tools list surface (no MCP, no templates)."""
+        return self.query(Tool).filter(Tool.tool_type != 'mcp', Tool.is_template != True)
+
+    def _apply_tool_named_filters(self, query, body: Dict[str, Any]):
+        """Apply the legacy named params (search / tool_type / is_active)."""
+        search = body.get("search")
+        if search:
+            query = query.filter(or_(
+                Tool.name.ilike(f"%{search}%"),
+                Tool.description.ilike(f"%{search}%"),
+            ))
+        tool_type = body.get("tool_type")
+        if tool_type:
+            query = query.filter(Tool.tool_type == tool_type)
+        is_active = body.get("is_active")
+        if is_active is not None:
+            query = query.filter(Tool.is_active == is_active)
+        return query
+
+    def list_tools(self, body: Dict[str, Any]) -> Dict[str, Any]:
+        page = max(int(body.get("page") or 1), 1)
+        page_size = min(max(int(body.get("page_size") or 20), 1), 100)
+        column_map = self._tool_column_map()
+
+        query = self._apply_tool_named_filters(self._tool_base_query(), body)
+        query = apply_filters(query, body.get("filters"), column_map)
+
+        total = query.count()
+
+        sort_by, sort_order = resolve_sort(body, "updated_at")
+        query = apply_sort(query, column_map, sort_by, sort_order, Tool.updated_at)
+
+        offset = (page - 1) * page_size
+        items = query.offset(offset).limit(page_size).all()
+        return {
+            "items": [self.tool_response(t) for t in items],
+            "total": total,
+            "page": page,
+            "page_size": page_size,
+        }
+
+    def get_facets(self, filters: Optional[List[Dict[str, Any]]] = None) -> Dict[str, Any]:
+        return build_facets(
+            self._tool_base_query, self._tool_column_map(), self.TOOL_FACET_FIELDS, filters
+        )
+
+    def get_filter_values(self, column_name: str) -> Dict[str, Any]:
+        column_map = self._tool_column_map()
+        allowed = {k: column_map[k] for k in ("name", "tool_type", "status")}
+        return distinct_values(self._tool_base_query(), allowed, column_name)
 
     def tool_response(self, tool: Tool) -> Dict[str, Any]:
         return {

--- a/core/utils/faceted_query.py
+++ b/core/utils/faceted_query.py
@@ -1,0 +1,147 @@
+"""Generic faceted-list helpers: filter / sort / facet-count / distinct-value.
+
+Extracted from the call-log implementation (``core.services.call_service``) so
+the simple list endpoints (Tool, MCP Server, Knowledge Base, Agent) can offer
+the same Vercel-style faceted filtering without copying the logic. These are
+pure functions over a SQLAlchemy ``Query`` — no model/session coupling — so a
+router, a route-builder closure, or a service method can all reuse them.
+
+A ``column_map`` maps a public field name to a SQLAlchemy column/expression.
+Only scalar columns belong in the map; raw JSONB columns must never be added
+(grouping/sorting on them is meaningless). Unknown or ``None``-mapped fields are
+skipped silently, matching the call-log behaviour.
+"""
+
+from typing import Any, Callable, Dict, List, Optional
+
+from fastapi import HTTPException
+from sqlalchemy import asc, desc, func
+from sqlalchemy.orm import Query
+
+
+def apply_filters(
+    query: Query,
+    filters: Optional[List[Dict[str, Any]]],
+    column_map: Dict[str, Any],
+    exclude_field: Optional[str] = None,
+) -> Query:
+    """Apply ``[{field, operator, value}]`` filters to ``query`` immutably.
+
+    Supported operators: ``equal_to``, ``greater_than``, ``less_than``,
+    ``between`` (value is ``[lo, hi]``), ``in`` (value is a list), ``contains``
+    (case-insensitive substring). ``exclude_field`` skips one field so a facet's
+    own selection doesn't constrain its own counts (Vercel semantics).
+    """
+    if not filters:
+        return query
+
+    for f in filters:
+        field = f.get("field")
+        operator = f.get("operator")
+        value = f.get("value")
+
+        if exclude_field is not None and field == exclude_field:
+            continue
+
+        col = column_map.get(field)
+        if col is None:
+            continue
+
+        if operator == "equal_to":
+            query = query.filter(col == value)
+        elif operator == "greater_than":
+            query = query.filter(col > value)
+        elif operator == "less_than":
+            query = query.filter(col < value)
+        elif operator == "between":
+            if isinstance(value, list) and len(value) == 2:
+                query = query.filter(col.between(value[0], value[1]))
+        elif operator == "in":
+            if isinstance(value, list):
+                query = query.filter(col.in_(value))
+        elif operator == "contains":
+            query = query.filter(col.ilike(f"%{value}%"))
+
+    return query
+
+
+def apply_sort(
+    query: Query,
+    column_map: Dict[str, Any],
+    sort_by: Optional[str],
+    sort_order: str,
+    default_col: Any,
+) -> Query:
+    """Order ``query`` by ``sort_by`` (validated against ``column_map``).
+
+    Falls back to ``default_col`` when ``sort_by`` is missing or unmapped — a bad
+    sort field is silently ignored, matching the existing list endpoints.
+    """
+    sort_col = column_map.get(sort_by) if sort_by else None
+    if sort_col is None:
+        sort_col = default_col
+    order_fn = asc if sort_order == "asc" else desc
+    return query.order_by(order_fn(sort_col))
+
+
+def build_facets(
+    base_query_factory: Callable[[], Query],
+    column_map: Dict[str, Any],
+    facet_fields: List[str],
+    filters: Optional[List[Dict[str, Any]]] = None,
+    limit: int = 50,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Per-value counts for each facet field, for the filter drawer.
+
+    Each facet reflects every *other* active filter but NOT its own selection,
+    so toggling a value within a facet doesn't zero out its siblings.
+    ``base_query_factory`` must return a fresh query each call (it carries the
+    entity's base constraints, joins and org scope).
+    """
+    result: Dict[str, List[Dict[str, Any]]] = {}
+
+    for field in facet_fields:
+        col = column_map.get(field)
+        if col is None:
+            continue
+
+        scoped = apply_filters(
+            base_query_factory(), filters, column_map, exclude_field=field
+        )
+        rows = (
+            scoped.with_entities(col, func.count())
+            .group_by(col)
+            .order_by(func.count().desc())
+            .limit(limit)
+            .all()
+        )
+        result[field] = [
+            {"value": value, "count": count}
+            for value, count in rows
+            if value is not None and value != ""
+        ]
+
+    return result
+
+
+def distinct_values(
+    base_query: Query,
+    column_map: Dict[str, Any],
+    column_name: str,
+) -> Dict[str, Any]:
+    """Distinct non-null/non-empty values of ``column_name`` for autocomplete.
+
+    Raises ``HTTPException(400)`` for a column that isn't in ``column_map``.
+    """
+    col = column_map.get(column_name)
+    if col is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid column: {column_name}. "
+                f"Allowed: {', '.join(sorted(column_map))}"
+            ),
+        )
+    rows = base_query.with_entities(col).distinct().all()
+    values = sorted([r[0] for r in rows if r[0] is not None and r[0] != ""])
+    return {"column": column_name, "values": values}

--- a/core/utils/list_params.py
+++ b/core/utils/list_params.py
@@ -1,0 +1,26 @@
+"""Helpers for reading list-endpoint request params from a dict body."""
+
+from typing import Any, Dict, Optional, Tuple
+
+
+def resolve_sort(
+    body: Dict[str, Any],
+    default_field: str,
+    default_order: str = "desc",
+) -> Tuple[Optional[str], str]:
+    """Resolve a (sort_by, sort_order) pair from a request body.
+
+    Supports both the new contract (``sort_by`` = plain field + ``sort_order`` =
+    ``asc``/``desc``) and the legacy ``sort_by`` = ``"-field"`` prefixed string,
+    so existing callers keep working. Returns ``(default_field, default_order)``
+    when no sort is supplied.
+    """
+    raw = body.get("sort_by")
+    order = body.get("sort_order")
+    if order is None:
+        if raw and raw.startswith("-"):
+            return raw[1:], "desc"
+        if raw:
+            return raw, "asc"
+        return default_field, default_order
+    return (raw or default_field), order

--- a/ee/api/v1/agents.py
+++ b/ee/api/v1/agents.py
@@ -11,8 +11,11 @@ from core.api.v1.agents import (
     ImprovePromptRequest,
     UpdateAgentRequest,
     _prompt_errors,
+    agent_facets_for_org,
+    agent_filter_values_for_org,
     list_agents_for_org,
 )
+from core.api.v1.faceted_schemas import FacetsRequest
 from core.database.session import get_db
 from core.models.agent import Agent
 from core.services.agent_service import AgentService
@@ -112,6 +115,27 @@ def list_agents(
 ):
     org_id = UUID(claims.org_id)
     return list_agents_for_org(db, org_id, body)
+
+
+@router.post("/facets")
+def get_agent_facets(
+    body: FacetsRequest,
+    claims: EEJWTClaims = Depends(require_ee_org_member),
+    db: Session = Depends(get_db),
+):
+    org_id = UUID(claims.org_id)
+    filters = [f.model_dump() for f in body.filters] if body.filters else None
+    return agent_facets_for_org(db, org_id, filters)
+
+
+@router.get("/filter-values")
+def get_agent_filter_values(
+    column_name: str = Query(...),
+    claims: EEJWTClaims = Depends(require_ee_org_member),
+    db: Session = Depends(get_db),
+):
+    org_id = UUID(claims.org_id)
+    return agent_filter_values_for_org(db, org_id, column_name)
 
 
 @router.post("/generate_prompt", response_model=GeneratedPromptResponse)

--- a/ee/api/v1/mcp_servers.py
+++ b/ee/api/v1/mcp_servers.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from core.database.session import get_db
 from core.services.mcp_server_service import McpServerService
+from core.api.v1.faceted_schemas import FacetsRequest
 from core.utils.pagination import parse_sort, parse_page
 from ee.middleware.auth import require_ee_org_member, EEJWTClaims
 
@@ -45,7 +46,12 @@ def list_mcp_servers(
       page_size?: int,         # None/0 means "all"
     }
     """
-    sort_by, sort_order = parse_sort(data.get("sort"), _ALLOWED_SORT_FIELDS)
+    # Prefer the new sort_by/sort_order contract; fall back to legacy "-field" sort.
+    if data.get("sort_by") or data.get("sort_order"):
+        sort_by = data.get("sort_by") or "created_at"
+        sort_order = data.get("sort_order") or "desc"
+    else:
+        sort_by, sort_order = parse_sort(data.get("sort"), _ALLOWED_SORT_FIELDS)
     page, page_size = parse_page(data)
 
     is_active = data.get("is_active")
@@ -60,7 +66,27 @@ def list_mcp_servers(
         sort_order=sort_order,
         page=page,
         page_size=page_size,
+        filters=data.get("filters"),
     )
+
+
+@router.post("/facets")
+def get_mcp_facets(
+    body: FacetsRequest,
+    claims: EEJWTClaims = Depends(require_ee_org_member),
+    db: Session = Depends(get_db),
+):
+    filters = [f.model_dump() for f in body.filters] if body.filters else None
+    return _get_service(claims, db).get_facets(filters=filters)
+
+
+@router.get("/filter-values")
+def get_mcp_filter_values(
+    column_name: str = Query(...),
+    claims: EEJWTClaims = Depends(require_ee_org_member),
+    db: Session = Depends(get_db),
+):
+    return _get_service(claims, db).get_filter_values(column_name=column_name)
 
 
 @router.post("/upsert_mcp_server", status_code=status.HTTP_200_OK)

--- a/ee/api/v1/services.py
+++ b/ee/api/v1/services.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from fastapi import APIRouter, Body, Depends, Query, status
 from sqlalchemy.orm import Session
 
+from core.api.v1.faceted_schemas import FacetsRequest
 from core.database.session import get_db
 from core.services.model_provider_service import ModelProviderService
 from ee.middleware.auth import (
@@ -32,6 +33,25 @@ def list_services(
     db: Session = Depends(get_db),
 ):
     return _service(claims, db).list_services(body)
+
+
+@router.post("/facets")
+def get_service_facets(
+    body: FacetsRequest,
+    claims: EEJWTClaims = Depends(require_ee_org_member),
+    db: Session = Depends(get_db),
+):
+    filters = [f.model_dump() for f in body.filters] if body.filters else None
+    return _service(claims, db).get_service_facets(filters)
+
+
+@router.get("/filter-values")
+def get_service_filter_values(
+    column_name: str = Query(...),
+    claims: EEJWTClaims = Depends(require_ee_org_member),
+    db: Session = Depends(get_db),
+):
+    return _service(claims, db).get_service_filter_values(column_name)
 
 
 @router.post("", status_code=status.HTTP_201_CREATED)
@@ -107,6 +127,19 @@ def list_provider_keys(
     return _service(claims, db).list_provider_keys(provider_id, body)
 
 
+@router.get("/providers/{provider_id}/keys/filter-values")
+def get_provider_key_filter_values(
+    provider_id: str,
+    column_name: str = Query(...),
+    service_type: str | None = None,
+    claims: EEJWTClaims = Depends(require_ee_org_member),
+    db: Session = Depends(get_db),
+):
+    return _service(claims, db).get_provider_key_filter_values(
+        provider_id, column_name, service_type
+    )
+
+
 @router.post("/providers/{provider_id}/models")
 def list_provider_models(
     provider_id: str,
@@ -115,6 +148,19 @@ def list_provider_models(
     db: Session = Depends(get_db),
 ):
     return _service(claims, db).list_provider_models(provider_id, body)
+
+
+@router.get("/providers/{provider_id}/models/filter-values")
+def get_provider_model_filter_values(
+    provider_id: str,
+    column_name: str = Query(...),
+    service_type: str | None = None,
+    claims: EEJWTClaims = Depends(require_ee_org_member),
+    db: Session = Depends(get_db),
+):
+    return _service(claims, db).get_provider_model_filter_values(
+        provider_id, column_name, service_type
+    )
 
 
 # The `models` table is a global catalog (no organization_id) referenced by

--- a/ee/api/v1/tools.py
+++ b/ee/api/v1/tools.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 from core.database.session import get_db
 from core.models.tool import Tool
 from core.services.tool_service import ToolService
+from core.api.v1.faceted_schemas import FacetsRequest
 from ee.middleware.auth import require_ee_org_member, EEJWTClaims
 
 router = APIRouter()
@@ -60,46 +61,26 @@ def list_tools(
     claims: EEJWTClaims = Depends(require_ee_org_member),
     db: Session = Depends(get_db),
 ):
-    from sqlalchemy import or_
-    from core.services.crud import list_records
+    return _get_service(claims, db).list_tools(body)
 
-    org_id = UUID(claims.org_id)
 
-    page = max(int(body.get("page") or 1), 1)
-    page_size = min(max(int(body.get("page_size") or 20), 1), 100)
-    search = body.get("search")
-    sort_by = body.get("sort_by")
-    tool_type = body.get("tool_type")
-    is_active = body.get("is_active")
+@router.post("/facets")
+def get_tool_facets(
+    body: FacetsRequest,
+    claims: EEJWTClaims = Depends(require_ee_org_member),
+    db: Session = Depends(get_db),
+):
+    filters = [f.model_dump() for f in body.filters] if body.filters else None
+    return _get_service(claims, db).get_facets(filters=filters)
 
-    filters = [Tool.tool_type != 'mcp', Tool.is_template != True]
-    if search:
-        filters.append(or_(
-            Tool.name.ilike(f"%{search}%"),
-            Tool.description.ilike(f"%{search}%"),
-        ))
-    if tool_type:
-        filters.append(Tool.tool_type == tool_type)
-    if is_active is not None:
-        filters.append(Tool.is_active == is_active)
 
-    allowed_sort_fields = {"name", "tool_type", "is_active", "created_at", "updated_at"}
-    order_by = Tool.updated_at.desc()
-    if sort_by:
-        desc = sort_by.startswith("-")
-        field_name = sort_by.lstrip("-")
-        if field_name in allowed_sort_fields:
-            col = getattr(Tool, field_name)
-            order_by = col.desc() if desc else col.asc()
-
-    svc = ToolService(db, org_id=org_id)
-    items, total = list_records(db, Tool, org_id, page, page_size, filters, order_by)
-    return {
-        "items": [svc.tool_response(t) for t in items],
-        "total": total,
-        "page": page,
-        "page_size": page_size,
-    }
+@router.get("/filter-values")
+def get_tool_filter_values(
+    column_name: str = Query(...),
+    claims: EEJWTClaims = Depends(require_ee_org_member),
+    db: Session = Depends(get_db),
+):
+    return _get_service(claims, db).get_filter_values(column_name=column_name)
 
 
 @router.get("/get_all_tools")

--- a/frontend/src/app/(dashboard)/settings/layout.tsx
+++ b/frontend/src/app/(dashboard)/settings/layout.tsx
@@ -56,12 +56,6 @@ export default function SettingsLayout({ children }: { children: React.ReactNode
   // switching between the app and settings never changes the rail width.
   const { sidebarCollapsed, toggleSidebar } = useNavigation();
 
-  // The Model Providers detail editor is a focused, full-width page with its own
-  // back navigation — render it without any settings chrome.
-  if (pathname.startsWith('/settings/model-providers/')) {
-    return <div className="h-full w-full overflow-y-auto">{children}</div>;
-  }
-
   return (
     <div className="flex h-full w-full min-w-0 bg-background">
       {/* ── Settings rail (desktop) — shares SidebarShell with the app sidebar ── */}

--- a/frontend/src/app/(dashboard)/settings/model-providers/[providerId]/[serviceType]/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/model-providers/[providerId]/[serviceType]/page.tsx
@@ -1,5 +1,9 @@
 import ServiceProviderDetailPage from '@/components/service-providers/ServiceProviderDetailPage';
 
-const Page = () => <ServiceProviderDetailPage />;
+const Page = () => (
+  <div className="flex min-h-0 flex-1 flex-col p-6 lg:p-8">
+    <ServiceProviderDetailPage />
+  </div>
+);
 
 export default Page;

--- a/frontend/src/components/agents/AgentListPage.tsx
+++ b/frontend/src/components/agents/AgentListPage.tsx
@@ -1,64 +1,36 @@
 'use client';
 
-import { deleteAgentAtom, fetchPaginatedAgentList, paginatedAgentsAtom } from '@/atoms/AgentsAtom';
+import { deleteAgentAtom } from '@/atoms/AgentsAtom';
 import { AgentActionMenu } from '@/components/agents/AgentActionMenu';
 import { AgentTypeBadge } from '@/components/agents/AgentTypeBadge';
+import { agentsListConfig } from '@/components/agents/agentsListConfig';
 import CreateAgentModal from '@/components/agents/CreateAgentModal';
-import { CustomButton, CustomTable, PhoneNumberDisplay } from '@/components/shared';
-import SearchBar from '@/components/shared/SearchBar';
-import SelectInput from '@/components/shared/SelectInput';
+import {
+  CustomButton,
+  CustomTable,
+  FacetFilterBar,
+  FacetFilterDrawer,
+  PhoneNumberDisplay,
+  useFacetedList,
+} from '@/components/shared';
 import { Badge } from '@/components/ui/badge';
-import { AGENT_TYPE_OPTIONS } from '@/lib/constants/filters';
-import type { AgentDirection, ApiAgent, ListAgentsParams } from '@/types/agent';
-import type { CustomTableColumn, CustomTableSortState } from '@/types/components';
+import type { ApiAgent } from '@/types/agent';
+import type { CustomTableColumn } from '@/types/components';
 import { formatDate } from '@/utils/date';
 import { handleApiError } from '@/utils/helpers';
 import { showToast } from '@/utils/toast';
 import { useAtom } from 'jotai';
 import { Bot, Plus } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-
-const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+import { useCallback, useState } from 'react';
 
 const AgentListPage: React.FC = () => {
   const router = useRouter();
-  const [data] = useAtom(paginatedAgentsAtom);
-  const [, fetchList] = useAtom(fetchPaginatedAgentList);
   const [, removeAgent] = useAtom(deleteAgentAtom);
 
-  const [page, setPage] = useState(1);
-  const [pageSize, setPageSize] = useState(10);
-  const [search, setSearch] = useState('');
-  const [sortBy, setSortBy] = useState<string | undefined>(undefined);
-  const [agentTypeFilter, setAgentTypeFilter] = useState<string>('all');
+  const fl = useFacetedList(agentsListConfig);
+  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
-
-  const params = useMemo<ListAgentsParams>(
-    () => ({
-      page,
-      page_size: pageSize,
-      search: search.trim() || undefined,
-      sort_by: sortBy,
-      agent_type: agentTypeFilter === 'all' ? undefined : (agentTypeFilter as AgentDirection),
-    }),
-    [page, pageSize, search, sortBy, agentTypeFilter],
-  );
-
-  const refresh = useCallback(
-    async (overrides: ListAgentsParams = {}) => {
-      try {
-        await fetchList({ ...params, ...overrides });
-      } catch (error) {
-        handleApiError(error);
-      }
-    },
-    [fetchList, params],
-  );
-
-  useEffect(() => {
-    refresh();
-  }, [refresh]);
 
   const handleEdit = useCallback(
     (row: ApiAgent) => {
@@ -74,37 +46,17 @@ const AgentListPage: React.FC = () => {
       try {
         await removeAgent(agentId);
         showToast.success('Agent deleted successfully');
-        const remaining = Math.max(0, data.total - 1);
-        const lastPage = Math.max(1, Math.ceil(remaining / pageSize));
-        const nextPage = Math.min(page, lastPage);
-        if (nextPage !== page) setPage(nextPage);
-        else await refresh();
+        // Step back a page if we just removed the last row on the final page.
+        const remaining = Math.max(0, fl.total - 1);
+        const lastPage = Math.max(1, Math.ceil(remaining / fl.pageSize));
+        if (fl.page > lastPage) fl.handlePaginationChange(lastPage, fl.pageSize);
+        else fl.refresh();
       } catch (error) {
         handleApiError(error);
       }
     },
-    [removeAgent, data.total, pageSize, page, refresh],
+    [removeAgent, fl],
   );
-
-  const handleSearchChange = useCallback((value: string) => {
-    setSearch(value);
-    setPage(1);
-  }, []);
-
-  const handleAgentTypeFilter = useCallback((value: string) => {
-    setAgentTypeFilter(value);
-    setPage(1);
-  }, []);
-
-  const handleSortChange = useCallback((sort: CustomTableSortState | null) => {
-    setSortBy(sort ? `${sort.order === 'desc' ? '-' : ''}${sort.field}` : undefined);
-    setPage(1);
-  }, []);
-
-  const handlePaginationChange = useCallback((nextPage: number, nextPageSize: number) => {
-    setPage(nextPage);
-    setPageSize(nextPageSize);
-  }, []);
 
   const columns: CustomTableColumn<ApiAgent>[] = [
     {
@@ -194,9 +146,9 @@ const AgentListPage: React.FC = () => {
         <div>
           <div className="flex items-center gap-3">
             <h1 className="text-2xl font-semibold tracking-tight text-foreground">Agents</h1>
-            {data.total > 0 && (
+            {fl.total > 0 && (
               <Badge variant="secondary" className="text-xs tabular-nums">
-                {data.total}
+                {fl.total}
               </Badge>
             )}
           </div>
@@ -207,39 +159,32 @@ const AgentListPage: React.FC = () => {
         </CustomButton>
       </div>
 
-      <div className="flex flex-wrap items-center gap-3">
-        <SearchBar
-          placeholder="Search agents..."
-          value={search}
-          onSearch={handleSearchChange}
-          debounceMs={400}
-          containerClassName="max-w-xs flex-1"
-        />
-        <SelectInput
-          name="agent-type-filter"
-          options={AGENT_TYPE_OPTIONS}
-          value={agentTypeFilter}
-          onValueChange={handleAgentTypeFilter}
-          placeholder="All types"
-          size="sm"
-          triggerClassName="min-w-[160px]"
-        />
-      </div>
+      <FacetFilterBar
+        fields={fl.tokenFields}
+        tokens={fl.tokens}
+        onTokensChange={fl.setTokens}
+        onClear={fl.clearAll}
+        showClear={fl.hasActiveFilters}
+        placeholder="Search agents… (e.g. name:hotel)"
+        drawerFilterCount={fl.drawerFilterCount}
+        onOpenDrawer={() => setFilterDrawerOpen(true)}
+      />
 
       <div className="flex min-h-0 flex-1 flex-col">
         <CustomTable
           columns={columns}
-          dataSource={data.items}
+          dataSource={fl.rows}
           rowKey="id"
-          loading={data.loading}
+          loading={fl.listLoading}
           onRowClick={handleEdit}
-          onSortChange={handleSortChange}
+          onSortChange={fl.handleSortChange}
+          initialSort={agentsListConfig.defaultSort ?? undefined}
           pagination={{
-            current: page,
-            pageSize,
-            total: data.total,
-            pageSizeOptions: PAGE_SIZE_OPTIONS,
-            onChange: handlePaginationChange,
+            current: fl.page,
+            pageSize: fl.pageSize,
+            total: fl.total,
+            pageSizeOptions: fl.pageSizeOptions,
+            onChange: fl.handlePaginationChange,
           }}
           emptyState={
             <div className="flex flex-col items-center gap-4 py-8">
@@ -259,6 +204,17 @@ const AgentListPage: React.FC = () => {
           }
         />
       </div>
+
+      <FacetFilterDrawer
+        open={filterDrawerOpen}
+        onClose={() => setFilterDrawerOpen(false)}
+        description="Filter agents by type and status."
+        sections={agentsListConfig.facetSections}
+        value={fl.facetSelections}
+        facets={fl.facets}
+        facetsLoading={fl.facetsLoading}
+        onApply={fl.applyDrawer}
+      />
 
       <CreateAgentModal open={modalOpen} onClose={() => setModalOpen(false)} />
     </div>

--- a/frontend/src/components/agents/agentsListConfig.ts
+++ b/frontend/src/components/agents/agentsListConfig.ts
@@ -1,0 +1,24 @@
+import { fetchFacetedList, fetchFacets, fetchFilterValues } from '@/services/facetedApi';
+import type { ApiAgent } from '@/types/agent';
+import type { FacetedListConfig } from '@/types/facetedList';
+
+const BASE = '/agent';
+
+/**
+ * Faceted-list config for the Agents page. The `status` facet mirrors the list
+ * UI (active = has a phone number), computed server-side.
+ */
+export const agentsListConfig: FacetedListConfig<ApiAgent> = {
+  entityName: 'agent',
+  searchField: { key: 'name', label: 'Name' },
+  facetSections: [
+    { field: 'agent_type', label: 'Type', titleCase: true },
+    { field: 'status', label: 'Status', titleCase: true },
+  ],
+  defaultSort: { field: 'updated_at', order: 'desc' },
+  defaultPageSize: 10,
+  pageSizeOptions: [10, 25, 50, 100],
+  fetchList: (q) => fetchFacetedList<ApiAgent>(`${BASE}/list`, q),
+  fetchFacets: (q) => fetchFacets(`${BASE}/facets`, q),
+  fetchFilterValues: (field) => fetchFilterValues(`${BASE}/filter-values`, field),
+};

--- a/frontend/src/components/knowledge-base/KnowledgeBasePage.tsx
+++ b/frontend/src/components/knowledge-base/KnowledgeBasePage.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useQueryClient } from '@tanstack/react-query';
 import { useAtom } from 'jotai';
 import {
   AlertTriangle,
@@ -21,21 +20,24 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import agentsAtom, { fetchAllAgentsAtom } from '@/atoms/AgentsAtom';
 import DocumentUpload from '@/components/knowledge-base/DocumentUpload';
 import EditDocument from '@/components/knowledge-base/EditDocument';
-import { CustomButton, CustomModal, CustomTable } from '@/components/shared';
-import SearchBar from '@/components/shared/SearchBar';
-import SelectInput from '@/components/shared/SelectInput';
+import {
+  CustomButton,
+  CustomModal,
+  CustomTable,
+  FacetFilterBar,
+  FacetFilterDrawer,
+  useFacetedList,
+} from '@/components/shared';
+import { knowledgeBaseListConfig } from '@/components/knowledge-base/knowledgeBaseListConfig';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
-  KNOWLEDGE_BASE_QUERY_KEY,
   knowledgeBaseApi,
   useDeleteKnowledgeBase,
-  useKnowledgeBase,
   useReprocessKnowledgeBase,
 } from '@/lib/api/knowledge-base';
-import { KNOWLEDGE_BASE_STATUS_OPTIONS } from '@/lib/constants/filters';
 import type { AgentDropdownItem } from '@/types/agent';
-import type { CustomTableColumn, CustomTableSortState } from '@/types/components';
+import type { CustomTableColumn } from '@/types/components';
 import type { KnowledgeBaseDocument } from '@/types/knowledgeBase';
 import { cn } from '@/utils/cn';
 import { formatDate } from '@/utils/date';
@@ -129,20 +131,16 @@ const statusConfig: Record<StatusKey, { label: string; className: string }> = {
   },
 };
 
-const PAGE_SIZE_OPTIONS = [10, 20, 50];
-
 export default function KnowledgeBasePage() {
-  const queryClient = useQueryClient();
-
   const [agentData] = useAtom(agentsAtom);
   const [, fetchAgents] = useAtom(fetchAllAgentsAtom);
   const hasFetchedAgentsRef = useRef(false);
 
-  const [page, setPage] = useState(1);
-  const [pageSize, setPageSize] = useState(10);
-  const [sortBy, setSortBy] = useState('-updated_at');
-  const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState<string>('all');
+  const fl = useFacetedList(knowledgeBaseListConfig);
+  const documents = fl.rows;
+  const total = fl.total;
+
+  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
   const [uploadModalOpen, setUploadModalOpen] = useState(false);
@@ -151,21 +149,6 @@ export default function KnowledgeBasePage() {
   const [deleteTarget, setDeleteTarget] = useState<KnowledgeBaseDocument | null>(null);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [bulkDeleting, setBulkDeleting] = useState(false);
-
-  const queryParams = useMemo(
-    () => ({
-      page,
-      page_size: pageSize,
-      sort_by: sortBy,
-      search: search || undefined,
-      status: statusFilter && statusFilter !== 'all' ? statusFilter : undefined,
-    }),
-    [page, pageSize, sortBy, search, statusFilter],
-  );
-
-  const { data, isLoading } = useKnowledgeBase(queryParams);
-  const documents = data?.items ?? [];
-  const total = data?.total ?? 0;
 
   const deleteMutation = useDeleteKnowledgeBase();
   const reprocessMutation = useReprocessKnowledgeBase();
@@ -187,30 +170,6 @@ export default function KnowledgeBasePage() {
     });
     return map;
   }, [agentData.agentList]);
-
-  const handleSearch = useCallback((value: string) => {
-    setSearch(value);
-    setPage(1);
-  }, []);
-
-  const handleStatusFilter = useCallback((value: string) => {
-    setStatusFilter(value);
-    setPage(1);
-  }, []);
-
-  const handleSortChange = useCallback((sort: CustomTableSortState | null) => {
-    if (!sort) {
-      setSortBy('-updated_at');
-    } else {
-      setSortBy(sort.order === 'desc' ? `-${sort.field}` : sort.field);
-    }
-    setPage(1);
-  }, []);
-
-  const handlePageChange = useCallback((nextPage: number, nextPageSize: number) => {
-    setPage(nextPage);
-    setPageSize(nextPageSize);
-  }, []);
 
   const toggleRow = useCallback((id: string) => {
     setSelectedIds((prev) => {
@@ -255,10 +214,11 @@ export default function KnowledgeBasePage() {
       });
       if (selectedDoc?.id === deleteTarget.id) setSelectedDoc(null);
       setDeleteTarget(null);
+      fl.refresh();
     } catch (error) {
       handleApiError(error);
     }
-  }, [deleteTarget, deleteMutation, selectedDoc]);
+  }, [deleteTarget, deleteMutation, selectedDoc, fl]);
 
   const handleBulkDelete = useCallback(async () => {
     if (selectedIds.size === 0) return;
@@ -266,7 +226,7 @@ export default function KnowledgeBasePage() {
     const ids = Array.from(selectedIds);
     const results = await Promise.allSettled(ids.map((id) => knowledgeBaseApi.delete(id)));
     const failed = results.filter((r) => r.status === 'rejected').length;
-    queryClient.invalidateQueries({ queryKey: [KNOWLEDGE_BASE_QUERY_KEY] });
+    fl.refresh();
     setBulkDeleting(false);
     setBulkDeleteOpen(false);
 
@@ -288,12 +248,12 @@ export default function KnowledgeBasePage() {
       });
       setSelectedIds(failedIds);
     }
-  }, [selectedIds, queryClient]);
+  }, [selectedIds, fl]);
 
   const handleUploadSuccess = useCallback(() => {
     setUploadModalOpen(false);
-    queryClient.invalidateQueries({ queryKey: [KNOWLEDGE_BASE_QUERY_KEY] });
-  }, [queryClient]);
+    fl.refresh();
+  }, [fl]);
 
   const handleReprocess = useCallback(
     async (doc: KnowledgeBaseDocument) => {
@@ -305,13 +265,15 @@ export default function KnowledgeBasePage() {
         // Keep the detail modal in sync if it's open on this document. Merge so
         // fields not returned by the reprocess endpoint (e.g. agent_id) survive.
         setSelectedDoc((prev) => (prev && prev.id === doc.id ? { ...prev, ...updated } : prev));
+        // Reflect the status flip immediately; pollWhile keeps it fresh after.
+        fl.refresh();
       } catch (error) {
         handleApiError(error);
       } finally {
         setReprocessingId(null);
       }
     },
-    [reprocessMutation, reprocessingId],
+    [reprocessMutation, reprocessingId, fl],
   );
 
   const columns = useMemo<CustomTableColumn<KnowledgeBaseDocument>[]>(
@@ -529,24 +491,16 @@ export default function KnowledgeBasePage() {
       </div>
 
       {/* ─── toolbar ──────────────────────────────────────────────────── */}
-      <div className="flex flex-wrap items-center gap-3">
-        <SearchBar
-          placeholder="Search documents by name…"
-          value={search}
-          onSearch={handleSearch}
-          debounceMs={400}
-          containerClassName="max-w-xs flex-1"
-        />
-        <SelectInput
-          name="status-filter"
-          options={KNOWLEDGE_BASE_STATUS_OPTIONS}
-          value={statusFilter}
-          onValueChange={handleStatusFilter}
-          placeholder="All statuses"
-          size="sm"
-          triggerClassName="min-w-[160px]"
-        />
-      </div>
+      <FacetFilterBar
+        fields={fl.tokenFields}
+        tokens={fl.tokens}
+        onTokensChange={fl.setTokens}
+        onClear={fl.clearAll}
+        showClear={fl.hasActiveFilters}
+        placeholder="Search documents… (e.g. name:resort, status:ready)"
+        drawerFilterCount={fl.drawerFilterCount}
+        onOpenDrawer={() => setFilterDrawerOpen(true)}
+      />
 
       {/* ─── table ────────────────────────────────────────────────────── */}
       <div className="flex min-h-0 flex-1 flex-col">
@@ -554,25 +508,34 @@ export default function KnowledgeBasePage() {
           columns={columns}
           dataSource={documents}
           rowKey="id"
-          loading={isLoading}
+          loading={fl.listLoading}
           onRowClick={(record) => setSelectedDoc(record)}
-          onSortChange={handleSortChange}
-          initialSort={{ field: 'updated_at', order: 'desc' }}
+          onSortChange={fl.handleSortChange}
+          initialSort={knowledgeBaseListConfig.defaultSort ?? undefined}
           pagination={{
-            current: page,
-            pageSize,
+            current: fl.page,
+            pageSize: fl.pageSize,
             total,
-            pageSizeOptions: PAGE_SIZE_OPTIONS,
-            onChange: handlePageChange,
+            pageSizeOptions: fl.pageSizeOptions,
+            onChange: fl.handlePaginationChange,
           }}
           emptyState={
-            <EmptyState
-              onAdd={() => setUploadModalOpen(true)}
-              hasFilter={!!search || statusFilter !== 'all'}
-            />
+            <EmptyState onAdd={() => setUploadModalOpen(true)} hasFilter={fl.hasActiveFilters} />
           }
         />
       </div>
+
+      {/* ─── filter drawer ────────────────────────────────────────────── */}
+      <FacetFilterDrawer
+        open={filterDrawerOpen}
+        onClose={() => setFilterDrawerOpen(false)}
+        description="Filter documents by status."
+        sections={knowledgeBaseListConfig.facetSections}
+        value={fl.facetSelections}
+        facets={fl.facets}
+        facetsLoading={fl.facetsLoading}
+        onApply={fl.applyDrawer}
+      />
 
       {/* ─── floating selection bar ───────────────────────────────────── */}
       <SelectionBar

--- a/frontend/src/components/knowledge-base/knowledgeBaseListConfig.ts
+++ b/frontend/src/components/knowledge-base/knowledgeBaseListConfig.ts
@@ -1,0 +1,21 @@
+import { fetchFacetedList, fetchFacets, fetchFilterValues } from '@/services/facetedApi';
+import type { FacetedListConfig } from '@/types/facetedList';
+import type { KnowledgeBaseDocument } from '@/types/knowledgeBase';
+
+const BASE = '/knowledge-base';
+
+/** Faceted-list config for the Knowledge Base page (filter by status). */
+export const knowledgeBaseListConfig: FacetedListConfig<KnowledgeBaseDocument> = {
+  entityName: 'document',
+  searchField: { key: 'file_name', label: 'Name' },
+  facetSections: [{ field: 'status', label: 'Status', titleCase: true }],
+  defaultSort: { field: 'updated_at', order: 'desc' },
+  defaultPageSize: 10,
+  pageSizeOptions: [10, 20, 50],
+  // Keep polling while any document is still processing (mirrors the old hook).
+  pollWhile: (rows) => rows.some((d) => d.status === 'processing'),
+  pollIntervalMs: 4000,
+  fetchList: (q) => fetchFacetedList<KnowledgeBaseDocument>(`${BASE}/list`, q),
+  fetchFacets: (q) => fetchFacets(`${BASE}/facets`, q),
+  fetchFilterValues: (field) => fetchFilterValues(`${BASE}/filter-values`, field),
+};

--- a/frontend/src/components/mcp/MCPListPage.tsx
+++ b/frontend/src/components/mcp/MCPListPage.tsx
@@ -1,10 +1,18 @@
 'use client';
 
-import { deleteMcpServerAtom, fetchMcpServersAtom, mcpServersAtom } from '@/atoms/MCPAtom';
+import { deleteMcpServerAtom } from '@/atoms/MCPAtom';
 import MCPCardSkeleton from '@/components/mcp/MCPCardSkeleton';
 import MCPEmptyState from '@/components/mcp/MCPEmptyState';
 import MCPServerCard from '@/components/mcp/MCPServerCard';
-import { CustomButton, SearchBar } from '@/components/shared';
+import { mcpListConfig } from '@/components/mcp/mcpListConfig';
+import {
+  CustomButton,
+  FacetFilterBar,
+  FacetFilterDrawer,
+  useFacetedList,
+} from '@/components/shared';
+import SelectInput from '@/components/shared/SelectInput';
+import type { SelectOption } from '@/types/components';
 import type { MCPServer } from '@/types/mcp';
 import { handleApiError } from '@/utils/helpers';
 import { showToast } from '@/utils/toast';
@@ -12,30 +20,33 @@ import { motion } from 'framer-motion';
 import { useAtom } from 'jotai';
 import { Plus, Search } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
+
+const SORT_OPTIONS: SelectOption[] = [
+  { value: 'created_at:desc', label: 'Newest' },
+  { value: 'created_at:asc', label: 'Oldest' },
+  { value: 'name:asc', label: 'Name A–Z' },
+  { value: 'name:desc', label: 'Name Z–A' },
+  { value: 'updated_at:desc', label: 'Recently updated' },
+];
 
 export default function MCPListPage() {
   const router = useRouter();
-  const [{ servers, loading }] = useAtom(mcpServersAtom);
-  const [, fetchServers] = useAtom(fetchMcpServersAtom);
   const [, deleteServer] = useAtom(deleteMcpServerAtom);
 
-  const [search, setSearch] = useState('');
+  const fl = useFacetedList(mcpListConfig);
+  const servers = fl.rows;
+  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
+  const [sortValue, setSortValue] = useState('created_at:desc');
 
-  useEffect(() => {
-    fetchServers().catch(handleApiError);
-  }, [fetchServers]);
-
-  const filteredServers = useMemo(() => {
-    if (!search.trim()) return servers;
-    const q = search.toLowerCase();
-    return servers.filter(
-      (s) =>
-        (s.name ?? '').toLowerCase().includes(q) ||
-        (s.description ?? '').toLowerCase().includes(q) ||
-        (s.server_url ?? '').toLowerCase().includes(q),
-    );
-  }, [servers, search]);
+  const handleSort = useCallback(
+    (value: string) => {
+      setSortValue(value);
+      const [field, order] = value.split(':');
+      fl.handleSortChange({ field, order: order as 'asc' | 'desc' });
+    },
+    [fl],
+  );
 
   const handleCreate = useCallback(() => {
     router.push('/mcp/create');
@@ -60,13 +71,20 @@ export default function MCPListPage() {
       try {
         await deleteServer(server.id);
         showToast.success('MCP server deleted successfully');
-        await fetchServers();
+        fl.refresh();
       } catch (error) {
         handleApiError(error);
       }
     },
-    [deleteServer, fetchServers],
+    [deleteServer, fl],
   );
+
+  // Keep the toolbar visible during the initial skeleton load too; only hide it
+  // once we know there are genuinely no servers and no active filters.
+  const showToolbar = fl.listLoading || fl.total > 0 || fl.hasActiveFilters;
+  const isInitialLoading = fl.listLoading && servers.length === 0;
+  const noServersAtAll = !fl.listLoading && servers.length === 0 && !fl.hasActiveFilters;
+  const noMatches = !fl.listLoading && servers.length === 0 && fl.hasActiveFilters;
 
   return (
     <div className="animate-page flex h-full min-h-0 flex-col gap-5">
@@ -85,27 +103,32 @@ export default function MCPListPage() {
       </div>
 
       {/* Toolbar */}
-      {servers.length > 0 && (
-        <div className="flex flex-wrap items-center gap-3">
-          <SearchBar
-            placeholder="Search MCP servers..."
-            value={search}
-            onSearch={setSearch}
-            debounceMs={300}
-            containerClassName="max-w-xs flex-1"
-          />
-          {search && filteredServers.length > 0 && (
-            <span className="text-xs text-muted-foreground tabular-nums">
-              {filteredServers.length} of {servers.length} shown
-            </span>
-          )}
-        </div>
+      {showToolbar && (
+        <FacetFilterBar
+          fields={fl.tokenFields}
+          tokens={fl.tokens}
+          onTokensChange={fl.setTokens}
+          onClear={fl.clearAll}
+          showClear={fl.hasActiveFilters}
+          placeholder="Search MCP servers… (e.g. name:clickup)"
+          drawerFilterCount={fl.drawerFilterCount}
+          onOpenDrawer={() => setFilterDrawerOpen(true)}
+          rightSlot={
+            <SelectInput
+              name="mcp-sort"
+              options={SORT_OPTIONS}
+              value={sortValue}
+              onValueChange={handleSort}
+              size="sm"
+              triggerClassName="min-w-[170px]"
+            />
+          }
+        />
       )}
 
       {/* Content */}
       <div className="flex min-h-0 flex-1 flex-col">
-        {/* Loading state */}
-        {loading && servers.length === 0 && (
+        {isInitialLoading && (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
             {[1, 2, 3].map((i) => (
               <MCPCardSkeleton key={i} />
@@ -113,30 +136,26 @@ export default function MCPListPage() {
           </div>
         )}
 
-        {/* Empty state */}
-        {!loading && servers.length === 0 && <MCPEmptyState onCreate={handleCreate} />}
+        {noServersAtAll && <MCPEmptyState onCreate={handleCreate} />}
 
-        {/* No search results */}
-        {!loading && search && filteredServers.length === 0 && servers.length > 0 && (
+        {noMatches && (
           <div className="flex flex-col items-center justify-center py-16 text-center">
             <div className="mb-3 flex size-12 items-center justify-center rounded-xl bg-muted">
               <Search className="size-5 text-muted-foreground" />
             </div>
-            <p className="text-sm text-foreground">
-              No MCP servers matching &ldquo;{search}&rdquo;
-            </p>
+            <p className="text-sm text-foreground">No MCP servers match your filters</p>
             <button
               type="button"
-              onClick={() => setSearch('')}
+              onClick={fl.clearAll}
               className="mt-3 text-[13px] font-medium text-primary hover:underline"
             >
-              Clear search
+              Clear filters
             </button>
           </div>
         )}
 
         {/* Card grid */}
-        {!loading && filteredServers.length > 0 && (
+        {!fl.listLoading && servers.length > 0 && (
           <motion.div
             className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3"
             initial="hidden"
@@ -146,7 +165,7 @@ export default function MCPListPage() {
               visible: { transition: { staggerChildren: 0.04, delayChildren: 0.05 } },
             }}
           >
-            {filteredServers.map((server) => (
+            {servers.map((server) => (
               <motion.div
                 key={server.id}
                 className="h-full"
@@ -188,6 +207,17 @@ export default function MCPListPage() {
           </motion.div>
         )}
       </div>
+
+      <FacetFilterDrawer
+        open={filterDrawerOpen}
+        onClose={() => setFilterDrawerOpen(false)}
+        description="Filter MCP servers by status and transport."
+        sections={mcpListConfig.facetSections}
+        value={fl.facetSelections}
+        facets={fl.facets}
+        facetsLoading={fl.facetsLoading}
+        onApply={fl.applyDrawer}
+      />
     </div>
   );
 }

--- a/frontend/src/components/mcp/MCPToolsListPage.tsx
+++ b/frontend/src/components/mcp/MCPToolsListPage.tsx
@@ -3,12 +3,11 @@
 import { ArrowLeft, RefreshCw, Wrench } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { AppLoader, CustomButton, CustomTable } from '@/components/shared';
-import SearchBar from '@/components/shared/SearchBar';
+import { AppLoader, CustomButton, CustomTable, TokenSearchBar } from '@/components/shared';
 import { Badge } from '@/components/ui/badge';
 import { useGoBack } from '@/hooks/useGoBack';
 import { discoverMcpTools, getMcpServer } from '@/services/mcpServerService';
-import type { CustomTableColumn } from '@/types/components';
+import type { CustomTableColumn, SearchToken, TokenSearchField } from '@/types/components';
 import type { MCPServer, MCPTool } from '@/types/mcp';
 import { handleApiError } from '@/utils/helpers';
 
@@ -81,6 +80,27 @@ export default function MCPToolsListPage({ serverId }: MCPToolsListPageProps) {
       (t) => t.name.toLowerCase().includes(q) || (t.description ?? '').toLowerCase().includes(q),
     );
   }, [tools, trimmedSearch]);
+
+  // Token-bar "Name" field — a value dropdown sourced from the loaded tools.
+  const searchFields = useMemo<TokenSearchField[]>(
+    () => [
+      {
+        key: 'name',
+        label: 'Name',
+        type: 'enum',
+        fetchValues: () => Promise.resolve([...new Set(tools.map((t) => t.name))].sort()),
+      },
+    ],
+    [tools],
+  );
+  const searchTokens = useMemo<SearchToken[]>(
+    () => (search ? [{ field: 'name', value: search }] : []),
+    [search],
+  );
+  const handleSearchTokens = useCallback((tokens: SearchToken[]) => {
+    const last = [...tokens].reverse().find((t) => t.field === 'name');
+    setSearch(last?.value ?? '');
+  }, []);
 
   const columns = useMemo<CustomTableColumn<MCPTool>[]>(
     () => [
@@ -192,12 +212,12 @@ export default function MCPToolsListPage({ serverId }: MCPToolsListPageProps) {
 
       {/* Toolbar */}
       <div className="flex flex-wrap items-center gap-3">
-        <SearchBar
-          placeholder="Search tools..."
-          value={search}
-          onSearch={setSearch}
-          debounceMs={300}
-          containerClassName="max-w-xs flex-1"
+        <TokenSearchBar
+          fields={searchFields}
+          value={searchTokens}
+          onChange={handleSearchTokens}
+          placeholder="Search tools… (e.g. name:get_weather)"
+          className="w-full sm:max-w-xs"
         />
       </div>
 

--- a/frontend/src/components/mcp/mcpListConfig.ts
+++ b/frontend/src/components/mcp/mcpListConfig.ts
@@ -1,0 +1,29 @@
+import { fetchFacetedList, fetchFacets, fetchFilterValues } from '@/services/facetedApi';
+import type { FacetedListConfig } from '@/types/facetedList';
+import type { MCPServer } from '@/types/mcp';
+
+const BASE = '/mcp-server';
+
+/**
+ * Faceted-list config for the MCP Servers page (a card grid). Sorting is exposed
+ * via a select (`sortableColumns`) since there are no table headers, and the
+ * grid shows all matching servers (page size 0 → "all" on the backend).
+ */
+export const mcpListConfig: FacetedListConfig<MCPServer> = {
+  entityName: 'MCP server',
+  searchField: { key: 'name', label: 'Name' },
+  facetSections: [
+    { field: 'status', label: 'Status', titleCase: true },
+    { field: 'transport_type', label: 'Transport', titleCase: true },
+  ],
+  sortableColumns: [
+    { key: 'name', label: 'Name' },
+    { key: 'created_at', label: 'Created' },
+    { key: 'updated_at', label: 'Updated' },
+  ],
+  defaultSort: { field: 'created_at', order: 'desc' },
+  defaultPageSize: 0,
+  fetchList: (q) => fetchFacetedList<MCPServer>(`${BASE}/list`, q),
+  fetchFacets: (q) => fetchFacets(`${BASE}/facets`, q),
+  fetchFilterValues: (field) => fetchFilterValues(`${BASE}/filter-values`, field),
+};

--- a/frontend/src/components/service-providers/ServiceProviderDetailPage.tsx
+++ b/frontend/src/components/service-providers/ServiceProviderDetailPage.tsx
@@ -2,8 +2,9 @@
 
 import { AnimatePresence, motion } from 'framer-motion';
 import { useAtom } from 'jotai';
-import { ArrowLeft, KeyRound, Layers, Pencil, Plus, Trash2 } from 'lucide-react';
-import { useParams, useRouter } from 'next/navigation';
+import { ChevronRight, KeyRound, Layers, Pencil, Plus, Trash2 } from 'lucide-react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -16,11 +17,21 @@ import {
   upsertProviderModelAtom,
   upsertServiceAtom,
 } from '@/atoms/ServicesAtom';
-import { CustomButton, CustomModal, CustomTable, SearchBar } from '@/components/shared';
+import { CustomButton, CustomModal, CustomTable, TokenSearchBar } from '@/components/shared';
 import { Badge } from '@/components/ui/badge';
-import { deleteService, listProviderCatalog } from '@/services/servicesService';
+import {
+  deleteService,
+  listProviderCatalog,
+  listProviderKeyFilterValues,
+  listProviderModelFilterValues,
+} from '@/services/servicesService';
 import type { ModelUpsertPayload } from '@/services/servicesService';
-import type { CustomTableColumn, CustomTableSortState } from '@/types/components';
+import type {
+  CustomTableColumn,
+  CustomTableSortState,
+  SearchToken,
+  TokenSearchField,
+} from '@/types/components';
 import type {
   ProviderCatalogItem,
   ProviderModel,
@@ -43,7 +54,6 @@ const KEYS_PAGE_SIZE = 20;
 const MODELS_PAGE_SIZE = 20;
 
 export default function ServiceProviderDetailPage() {
-  const router = useRouter();
   const params = useParams<{ providerId: string; serviceType?: string }>();
   const providerId = params?.providerId;
   // The detail page is scoped to one (provider, service_type). The route is
@@ -254,8 +264,44 @@ export default function ServiceProviderDetailPage() {
     }
   };
 
-  const handleKeysSearch = useCallback((value: string) => {
-    setKeysSearch(value);
+  // Token-bar "Name" field — a value dropdown backed by /filter-values, scoped
+  // to this provider (and service_type).
+  const keysFields = useMemo<TokenSearchField[]>(
+    () => [
+      {
+        key: 'name',
+        label: 'Name',
+        type: 'enum',
+        fetchValues: () =>
+          providerId
+            ? listProviderKeyFilterValues(providerId, 'name', serviceType ?? undefined)
+            : Promise.resolve([]),
+      },
+    ],
+    [providerId, serviceType],
+  );
+  const modelsFields = useMemo<TokenSearchField[]>(
+    () => [
+      {
+        key: 'name',
+        label: 'Name',
+        type: 'enum',
+        fetchValues: () =>
+          providerId
+            ? listProviderModelFilterValues(providerId, 'name', serviceType ?? undefined)
+            : Promise.resolve([]),
+      },
+    ],
+    [providerId, serviceType],
+  );
+
+  const keysTokens = useMemo<SearchToken[]>(
+    () => (keysSearch ? [{ field: 'name', value: keysSearch }] : []),
+    [keysSearch],
+  );
+  const handleKeysTokens = useCallback((tokens: SearchToken[]) => {
+    const last = [...tokens].reverse().find((t) => t.field === 'name');
+    setKeysSearch(last?.value ?? '');
     setKeysPage(1);
   }, []);
   const handleKeysSort = useCallback((s: CustomTableSortState | null) => {
@@ -263,14 +309,29 @@ export default function ServiceProviderDetailPage() {
     if (!s) return setKeysSort('-updated_at');
     setKeysSort(s.order === 'desc' ? `-${s.field}` : s.field);
   }, []);
-  const handleModelsSearch = useCallback((value: string) => {
-    setModelsSearch(value);
+
+  const modelsTokens = useMemo<SearchToken[]>(
+    () => (modelsSearch ? [{ field: 'name', value: modelsSearch }] : []),
+    [modelsSearch],
+  );
+  const handleModelsTokens = useCallback((tokens: SearchToken[]) => {
+    const last = [...tokens].reverse().find((t) => t.field === 'name');
+    setModelsSearch(last?.value ?? '');
     setModelsPage(1);
   }, []);
   const handleModelsSort = useCallback((s: CustomTableSortState | null) => {
     setModelsPage(1);
     if (!s) return setModelsSort('name');
     setModelsSort(s.order === 'desc' ? `-${s.field}` : s.field);
+  }, []);
+
+  // Switching tabs starts clean — reset both tabs' search + pagination.
+  const handleTabChange = useCallback((tab: 'keys' | 'models') => {
+    setActiveTab(tab);
+    setKeysSearch('');
+    setKeysPage(1);
+    setModelsSearch('');
+    setModelsPage(1);
   }, []);
 
   // ─── columns ──────────────────────────────────────────────────────────────
@@ -507,19 +568,20 @@ export default function ServiceProviderDetailPage() {
   const isKeysTab = activeTab === 'keys';
 
   return (
-    <div className="animate-page flex h-full min-h-0 flex-col gap-2">
-      {/* back nav */}
-      <div className="shrink-0">
-        <CustomButton
-          type="text"
-          size="sm"
-          icon={<ArrowLeft className="size-4" />}
-          onClick={() => router.push('/settings/model-providers')}
-          className="-ml-2 text-muted-foreground hover:text-foreground"
-        >
-          Back to Model Providers
-        </CustomButton>
-      </div>
+    <div className="animate-page flex h-full min-h-0 flex-col gap-3">
+      {/* breadcrumb */}
+      <nav
+        aria-label="Breadcrumb"
+        className="flex shrink-0 items-center gap-1.5 text-sm text-muted-foreground"
+      >
+        <Link href="/settings/model-providers" className="transition-colors hover:text-foreground">
+          Model Providers
+        </Link>
+        <ChevronRight className="size-3.5" aria-hidden />
+        <span className="truncate font-medium text-foreground">
+          {providerLoading ? 'Loading…' : (provider?.display_name ?? 'Unknown provider')}
+        </span>
+      </nav>
 
       {/* tight inline header */}
       <header className="flex shrink-0 items-center gap-3">
@@ -550,63 +612,64 @@ export default function ServiceProviderDetailPage() {
         </div>
       </header>
 
-      {/* tab strip + per-tab toolbar */}
-      <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b border-border">
-        <div className="relative -mb-px flex items-center gap-1">
-          <TabButton
-            active={isKeysTab}
-            onClick={() => setActiveTab('keys')}
-            icon={<KeyRound className="size-3.5" />}
-            label="API Keys"
-            count={keysState.total}
+      {/* tab strip */}
+      <div className="flex shrink-0 items-center gap-1 border-b border-border">
+        <TabButton
+          active={isKeysTab}
+          onClick={() => handleTabChange('keys')}
+          icon={<KeyRound className="size-3.5" />}
+          label="API Keys"
+          count={keysState.total}
+        />
+        <TabButton
+          active={!isKeysTab}
+          onClick={() => handleTabChange('models')}
+          icon={<Layers className="size-3.5" />}
+          label="Models"
+          count={modelsState.total}
+        />
+      </div>
+
+      {/* toolbar: search (left) + add (right) */}
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-3">
+        {isKeysTab ? (
+          <TokenSearchBar
+            key="keys-search"
+            fields={keysFields}
+            value={keysTokens}
+            onChange={handleKeysTokens}
+            placeholder="Search keys… (e.g. name:nemotron)"
+            className="w-full sm:max-w-sm"
           />
-          <TabButton
-            active={!isKeysTab}
-            onClick={() => setActiveTab('models')}
-            icon={<Layers className="size-3.5" />}
-            label="Models"
-            count={modelsState.total}
+        ) : (
+          <TokenSearchBar
+            key="models-search"
+            fields={modelsFields}
+            value={modelsTokens}
+            onChange={handleModelsTokens}
+            placeholder="Search models… (e.g. name:gpt)"
+            className="w-full sm:max-w-sm"
           />
-        </div>
-        <div className="flex items-center gap-2 pb-2">
-          {isKeysTab ? (
-            <>
-              <SearchBar
-                placeholder="Search keys…"
-                value={keysSearch}
-                onSearch={handleKeysSearch}
-                debounceMs={300}
-                containerClassName="max-w-[220px]"
-              />
-              <CustomButton
-                type="primary"
-                size="sm"
-                icon={<Plus className="size-4" />}
-                onClick={handleAddKey}
-              >
-                Add API key
-              </CustomButton>
-            </>
-          ) : (
-            <>
-              <SearchBar
-                placeholder="Search models…"
-                value={modelsSearch}
-                onSearch={handleModelsSearch}
-                debounceMs={300}
-                containerClassName="max-w-[220px]"
-              />
-              <CustomButton
-                type="primary"
-                size="sm"
-                icon={<Plus className="size-4" />}
-                onClick={handleAddModel}
-              >
-                Add model
-              </CustomButton>
-            </>
-          )}
-        </div>
+        )}
+        {isKeysTab ? (
+          <CustomButton
+            type="primary"
+            size="sm"
+            icon={<Plus className="size-4" />}
+            onClick={handleAddKey}
+          >
+            Add API key
+          </CustomButton>
+        ) : (
+          <CustomButton
+            type="primary"
+            size="sm"
+            icon={<Plus className="size-4" />}
+            onClick={handleAddModel}
+          >
+            Add model
+          </CustomButton>
+        )}
       </div>
 
       {/* table panes — animated swap; this is the only scroll surface */}

--- a/frontend/src/components/service-providers/ServiceProvidersPage.tsx
+++ b/frontend/src/components/service-providers/ServiceProvidersPage.tsx
@@ -3,18 +3,20 @@
 import { useAtom } from 'jotai';
 import { Plug, Plus } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 
-import servicesAtom, {
-  deleteProviderAtom,
-  fetchServiceAtom,
-  fetchServicesAtom,
-  upsertServiceAtom,
-} from '@/atoms/ServicesAtom';
-import { CustomButton, CustomModal, SearchBar, SelectInput } from '@/components/shared';
+import { deleteProviderAtom, fetchServiceAtom, upsertServiceAtom } from '@/atoms/ServicesAtom';
+import {
+  CustomButton,
+  CustomModal,
+  FacetFilterBar,
+  FacetFilterDrawer,
+  useFacetedList,
+} from '@/components/shared';
+import { servicesListConfig } from '@/components/service-providers/servicesListConfig';
 import { Badge } from '@/components/ui/badge';
 import { listProviderKeys } from '@/services/servicesService';
-import type { ProviderUsage, Service, ServiceKind, ServiceUpsertPayload } from '@/types/service';
+import type { ProviderUsage, Service, ServiceUpsertPayload } from '@/types/service';
 import { handleApiError } from '@/utils/helpers';
 import { showToast } from '@/utils/toast';
 
@@ -23,25 +25,17 @@ import ApiKeyEditDrawer from './api-key-edit-drawer';
 import ServiceGrid from './service-grid';
 import ServiceGridSkeleton from './service-grid-skeleton';
 
-const PAGE_SIZE = 12;
-
-const TYPE_FILTER_OPTIONS = [
-  { value: 'all', label: 'All types' },
-  { value: 'llm', label: 'LLM' },
-  { value: 'stt', label: 'STT' },
-  { value: 'tts', label: 'TTS' },
-];
+const noop = () => {};
 
 export default function ServiceProvidersPage() {
   const router = useRouter();
-  const [state] = useAtom(servicesAtom);
-  const [, fetchServices] = useAtom(fetchServicesAtom);
   const [, fetchService] = useAtom(fetchServiceAtom);
   const [, upsertService] = useAtom(upsertServiceAtom);
   const [, deleteProvider] = useAtom(deleteProviderAtom);
 
-  const [search, setSearch] = useState('');
-  const [typeFilter, setTypeFilter] = useState<'all' | ServiceKind>('all');
+  const fl = useFacetedList(servicesListConfig);
+
+  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const [editingService, setEditingService] = useState<Service | null>(null);
@@ -49,61 +43,6 @@ export default function ServiceProvidersPage() {
   const [isSaving, setIsSaving] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<ProviderUsage | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
-
-  const pageRef = useRef(state.page);
-  pageRef.current = state.page;
-
-  const loadInitial = useCallback(
-    (overrides?: { search?: string; service_type?: 'all' | ServiceKind }) =>
-      fetchServices({
-        page: 1,
-        page_size: PAGE_SIZE,
-        search: overrides?.search ?? search ?? undefined,
-        service_type: overrides?.service_type ?? typeFilter,
-        append: false,
-      }),
-    [fetchServices, search, typeFilter],
-  );
-
-  const hasFetchedRef = useRef(false);
-  useEffect(() => {
-    if (hasFetchedRef.current) return;
-    hasFetchedRef.current = true;
-    loadInitial().catch(handleApiError);
-  }, [loadInitial]);
-
-  const handleSearch = useCallback(
-    (value: string) => {
-      setSearch(value);
-      loadInitial({ search: value }).catch(handleApiError);
-    },
-    [loadInitial],
-  );
-
-  const handleTypeFilter = useCallback(
-    (value: string) => {
-      const v = value as 'all' | ServiceKind;
-      setTypeFilter(v);
-      loadInitial({ service_type: v }).catch(handleApiError);
-    },
-    [loadInitial],
-  );
-
-  const hasNextPage = useMemo(
-    () => state.items.length < state.total,
-    [state.items.length, state.total],
-  );
-
-  const handleFetchNext = useCallback(() => {
-    if (state.loadingMore) return;
-    fetchServices({
-      page: pageRef.current + 1,
-      page_size: PAGE_SIZE,
-      search: search || undefined,
-      service_type: typeFilter,
-      append: true,
-    }).catch(handleApiError);
-  }, [fetchServices, search, typeFilter, state.loadingMore]);
 
   const handleSelect = useCallback(
     (u: ProviderUsage) => {
@@ -170,40 +109,35 @@ export default function ServiceProvidersPage() {
         providerId: deleteTarget.provider.id,
         serviceType: deleteTarget.service_type,
       });
-      // Keep the modal open with the Delete button still in its loading state
-      // until the listing refresh lands, so the user doesn't see a stale card
-      // briefly remain after dismissing the dialog.
-      await loadInitial();
       const typeLabel = deleteTarget.service_type.toUpperCase();
       showToast.success(
         `Removed ${deleted} key${deleted === 1 ? '' : 's'}`,
         `${deleteTarget.provider.display_name} · ${typeLabel} keys have been deleted.`,
       );
       setDeleteTarget(null);
+      fl.refresh();
     } catch (err) {
       handleApiError(err);
     } finally {
       setIsDeleting(false);
     }
-  }, [deleteTarget, deleteProvider, loadInitial]);
+  }, [deleteTarget, deleteProvider, fl]);
 
   const handleCreate = useCallback(
     async (payload: ServiceUpsertPayload) => {
       setIsSaving(true);
       try {
         await upsertService({ values: payload });
-        // Wait for the listing refresh before dismissing the drawer so the
-        // Create button keeps its loading state until the new card is in view.
-        await loadInitial();
         showToast.success('Provider added');
         setCreateOpen(false);
+        fl.refresh();
       } catch (err) {
         handleApiError(err);
       } finally {
         setIsSaving(false);
       }
     },
-    [upsertService, loadInitial],
+    [upsertService, fl],
   );
 
   const handleUpdate = useCallback(
@@ -211,24 +145,22 @@ export default function ServiceProvidersPage() {
       setIsSaving(true);
       try {
         await upsertService({ id, values: payload as ServiceUpsertPayload });
-        // Mirror handleCreate / handleDeleteConfirm: keep the Save button in
-        // its loading state until the refreshed list lands.
-        await loadInitial();
         showToast.success('Provider updated');
         setEditOpen(false);
         setEditingService(null);
+        fl.refresh();
       } catch (err) {
         handleApiError(err);
       } finally {
         setIsSaving(false);
       }
     },
-    [upsertService, loadInitial],
+    [upsertService, fl],
   );
 
-  const isInitialLoading = state.loading && state.items.length === 0;
-  const isEmpty = !isInitialLoading && state.items.length === 0;
-  const hasActiveFilter = !!search || typeFilter !== 'all';
+  const isInitialLoading = fl.listLoading && fl.rows.length === 0;
+  const isEmpty = !isInitialLoading && fl.rows.length === 0;
+  const hasActiveFilter = fl.hasActiveFilters;
 
   return (
     <div className="animate-page flex h-full min-h-0 flex-col gap-5">
@@ -239,9 +171,9 @@ export default function ServiceProvidersPage() {
             <h1 className="text-2xl font-semibold tracking-tight text-foreground">
               Model Providers
             </h1>
-            {state.total > 0 && (
+            {fl.total > 0 && (
               <Badge variant="secondary" className="text-xs tabular-nums">
-                {state.total}
+                {fl.total}
               </Badge>
             )}
           </div>
@@ -255,24 +187,16 @@ export default function ServiceProvidersPage() {
       </div>
 
       {/* toolbar */}
-      <div className="flex flex-wrap items-center gap-3">
-        <SearchBar
-          placeholder="Search providers or services…"
-          value={search}
-          onSearch={handleSearch}
-          debounceMs={300}
-          containerClassName="max-w-xs flex-1"
-        />
-        <SelectInput
-          name="type-filter"
-          options={TYPE_FILTER_OPTIONS}
-          value={typeFilter}
-          onValueChange={handleTypeFilter}
-          placeholder="All types"
-          size="sm"
-          triggerClassName="min-w-[160px]"
-        />
-      </div>
+      <FacetFilterBar
+        fields={fl.tokenFields}
+        tokens={fl.tokens}
+        onTokensChange={fl.setTokens}
+        onClear={fl.clearAll}
+        showClear={fl.hasActiveFilters}
+        placeholder="Search providers… (e.g. name:OpenAI, type:llm)"
+        drawerFilterCount={fl.drawerFilterCount}
+        onOpenDrawer={() => setFilterDrawerOpen(true)}
+      />
 
       {/* grid */}
       <div className="flex min-h-0 flex-1 flex-col">
@@ -282,17 +206,29 @@ export default function ServiceProvidersPage() {
           <EmptyState onAdd={handleAdd} hasFilter={hasActiveFilter} />
         ) : (
           <ServiceGrid
-            items={state.items}
-            total={state.total}
-            hasNextPage={hasNextPage}
-            isFetchingNextPage={state.loadingMore}
-            fetchNextPage={handleFetchNext}
+            items={fl.rows}
+            total={fl.total}
+            hasNextPage={false}
+            isFetchingNextPage={false}
+            fetchNextPage={noop}
             onSelect={handleSelect}
             onEdit={handleEdit}
             onDelete={handleDeleteRequest}
           />
         )}
       </div>
+
+      {/* filter drawer */}
+      <FacetFilterDrawer
+        open={filterDrawerOpen}
+        onClose={() => setFilterDrawerOpen(false)}
+        description="Filter providers by type."
+        sections={servicesListConfig.facetSections}
+        value={fl.facetSelections}
+        facets={fl.facets}
+        facetsLoading={fl.facetsLoading}
+        onApply={fl.applyDrawer}
+      />
 
       {/* create drawer */}
       <ApiKeyCreateDrawer

--- a/frontend/src/components/service-providers/servicesListConfig.ts
+++ b/frontend/src/components/service-providers/servicesListConfig.ts
@@ -1,0 +1,21 @@
+import { fetchFacetedList, fetchFacets, fetchFilterValues } from '@/services/facetedApi';
+import type { FacetedListConfig } from '@/types/facetedList';
+import type { ProviderUsage } from '@/types/service';
+
+const BASE = '/services';
+
+/**
+ * Faceted-list config for the Model Providers page. Name is a multi-select
+ * (provider display name); Type (service_type) is the drawer facet with counts.
+ * The aggregated list caps at 100 cards (backend max) — realistic per org.
+ */
+export const servicesListConfig: FacetedListConfig<ProviderUsage> = {
+  entityName: 'provider',
+  searchField: { key: 'name', label: 'Name' },
+  facetSections: [{ field: 'service_type', label: 'Type', titleCase: true }],
+  defaultPageSize: 100,
+  pageSizeOptions: [100],
+  fetchList: (q) => fetchFacetedList<ProviderUsage>(`${BASE}/list`, q),
+  fetchFacets: (q) => fetchFacets(`${BASE}/facets`, q),
+  fetchFilterValues: (field) => fetchFilterValues(`${BASE}/filter-values`, field),
+};

--- a/frontend/src/components/shared/faceted-list/FacetFilterBar.tsx
+++ b/frontend/src/components/shared/faceted-list/FacetFilterBar.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import CustomButton from '@/components/shared/CustomButton';
+import TokenSearchBar from '@/components/shared/TokenSearchBar';
+import { Badge } from '@/components/ui/badge';
+import type { SearchToken, TokenSearchField } from '@/types/components';
+import { SlidersHorizontal } from 'lucide-react';
+import React from 'react';
+
+export interface FacetFilterBarProps {
+  fields: TokenSearchField[];
+  tokens: SearchToken[];
+  onTokensChange: (tokens: SearchToken[]) => void;
+  onClear?: () => void;
+  showClear?: boolean;
+  drawerFilterCount: number;
+  onOpenDrawer: () => void;
+  placeholder?: string;
+  /** Injected to the right of the search bar (e.g. a sort select for card grids). */
+  rightSlot?: React.ReactNode;
+  /** Hide the Filters button (e.g. when an entity exposes no facets). */
+  hideFilters?: boolean;
+}
+
+/**
+ * Toolbar pairing the tokenized search bar (free-text + facet chips) with a
+ * "Filters" drawer trigger (the drawer carries the facet checkboxes +
+ * server-driven counts). Optionally renders a `rightSlot` — used by card grids
+ * for a sort select.
+ */
+const FacetFilterBar: React.FC<FacetFilterBarProps> = ({
+  fields,
+  tokens,
+  onTokensChange,
+  onClear,
+  showClear,
+  drawerFilterCount,
+  onOpenDrawer,
+  placeholder,
+  rightSlot,
+  hideFilters = false,
+}) => (
+  <div className="flex flex-wrap items-center gap-2">
+    <TokenSearchBar
+      fields={fields}
+      value={tokens}
+      onChange={onTokensChange}
+      onClear={onClear}
+      showClear={showClear}
+      placeholder={placeholder}
+      className="min-w-[240px] flex-1"
+    />
+    {rightSlot}
+    {!hideFilters && (
+      <CustomButton
+        type="default"
+        size="sm"
+        icon={<SlidersHorizontal className="size-4" />}
+        onClick={onOpenDrawer}
+        aria-label="Open filters"
+        className={
+          drawerFilterCount > 0
+            ? 'border-primary/40 bg-primary/5 text-foreground hover:bg-primary/10'
+            : undefined
+        }
+      >
+        Filters
+        {drawerFilterCount > 0 && (
+          <Badge className="ml-2 bg-primary/15 text-primary tabular-nums hover:bg-primary/15">
+            {drawerFilterCount}
+          </Badge>
+        )}
+      </CustomButton>
+    )}
+  </div>
+);
+
+export default FacetFilterBar;

--- a/frontend/src/components/shared/faceted-list/FacetFilterDrawer.tsx
+++ b/frontend/src/components/shared/faceted-list/FacetFilterDrawer.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import CustomButton from '@/components/shared/CustomButton';
+import CustomDrawer from '@/components/shared/CustomDrawer';
+import type { FacetFilterDrawerProps } from '@/types/facetedList';
+import React, { useEffect, useState } from 'react';
+
+import FacetSection from './FacetSection';
+import { countFacetFilters } from './utils';
+
+/**
+ * Config-driven filter drawer: renders a checkbox facet section per
+ * `FacetSectionConfig`, with server-driven counts. Edits live in a local draft
+ * until the user clicks Apply (mirrors the Call History drawer).
+ */
+const FacetFilterDrawer: React.FC<FacetFilterDrawerProps> = ({
+  open,
+  onClose,
+  title = 'Filters',
+  description,
+  sections,
+  value,
+  facets,
+  facetsLoading,
+  onApply,
+  extraSections,
+}) => {
+  const [draft, setDraft] = useState<Record<string, string[]>>(value);
+
+  // Re-seed the draft from the applied value every time the drawer opens.
+  useEffect(() => {
+    if (open) setDraft(value);
+  }, [open, value]);
+
+  const toggleFacet = (field: string, val: string) => {
+    setDraft((prev) => {
+      const current = prev[field] ?? [];
+      const next = current.includes(val) ? current.filter((v) => v !== val) : [...current, val];
+      const draftNext = { ...prev };
+      if (next.length) draftNext[field] = next;
+      else delete draftNext[field];
+      return draftNext;
+    });
+  };
+
+  const handleReset = () => setDraft({});
+
+  const handleApply = () => {
+    onApply(draft);
+    onClose();
+  };
+
+  const activeCount = countFacetFilters(draft);
+
+  return (
+    <CustomDrawer
+      open={open}
+      onClose={onClose}
+      title={title}
+      description={description}
+      side="right"
+      width="w-full sm:max-w-[420px]"
+      contentClassName="px-6 pb-6"
+      footer={
+        <div className="flex items-center justify-between gap-2">
+          <CustomButton type="text" size="sm" onClick={handleReset} disabled={activeCount === 0}>
+            Reset
+          </CustomButton>
+          <CustomButton type="primary" size="sm" onClick={handleApply}>
+            Apply
+          </CustomButton>
+        </div>
+      }
+    >
+      <div className="flex flex-col">
+        {sections.map((s) => (
+          <FacetSection
+            key={s.field}
+            field={s.field}
+            label={s.label}
+            titleCase={s.titleCase}
+            values={facets[s.field] ?? []}
+            selected={draft[s.field] ?? []}
+            loading={facetsLoading}
+            onToggle={toggleFacet}
+          />
+        ))}
+        {extraSections}
+      </div>
+    </CustomDrawer>
+  );
+};
+
+export default FacetFilterDrawer;

--- a/frontend/src/components/shared/faceted-list/FacetOptionList.tsx
+++ b/frontend/src/components/shared/faceted-list/FacetOptionList.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { Checkbox } from '@/components/ui/checkbox';
+import type { FacetOptionListProps, FacetValue } from '@/types/facetedList';
+import { cn } from '@/utils/cn';
+import { Search } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+
+import { titleCase } from './utils';
+
+/** Searchable checkbox list of facet values with per-value counts. */
+const FacetOptionList: React.FC<FacetOptionListProps> = ({
+  field,
+  label,
+  titleCase: useTitleCase,
+  values,
+  selected,
+  loading,
+  onToggle,
+}) => {
+  const [query, setQuery] = useState('');
+  const format = (v: string) => (useTitleCase ? titleCase(v) : v);
+
+  const options = useMemo<FacetValue[]>(() => {
+    const present = new Set(values.map((v) => v.value));
+    // Keep selected-but-absent values visible (count 0) so they can be unchecked.
+    const extra = selected.filter((s) => !present.has(s)).map((s) => ({ value: s, count: 0 }));
+    return [...values, ...extra];
+  }, [values, selected]);
+
+  const showSearch = options.length > 8;
+  const filtered = query
+    ? options.filter((o) => format(o.value).toLowerCase().includes(query.toLowerCase()))
+    : options;
+
+  const isLoading = loading && values.length === 0;
+
+  return (
+    <>
+      {showSearch && (
+        <div className="mb-2 flex items-center gap-2 rounded-md border border-input bg-background px-2">
+          <Search className="size-3.5 shrink-0 text-muted-foreground" />
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={`Search ${label.toLowerCase()}…`}
+            aria-label={`Search ${label}`}
+            className="h-7 w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          />
+        </div>
+      )}
+
+      <div className="flex max-h-56 flex-col gap-0.5 overflow-y-auto">
+        {isLoading ? (
+          Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-2.5 px-2 py-1.5">
+              <div className="size-3.5 animate-pulse rounded bg-muted" />
+              <div className="h-3.5 flex-1 animate-pulse rounded bg-muted" />
+            </div>
+          ))
+        ) : filtered.length === 0 ? (
+          <p className="px-2 py-1.5 text-[13px] text-muted-foreground">No values</p>
+        ) : (
+          filtered.map((o) => {
+            const checkboxId = `facet-${field}-${o.value}`;
+            const isSelected = selected.includes(o.value);
+            return (
+              <label
+                key={o.value}
+                htmlFor={checkboxId}
+                className={cn(
+                  'flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 transition-colors hover:bg-muted/50',
+                  isSelected && 'bg-primary/5',
+                )}
+              >
+                <Checkbox
+                  id={checkboxId}
+                  checked={isSelected}
+                  onCheckedChange={() => onToggle(field, o.value)}
+                  className="size-3.5"
+                />
+                <span
+                  className={cn(
+                    'flex-1 truncate text-[13px] text-foreground',
+                    o.count === 0 && !isSelected && 'opacity-50',
+                  )}
+                >
+                  {format(o.value)}
+                </span>
+                <span className="text-xs tabular-nums text-muted-foreground">{o.count}</span>
+              </label>
+            );
+          })
+        )}
+      </div>
+    </>
+  );
+};
+
+export default FacetOptionList;

--- a/frontend/src/components/shared/faceted-list/FacetSection.tsx
+++ b/frontend/src/components/shared/faceted-list/FacetSection.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import type { FacetSectionProps } from '@/types/facetedList';
+import React from 'react';
+
+import FacetOptionList from './FacetOptionList';
+import FilterSection from './FilterSection';
+
+/** A faceted checkbox section rendered inside the drawer. */
+const FacetSection: React.FC<FacetSectionProps> = ({
+  field,
+  label,
+  titleCase,
+  values,
+  selected,
+  loading,
+  onToggle,
+}) => (
+  <FilterSection title={label} count={selected.length} defaultOpen={selected.length > 0}>
+    <FacetOptionList
+      field={field}
+      label={label}
+      titleCase={titleCase}
+      values={values}
+      selected={selected}
+      loading={loading}
+      onToggle={onToggle}
+    />
+  </FilterSection>
+);
+
+export default FacetSection;

--- a/frontend/src/components/shared/faceted-list/FilterSection.tsx
+++ b/frontend/src/components/shared/faceted-list/FilterSection.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import CustomButton from '@/components/shared/CustomButton';
+import type { FilterSectionProps } from '@/types/facetedList';
+import { cn } from '@/utils/cn';
+import { ChevronDown } from 'lucide-react';
+import React, { useState } from 'react';
+
+/** Collapsible drawer section with a CustomButton disclosure header. */
+const FilterSection: React.FC<FilterSectionProps> = ({
+  title,
+  count = 0,
+  defaultOpen = true,
+  children,
+}) => {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="border-b border-border last:border-0">
+      <CustomButton
+        type="text"
+        size="sm"
+        fullWidth
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="group h-auto justify-start gap-2 px-0 py-3 hover:bg-transparent"
+      >
+        <ChevronDown
+          className={cn(
+            'size-4 shrink-0 text-muted-foreground transition-[transform,color] group-hover:text-foreground',
+            !open && '-rotate-90',
+          )}
+        />
+        <span className="text-sm font-medium text-foreground">{title}</span>
+        {count > 0 && (
+          <span className="ml-auto rounded-full bg-primary/15 px-1.5 text-[11px] font-medium tabular-nums text-primary">
+            {count}
+          </span>
+        )}
+      </CustomButton>
+      {open && <div className="pb-3">{children}</div>}
+    </div>
+  );
+};
+
+export default FilterSection;

--- a/frontend/src/components/shared/faceted-list/index.ts
+++ b/frontend/src/components/shared/faceted-list/index.ts
@@ -1,0 +1,12 @@
+export { default as FacetFilterBar } from './FacetFilterBar';
+export type { FacetFilterBarProps } from './FacetFilterBar';
+export { default as FacetFilterDrawer } from './FacetFilterDrawer';
+export { useFacetedList } from './useFacetedList';
+export type { UseFacetedListResult } from './useFacetedList';
+export {
+  countFacetFilters,
+  facetsToFilterParams,
+  facetsToTokens,
+  titleCase,
+  tokensToFacets,
+} from './utils';

--- a/frontend/src/components/shared/faceted-list/useFacetedList.ts
+++ b/frontend/src/components/shared/faceted-list/useFacetedList.ts
@@ -1,0 +1,277 @@
+'use client';
+
+import type { CustomTableSortState, SearchToken, TokenSearchField } from '@/types/components';
+import type {
+  FacetedFacetsQuery,
+  FacetedListConfig,
+  FacetedListQuery,
+  Facets,
+} from '@/types/facetedList';
+import { handleApiError } from '@/utils/helpers';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  countFacetFilters,
+  facetsToFilterParams,
+  facetsToTokens,
+  titleCase,
+  tokensToFacets,
+} from './utils';
+
+export interface UseFacetedListResult<TRow> {
+  rows: TRow[];
+  total: number;
+  listLoading: boolean;
+  facets: Facets;
+  facetsLoading: boolean;
+  page: number;
+  pageSize: number;
+  pageSizeOptions?: number[];
+  /** Selected drawer facets (drawer source of truth). */
+  facetSelections: Record<string, string[]>;
+  /** Token chips for the search bar (search-field multi-select + facets). */
+  tokens: SearchToken[];
+  /** Field definitions for the token search bar. */
+  tokenFields: TokenSearchField[];
+  drawerFilterCount: number;
+  hasActiveFilters: boolean;
+  setTokens: (tokens: SearchToken[]) => void;
+  applyDrawer: (next: Record<string, string[]>) => void;
+  clearAll: () => void;
+  handleSortChange: (sort: CustomTableSortState | null) => void;
+  handlePaginationChange: (page: number, pageSize: number) => void;
+  refresh: () => void;
+}
+
+/**
+ * Server-driven faceted list state: a tokenized search bar (multi-select value
+ * dropdowns — a search field plus the enum facets, two-way synced with the
+ * filter drawer), server-computed facet counts, sort and pagination. Mirrors
+ * the Call History page but is generic and
+ * framework-neutral — it calls the entity's `fetch*` fns directly. The facets
+ * request depends only on the active facet filters, so searching, sorting or
+ * paginating never re-issues `/facets`.
+ */
+export function useFacetedList<TRow>(config: FacetedListConfig<TRow>): UseFacetedListResult<TRow> {
+  const configRef = useRef(config);
+  configRef.current = config;
+
+  const [rows, setRows] = useState<TRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [listLoading, setListLoading] = useState(true);
+  const [facets, setFacets] = useState<Facets>({});
+  const [facetsLoading, setFacetsLoading] = useState(false);
+
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(config.defaultPageSize ?? 10);
+  const [sortBy, setSortBy] = useState<string | undefined>(config.defaultSort?.field);
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>(config.defaultSort?.order ?? 'desc');
+  // The search field (e.g. Name) is a multi-select filter shown in the token
+  // bar but NOT in the drawer. Kept separate from the drawer facets.
+  const [searchSelections, setSearchSelections] = useState<string[]>([]);
+  const [facetSelections, setFacetSelections] = useState<Record<string, string[]>>({});
+
+  // Facets are counted from the drawer facets only — the (high-cardinality,
+  // exact-match) search field should not skew them.
+  const facetFilters = useMemo(() => facetsToFilterParams(facetSelections), [facetSelections]);
+
+  // The list is filtered by both the search-field selections and the facets.
+  const listFilters = useMemo(() => {
+    const combined: Record<string, string[]> = { ...facetSelections };
+    const key = config.searchField?.key;
+    if (key && searchSelections.length) combined[key] = searchSelections;
+    return facetsToFilterParams(combined);
+  }, [facetSelections, searchSelections, config.searchField]);
+
+  const listQuery = useMemo<FacetedListQuery>(() => {
+    const q: FacetedListQuery = { page_no: page, page_size: pageSize };
+    if (listFilters.length) q.filters = listFilters;
+    if (sortBy) {
+      q.sort_by = sortBy;
+      q.sort_order = sortOrder;
+    }
+    return q;
+  }, [page, pageSize, listFilters, sortBy, sortOrder]);
+
+  // Facet counts depend only on the active facet filters (not search/sort/page).
+  const facetsQuery = useMemo<FacetedFacetsQuery>(
+    () => (facetFilters.length ? { filters: facetFilters } : {}),
+    [facetFilters],
+  );
+
+  // Refs so the fetch callbacks stay stable while reading the latest query.
+  const listQueryRef = useRef(listQuery);
+  listQueryRef.current = listQuery;
+  const facetsQueryRef = useRef(facetsQuery);
+  facetsQueryRef.current = facetsQuery;
+
+  const listSeq = useRef(0);
+  const runListFetch = useCallback((silent = false) => {
+    const seq = ++listSeq.current;
+    if (!silent) setListLoading(true);
+    configRef.current
+      .fetchList(listQueryRef.current)
+      .then((res) => {
+        if (seq !== listSeq.current) return;
+        setRows(res.rows);
+        setTotal(res.total);
+      })
+      .catch((err) => {
+        if (seq !== listSeq.current) return;
+        handleApiError(err);
+      })
+      .finally(() => {
+        if (seq === listSeq.current && !silent) setListLoading(false);
+      });
+  }, []);
+
+  const facetsSeq = useRef(0);
+  const runFacetsFetch = useCallback(() => {
+    if (!configRef.current.facetSections.length) return;
+    const seq = ++facetsSeq.current;
+    setFacetsLoading(true);
+    configRef.current
+      .fetchFacets(facetsQueryRef.current)
+      .then((res) => {
+        if (seq === facetsSeq.current) setFacets(res);
+      })
+      .catch((err) => {
+        if (seq === facetsSeq.current) handleApiError(err);
+      })
+      .finally(() => {
+        if (seq === facetsSeq.current) setFacetsLoading(false);
+      });
+  }, []);
+
+  // List re-fetches on any query change (page/size/search/sort/filters).
+  useEffect(() => {
+    runListFetch();
+  }, [listQuery, runListFetch]);
+
+  // Facets re-fetch only when the active filters change.
+  useEffect(() => {
+    runFacetsFetch();
+  }, [facetsQuery, runFacetsFetch]);
+
+  // Optional polling (e.g. while documents are still processing).
+  useEffect(() => {
+    const cfg = configRef.current;
+    if (!cfg.pollWhile || !cfg.pollWhile(rows)) return;
+    const id = setInterval(() => runListFetch(true), cfg.pollIntervalMs ?? 4000);
+    return () => clearInterval(id);
+  }, [rows, runListFetch]);
+
+  // Token bar fields: the optional search field (a value dropdown backed by
+  // /filter-values), then the enum facets.
+  const tokenFields = useMemo<TokenSearchField[]>(() => {
+    const fields: TokenSearchField[] = [];
+    if (config.searchField) {
+      const searchKey = config.searchField.key;
+      fields.push({
+        key: searchKey,
+        label: config.searchField.label,
+        type: 'enum',
+        fetchValues: () => configRef.current.fetchFilterValues(searchKey),
+      });
+    }
+    for (const s of config.facetSections) {
+      fields.push({
+        key: s.field,
+        label: s.label,
+        type: 'enum',
+        fetchValues: () => configRef.current.fetchFilterValues(s.field),
+        formatValue: s.titleCase ? titleCase : undefined,
+      });
+    }
+    return fields;
+  }, [config.searchField, config.facetSections]);
+
+  // Token chips: one per selected search value (multi-select) plus one per
+  // selected facet value.
+  const tokens = useMemo<SearchToken[]>(() => {
+    const out: SearchToken[] = [];
+    const key = config.searchField?.key;
+    if (key) out.push(...searchSelections.map((value) => ({ field: key, value })));
+    out.push(...facetsToTokens(facetSelections, config.facetSections));
+    return out;
+  }, [config.searchField, config.facetSections, searchSelections, facetSelections]);
+
+  // The Filters drawer badge counts drawer facets only (Name lives in the bar).
+  const drawerFilterCount = useMemo(() => countFacetFilters(facetSelections), [facetSelections]);
+  const hasActiveFilters = useMemo(
+    () => searchSelections.length > 0 || Object.values(facetSelections).some((v) => v.length > 0),
+    [searchSelections, facetSelections],
+  );
+
+  const setTokens = useCallback((next: SearchToken[]) => {
+    const cfg = configRef.current;
+    const searchKey = cfg.searchField?.key;
+    if (searchKey) {
+      // All search-field tokens become the multi-select values (deduped).
+      const values: string[] = [];
+      for (const t of next) {
+        if (t.field === searchKey && !values.includes(t.value)) values.push(t.value);
+      }
+      setSearchSelections(values);
+    }
+    setFacetSelections(tokensToFacets(next, cfg.facetSections));
+    setPage(1);
+  }, []);
+
+  const applyDrawer = useCallback((nextFacets: Record<string, string[]>) => {
+    setFacetSelections(nextFacets);
+    setPage(1);
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setSearchSelections([]);
+    setFacetSelections({});
+    setPage(1);
+  }, []);
+
+  const handleSortChange = useCallback((sort: CustomTableSortState | null) => {
+    if (sort) {
+      setSortBy(sort.field);
+      setSortOrder(sort.order);
+    } else {
+      setSortBy(configRef.current.defaultSort?.field);
+      setSortOrder(configRef.current.defaultSort?.order ?? 'desc');
+    }
+    setPage(1);
+  }, []);
+
+  const handlePaginationChange = useCallback((nextPage: number, nextPageSize: number) => {
+    setPage(nextPage);
+    setPageSize(nextPageSize);
+  }, []);
+
+  // Re-fetch both the list and the facet counts. Mutations (create / delete /
+  // upload / reprocess) call this, and the facet counts must reflect the change
+  // too — the facets effect only fires when the active filters change.
+  const refresh = useCallback(() => {
+    runListFetch();
+    runFacetsFetch();
+  }, [runListFetch, runFacetsFetch]);
+
+  return {
+    rows,
+    total,
+    listLoading,
+    facets,
+    facetsLoading,
+    page,
+    pageSize,
+    pageSizeOptions: config.pageSizeOptions,
+    facetSelections,
+    tokens,
+    tokenFields,
+    drawerFilterCount,
+    hasActiveFilters,
+    setTokens,
+    applyDrawer,
+    clearAll,
+    handleSortChange,
+    handlePaginationChange,
+    refresh,
+  };
+}

--- a/frontend/src/components/shared/faceted-list/utils.ts
+++ b/frontend/src/components/shared/faceted-list/utils.ts
@@ -1,0 +1,47 @@
+import type { FacetSectionConfig, ListFilterParam } from '@/types/facetedList';
+import type { SearchToken } from '@/types/components';
+
+/** `in_progress` → `In Progress`. */
+export const titleCase = (v: string) =>
+  v.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+
+/** Selected facets → one `in` filter per field with at least one value. */
+export function facetsToFilterParams(facets: Record<string, string[]>): ListFilterParam[] {
+  const out: ListFilterParam[] = [];
+  for (const [field, vals] of Object.entries(facets)) {
+    if (vals?.length) out.push({ field, operator: 'in', value: vals });
+  }
+  return out;
+}
+
+/** Selected facets → flat token list for the token search bar. */
+export function facetsToTokens(
+  facets: Record<string, string[]>,
+  sections: FacetSectionConfig[],
+): SearchToken[] {
+  const out: SearchToken[] = [];
+  for (const s of sections) {
+    for (const v of facets[s.field] ?? []) out.push({ field: s.field, value: v });
+  }
+  return out;
+}
+
+/** Token list → selected facets (ignores tokens for unknown fields). */
+export function tokensToFacets(
+  tokens: SearchToken[],
+  sections: FacetSectionConfig[],
+): Record<string, string[]> {
+  const keys = new Set(sections.map((s) => s.field));
+  const facets: Record<string, string[]> = {};
+  for (const t of tokens) {
+    if (!keys.has(t.field)) continue;
+    const current = facets[t.field] ?? [];
+    if (!current.includes(t.value)) facets[t.field] = [...current, t.value];
+  }
+  return facets;
+}
+
+/** Number of facet fields with at least one selected value. */
+export function countFacetFilters(facets: Record<string, string[]>): number {
+  return Object.values(facets).reduce((n, v) => n + (v?.length ? 1 : 0), 0);
+}

--- a/frontend/src/components/shared/index.tsx
+++ b/frontend/src/components/shared/index.tsx
@@ -64,6 +64,17 @@ export type { CustomCardProps } from './CustomCard';
 export type { SearchableSelectOption } from './SearchableSelect';
 export type { TabItem } from './CustomTab';
 export type { ActionMenuProps } from './ActionMenu';
+export {
+  FacetFilterBar,
+  FacetFilterDrawer,
+  useFacetedList,
+  countFacetFilters,
+  facetsToFilterParams,
+  facetsToTokens,
+  titleCase as facetTitleCase,
+  tokensToFacets,
+} from './faceted-list';
+export type { FacetFilterBarProps, UseFacetedListResult } from './faceted-list';
 
 export {
   ActionMenu,

--- a/frontend/src/components/tools/ToolsListPage.tsx
+++ b/frontend/src/components/tools/ToolsListPage.tsx
@@ -1,19 +1,24 @@
 'use client';
 
-import { useQueryClient } from '@tanstack/react-query';
 import { Plus, Trash2, Wrench, X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useCallback, useMemo, useState } from 'react';
 
-import { ActionMenu, CustomButton, CustomModal, CustomTable } from '@/components/shared';
-import SearchBar from '@/components/shared/SearchBar';
-import SelectInput from '@/components/shared/SelectInput';
+import {
+  ActionMenu,
+  CustomButton,
+  CustomModal,
+  CustomTable,
+  FacetFilterBar,
+  FacetFilterDrawer,
+  useFacetedList,
+} from '@/components/shared';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
 import { TOOL_TYPE_HEADER } from '@/constants/toolForm';
-import { TOOLS_QUERY_KEY, toolsApi, useDeleteTool, useTools } from '@/lib/api/tools';
-import { TOOL_STATUS_OPTIONS, TOOL_TYPE_OPTIONS } from '@/lib/constants/filters';
-import type { CustomTableColumn, CustomTableSortState } from '@/types/components';
+import { toolsApi, useDeleteTool } from '@/lib/api/tools';
+import { toolsListConfig } from '@/components/tools/toolsListConfig';
+import type { CustomTableColumn } from '@/types/components';
 import type { Tool } from '@/types/tool';
 import { cn } from '@/utils/cn';
 import { showToast } from '@/utils/toast';
@@ -26,69 +31,20 @@ const METHOD_COLORS: Record<string, string> = {
   PATCH: 'bg-violet-100 text-violet-700 dark:bg-violet-500/15 dark:text-violet-400',
 };
 
-const PAGE_SIZE_OPTIONS = [10, 20, 50];
-
 export default function ToolsListPage() {
   const router = useRouter();
-  const queryClient = useQueryClient();
 
-  const [page, setPage] = useState(1);
-  const [pageSize, setPageSize] = useState(20);
-  const [sortBy, setSortBy] = useState('-updated_at');
-  const [search, setSearch] = useState('');
-  const [typeFilter, setTypeFilter] = useState('all');
-  const [statusFilter, setStatusFilter] = useState('all');
+  const fl = useFacetedList(toolsListConfig);
+  const tools = fl.rows;
+  const total = fl.total;
+
+  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [bulkDeleting, setBulkDeleting] = useState(false);
 
-  const queryParams = useMemo(
-    () => ({
-      page,
-      page_size: pageSize,
-      sort_by: sortBy,
-      search: search || undefined,
-      tool_type: typeFilter !== 'all' ? typeFilter : undefined,
-      is_active: statusFilter === 'active' ? true : statusFilter === 'inactive' ? false : undefined,
-    }),
-    [page, pageSize, sortBy, search, typeFilter, statusFilter],
-  );
-
-  const { data, isLoading, isFetching } = useTools(queryParams);
-  const tools = data?.items ?? [];
-  const total = data?.total ?? 0;
-
   const deleteMutation = useDeleteTool();
-
-  const handleSearch = useCallback((value: string) => {
-    setSearch(value);
-    setPage(1);
-  }, []);
-
-  const handleTypeFilter = useCallback((value: string) => {
-    setTypeFilter(value);
-    setPage(1);
-  }, []);
-
-  const handleStatusFilter = useCallback((value: string) => {
-    setStatusFilter(value);
-    setPage(1);
-  }, []);
-
-  const handleSortChange = useCallback((sort: CustomTableSortState | null) => {
-    if (!sort) {
-      setSortBy('-updated_at');
-    } else {
-      setSortBy(sort.order === 'desc' ? `-${sort.field}` : sort.field);
-    }
-    setPage(1);
-  }, []);
-
-  const handlePageChange = useCallback((nextPage: number, nextPageSize: number) => {
-    setPage(nextPage);
-    setPageSize(nextPageSize);
-  }, []);
 
   const handleEdit = useCallback(
     (tool: Tool) => {
@@ -103,7 +59,7 @@ export default function ToolsListPage() {
     const ids = Array.from(selectedIds);
     const results = await Promise.allSettled(ids.map((id) => toolsApi.delete(id)));
     const failed = results.filter((r) => r.status === 'rejected').length;
-    queryClient.invalidateQueries({ queryKey: [TOOLS_QUERY_KEY] });
+    fl.refresh();
     setBulkDeleting(false);
     setBulkDeleteOpen(false);
 
@@ -124,7 +80,7 @@ export default function ToolsListPage() {
       });
       setSelectedIds(failedIds);
     }
-  }, [selectedIds, queryClient]);
+  }, [selectedIds, fl]);
 
   const toggleRow = useCallback((id: string) => {
     setSelectedIds((prev) => {
@@ -300,16 +256,26 @@ export default function ToolsListPage() {
                 next.delete(record.id);
                 return next;
               });
+              fl.refresh();
             }}
             itemName={record.name}
           />
         ),
       },
     ],
-    [allRowsSelected, someRowsSelected, toggleAllRows, selectedIds, toggleRow, handleEdit],
+    [
+      allRowsSelected,
+      someRowsSelected,
+      toggleAllRows,
+      selectedIds,
+      toggleRow,
+      handleEdit,
+      deleteMutation,
+      fl,
+    ],
   );
 
-  const hasFilter = !!search || typeFilter !== 'all' || statusFilter !== 'all';
+  const hasFilter = fl.hasActiveFilters;
 
   return (
     <div className="animate-page flex h-full min-h-0 flex-col gap-5">
@@ -338,33 +304,16 @@ export default function ToolsListPage() {
       </div>
 
       {/* Toolbar */}
-      <div className="flex flex-wrap items-center gap-3">
-        <SearchBar
-          placeholder="Search tools..."
-          value={search}
-          onSearch={handleSearch}
-          debounceMs={400}
-          containerClassName="max-w-xs flex-1"
-        />
-        <SelectInput
-          name="type-filter"
-          options={TOOL_TYPE_OPTIONS}
-          value={typeFilter}
-          onValueChange={handleTypeFilter}
-          placeholder="All types"
-          size="sm"
-          triggerClassName="min-w-[160px]"
-        />
-        <SelectInput
-          name="status-filter"
-          options={TOOL_STATUS_OPTIONS}
-          value={statusFilter}
-          onValueChange={handleStatusFilter}
-          placeholder="All statuses"
-          size="sm"
-          triggerClassName="min-w-[160px]"
-        />
-      </div>
+      <FacetFilterBar
+        fields={fl.tokenFields}
+        tokens={fl.tokens}
+        onTokensChange={fl.setTokens}
+        onClear={fl.clearAll}
+        showClear={fl.hasActiveFilters}
+        placeholder="Search tools… (e.g. name:weather, status:active)"
+        drawerFilterCount={fl.drawerFilterCount}
+        onOpenDrawer={() => setFilterDrawerOpen(true)}
+      />
 
       {/* Table */}
       <div className="flex min-h-0 flex-1 flex-col">
@@ -372,22 +321,34 @@ export default function ToolsListPage() {
           columns={columns}
           dataSource={tools}
           rowKey="id"
-          loading={isLoading || isFetching}
+          loading={fl.listLoading}
           onRowClick={handleEdit}
-          onSortChange={handleSortChange}
-          initialSort={{ field: 'updated_at', order: 'desc' }}
+          onSortChange={fl.handleSortChange}
+          initialSort={toolsListConfig.defaultSort ?? undefined}
           pagination={{
-            current: page,
-            pageSize,
+            current: fl.page,
+            pageSize: fl.pageSize,
             total,
-            pageSizeOptions: PAGE_SIZE_OPTIONS,
-            onChange: handlePageChange,
+            pageSizeOptions: fl.pageSizeOptions,
+            onChange: fl.handlePaginationChange,
           }}
           emptyState={
             <EmptyState onAdd={() => router.push('/tools/create')} hasFilter={hasFilter} />
           }
         />
       </div>
+
+      {/* Filter drawer */}
+      <FacetFilterDrawer
+        open={filterDrawerOpen}
+        onClose={() => setFilterDrawerOpen(false)}
+        description="Filter tools by type and status."
+        sections={toolsListConfig.facetSections}
+        value={fl.facetSelections}
+        facets={fl.facets}
+        facetsLoading={fl.facetsLoading}
+        onApply={fl.applyDrawer}
+      />
 
       {/* Selection bar */}
       <SelectionBar

--- a/frontend/src/components/tools/toolsListConfig.ts
+++ b/frontend/src/components/tools/toolsListConfig.ts
@@ -1,0 +1,21 @@
+import { fetchFacetedList, fetchFacets, fetchFilterValues } from '@/services/facetedApi';
+import type { FacetedListConfig } from '@/types/facetedList';
+import type { Tool } from '@/types/tool';
+
+const BASE = '/tool';
+
+/** Faceted-list config for the Tools page (filter by type + status). */
+export const toolsListConfig: FacetedListConfig<Tool> = {
+  entityName: 'tool',
+  searchField: { key: 'name', label: 'Name' },
+  facetSections: [
+    { field: 'tool_type', label: 'Type', titleCase: true },
+    { field: 'status', label: 'Status', titleCase: true },
+  ],
+  defaultSort: { field: 'updated_at', order: 'desc' },
+  defaultPageSize: 20,
+  pageSizeOptions: [10, 20, 50],
+  fetchList: (q) => fetchFacetedList<Tool>(`${BASE}/list`, q),
+  fetchFacets: (q) => fetchFacets(`${BASE}/facets`, q),
+  fetchFilterValues: (field) => fetchFilterValues(`${BASE}/filter-values`, field),
+};

--- a/frontend/src/services/facetedApi.ts
+++ b/frontend/src/services/facetedApi.ts
@@ -1,0 +1,61 @@
+/**
+ * Transport helpers for the faceted-list pattern. Each entity exposes three
+ * endpoints — POST `/{entity}/list`, POST `/{entity}/facets`, and
+ * GET `/{entity}/filter-values` — and these helpers normalize their responses
+ * for `useFacetedList`.
+ */
+
+import type { FacetedFacetsQuery, FacetedListQuery, Facets } from '@/types/facetedList';
+import axios from '@/utils/axios';
+
+/** POST a faceted list query and normalize the envelope to `{ rows, total }`. */
+export async function fetchFacetedList<T>(
+  url: string,
+  query: FacetedListQuery,
+): Promise<{ rows: T[]; total: number }> {
+  // Entity list endpoints use `page` (not call-log's `page_no`).
+  const body: Record<string, unknown> = {
+    page: query.page_no,
+    page_size: query.page_size,
+  };
+  if (query.search) body.search = query.search;
+  if (query.sort_by) {
+    body.sort_by = query.sort_by;
+    body.sort_order = query.sort_order;
+  }
+  if (query.filters?.length) body.filters = query.filters;
+
+  const { data } = await axios.post(url, body);
+
+  if (Array.isArray(data)) return { rows: data as T[], total: data.length };
+  if (data && typeof data === 'object') {
+    const d = data as Record<string, unknown>;
+    // { items, total } — tool / knowledge-base / agent
+    if (Array.isArray(d.items)) {
+      return { rows: d.items as T[], total: (d.total as number) ?? d.items.length };
+    }
+    // { data, pagination } — mcp-server
+    if (Array.isArray(d.data) && d.pagination) {
+      const total = (d.pagination as { total?: number }).total ?? (d.data as T[]).length;
+      return { rows: d.data as T[], total };
+    }
+    if (Array.isArray(d.rows)) {
+      return { rows: d.rows as T[], total: (d.total as number) ?? d.rows.length };
+    }
+  }
+  return { rows: [], total: 0 };
+}
+
+/** POST a facets query and return the `{ field: [{ value, count }] }` map. */
+export async function fetchFacets(url: string, query: FacetedFacetsQuery): Promise<Facets> {
+  const { data } = await axios.post<Facets>(url, query);
+  return data ?? {};
+}
+
+/** GET distinct values of a column for token-search autocomplete. */
+export async function fetchFilterValues(url: string, field: string): Promise<string[]> {
+  const { data } = await axios.get<{ column: string; values: string[] }>(url, {
+    params: { column_name: field },
+  });
+  return data?.values ?? [];
+}

--- a/frontend/src/services/servicesService.ts
+++ b/frontend/src/services/servicesService.ts
@@ -94,6 +94,30 @@ export async function listProviderKeys(
   return pagedListRequest<Service>(`/services/providers/${providerId}/keys`, body);
 }
 
+export async function listProviderKeyFilterValues(
+  providerId: string,
+  columnName: string,
+  serviceType?: string,
+): Promise<string[]> {
+  const { data } = await axios.get<{ column: string; values: string[] }>(
+    `/services/providers/${providerId}/keys/filter-values`,
+    { params: { column_name: columnName, ...(serviceType ? { service_type: serviceType } : {}) } },
+  );
+  return data?.values ?? [];
+}
+
+export async function listProviderModelFilterValues(
+  providerId: string,
+  columnName: string,
+  serviceType?: string,
+): Promise<string[]> {
+  const { data } = await axios.get<{ column: string; values: string[] }>(
+    `/services/providers/${providerId}/models/filter-values`,
+    { params: { column_name: columnName, ...(serviceType ? { service_type: serviceType } : {}) } },
+  );
+  return data?.values ?? [];
+}
+
 export interface ListProviderModelsParams {
   page?: number;
   page_size?: number;

--- a/frontend/src/types/facetedList.ts
+++ b/frontend/src/types/facetedList.ts
@@ -1,0 +1,125 @@
+import type { ReactNode } from 'react';
+
+import type { CustomTableSortState } from '@/types/components';
+
+/** A single facet value with its server-computed count. */
+export interface FacetValue {
+  value: string;
+  count: number;
+}
+
+/** Map of facet field → its values+counts, as returned by `/{entity}/facets`. */
+export type Facets = Record<string, FacetValue[]>;
+
+/** Config for one faceted (checkbox) filter field. */
+export interface FacetSectionConfig {
+  field: string;
+  label: string;
+  /** Title-case the values for display (e.g. `in_progress` → `In Progress`). */
+  titleCase?: boolean;
+}
+
+/** Generic `{field, operator, value}` filter sent to a list/facets endpoint. */
+export interface ListFilterParam {
+  field: string;
+  operator: string;
+  value: string | number | boolean | Array<string | number>;
+}
+
+/** Request shape for a faceted list fetch. */
+export interface FacetedListQuery {
+  page_no: number;
+  page_size: number;
+  /** Free-text search (mapped to the backend `search` named param). */
+  search?: string;
+  sort_by?: string;
+  sort_order?: 'asc' | 'desc';
+  filters?: ListFilterParam[];
+}
+
+/** Request shape for a facets fetch (depends only on the active filters). */
+export interface FacetedFacetsQuery {
+  filters?: ListFilterParam[];
+}
+
+/** A sortable column option (used by card grids that sort via a select). */
+export interface SortableColumn {
+  key: string;
+  label: string;
+}
+
+/**
+ * Per-entity configuration that drives the whole faceted-list UX. Each page owns
+ * the transport (the three `fetch*` fns) so endpoint URLs stay out of the shared
+ * layer. Define configs as module-level constants so their identity is stable.
+ */
+export interface FacetedListConfig<TRow> {
+  /** Used in copy / aria (e.g. 'tool'). */
+  entityName: string;
+  /** Drives the drawer sections AND the token-search facet fields. */
+  facetSections: FacetSectionConfig[];
+  /**
+   * Optional free-text field shown in the token search bar (type `text`). Its
+   * token value maps to the backend `search` param so name search is preserved
+   * alongside the enum facets.
+   */
+  searchField?: { key: string; label: string };
+  /** Sort options for a card-grid sort select (tables sort via headers instead). */
+  sortableColumns?: SortableColumn[];
+  defaultSort?: CustomTableSortState | null;
+  defaultPageSize?: number;
+  pageSizeOptions?: number[];
+  fetchList: (params: FacetedListQuery) => Promise<{ rows: TRow[]; total: number }>;
+  fetchFacets: (params: FacetedFacetsQuery) => Promise<Facets>;
+  fetchFilterValues: (field: string) => Promise<string[]>;
+  /** While this returns true for the current rows, the list re-fetches on an interval. */
+  pollWhile?: (rows: TRow[]) => boolean;
+  /** Poll cadence in ms (default 4000). */
+  pollIntervalMs?: number;
+}
+
+/** Searchable checkbox-list of facet values (with counts + search). */
+export interface FacetOptionListProps {
+  field: string;
+  label: string;
+  titleCase?: boolean;
+  values: FacetValue[];
+  selected: string[];
+  loading: boolean;
+  onToggle: (field: string, value: string) => void;
+}
+
+/** Collapsible section inside the filter drawer. */
+export interface FilterSectionProps {
+  title: string;
+  count?: number;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}
+
+/** A faceted checkbox section inside the drawer (FilterSection + FacetOptionList). */
+export interface FacetSectionProps {
+  field: string;
+  label: string;
+  titleCase?: boolean;
+  values: FacetValue[];
+  selected: string[];
+  loading: boolean;
+  onToggle: (field: string, value: string) => void;
+}
+
+/** Props for the generalized, config-driven filter drawer. */
+export interface FacetFilterDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  description?: string;
+  sections: FacetSectionConfig[];
+  /** Applied facet selections used to seed the drawer draft. */
+  value: Record<string, string[]>;
+  facets: Facets;
+  facetsLoading: boolean;
+  onApply: (next: Record<string, string[]>) => void;
+  /** Escape hatch for page-specific sections (e.g. date/range filters). */
+  extraSections?: ReactNode;
+}


### PR DESCRIPTION
…Providers (#453)

* Add Call-History faceted filter/sort to Tools, MCP, KB & Agents

Bring the tokenized search bar + facet filter drawer (with server-driven counts) and server-side sort/pagination to the Tools, MCP Servers, Knowledge Base and Agents list pages.

Backend:
- New core/utils/faceted_query.py (apply_filters/apply_sort/build_facets/ distinct_values) + list_params.resolve_sort + shared faceted_schemas.
- Each entity's /list accepts generic filters[] + sort_by/sort_order (backward compatible) and gains POST /facets and GET /filter-values, centralized in services/helpers so Core + EE share them. Boolean is_active exposed as a string `status` facet via CASE.

Frontend:
- New shared components/shared/faceted-list/ module: useFacetedList hook, FacetFilterBar (TokenSearchBar) and config-driven FacetFilterDrawer.
- Per-entity configs; the four pages rewired to the hook. Name is a multi-select value dropdown (name IN (...)); facets are checkboxes with server counts, two-way synced with the token bar.



* Add faceted filtering to service providers, agents & MCP lists

Wire the shared faceted-list pattern into the Model Providers, Agents, MCP and Tools surfaces (facets, filter-values, token search). Also addresses review feedback: refresh() now re-fetches facet counts after mutations, and drops unused asc/desc imports from mcp_server_service.



---------