### PR TITLE
fix: bump protobuf/pyloudnorm/soxr/onnxruntime for tone-pipecat 0.0.7…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -167,7 +167,7 @@ numba==0.61.2
 numpy==2.2.6
 nvidia-riva-client==2.21.1
 oauthlib==3.2.2
-onnxruntime==1.23.2
+onnxruntime==1.24.3
 openai==2.16.0
 opencv-python==4.13.0.90
 openpyxl==3.1.5
@@ -214,7 +214,7 @@ Pygments==2.19.2
 PyJWT==2.10.1
 pylibsrtp==1.0.0
 pylint==2.16.0
-pyloudnorm==0.1.1
+pyloudnorm==0.2.0
 PyNaCl==1.5.0
 pyOpenSSL==25.3.0
 pyotp==2.9.0
@@ -261,7 +261,7 @@ six==1.16.0
 sniffio==1.3.0
 sortedcontainers==2.4.0
 soundfile==0.13.1
-soxr==0.5.0.post1
+soxr==1.0.0
 speechmatics-rt==0.5.3
 speechmatics-voice==0.2.8
 SQLAlchemy==2.0.46


### PR DESCRIPTION
…6.dev0 (pipecat v1.4.0)