### PR TITLE
Feature/staging/workflow under agent details (#588)

### DIFF
--- a/alembic/versions/b7c3f1a9d2e4_workflows_org_name_partial_unique.py
+++ b/alembic/versions/b7c3f1a9d2e4_workflows_org_name_partial_unique.py
@@ -1,0 +1,48 @@
+"""Make workflow org+name uniqueness ignore soft-deleted rows
+
+The original workflows migration (d4f7a1c9e2b8) created a plain UNIQUE
+constraint on (organization_id, name). That blocks reusing a workflow's name
+forever, even after it is soft-deleted (deleted_at set). Swap it for a partial
+unique INDEX scoped to live rows (deleted_at IS NULL) so a deleted name frees up.
+
+This is a separate migration (rather than an in-place edit of d4f7a1c9e2b8)
+because that revision is already applied in existing environments; editing its
+body would never re-run there. The drop-then-create here converges every
+database to the same end state.
+
+Revision ID: b7c3f1a9d2e4
+Revises: a4c8e1f7b2d6
+Create Date: 2026-06-30
+
+Note: re-pointed onto the dev head (a4c8e1f7b2d6) when dev was merged into this
+branch, so the two migration heads collapse into one linear history that applies
+cleanly on top of the current DB revision.
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b7c3f1a9d2e4'
+down_revision = 'a4c8e1f7b2d6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint('uq_workflows_org_name', 'workflows', type_='unique')
+    op.create_index(
+        'uq_workflows_org_name',
+        'workflows',
+        ['organization_id', 'name'],
+        unique=True,
+        postgresql_where=sa.text('deleted_at IS NULL'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('uq_workflows_org_name', table_name='workflows')
+    op.create_unique_constraint(
+        'uq_workflows_org_name', 'workflows', ['organization_id', 'name']
+    )

--- a/core/api/v1/agents.py
+++ b/core/api/v1/agents.py
@@ -1,9 +1,9 @@
 from contextlib import contextmanager
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, Query, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from sqlalchemy import and_, case, exists, or_
 from sqlalchemy.orm import Session
 
@@ -64,8 +64,14 @@ class AgentConfigRequest(BaseModel):
     stt_settings: Optional[Dict[str, Any]] = None
     conversation_settings: Optional[Dict[str, Any]] = None
     # Workflow assignment: mode = "prompt" | "workflow"; workflow_id = assigned org workflow.
-    mode: Optional[str] = None
+    mode: Optional[Literal["prompt", "workflow"]] = None
     workflow_id: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _require_workflow_when_workflow_mode(self) -> "AgentConfigRequest":
+        if self.mode == "workflow" and not self.workflow_id:
+            raise ValueError("workflow_id is required when mode is 'workflow'")
+        return self
 
 
 class PhoneNumberAttachment(BaseModel):

--- a/core/models/agent_config.py
+++ b/core/models/agent_config.py
@@ -1,5 +1,3 @@
-import uuid
-
 from sqlalchemy import Column, String, Integer, Boolean, Text, ForeignKey, DateTime, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 

--- a/core/models/enums.py
+++ b/core/models/enums.py
@@ -15,6 +15,7 @@ class WorkflowNodeType(str, enum.Enum):
     TRANSFER_CALL = "transferCall"
     END_CALL = "endCall"
     DECISION = "decision"
+    API_REQUEST = "apiRequest"
 
 
 class EdgeConditionType(str, enum.Enum):
@@ -27,3 +28,9 @@ class AgentConfigMode(str, enum.Enum):
     """Conversation-flow driver for an agent config."""
     PROMPT = "prompt"      # single system-prompt assistant (default / today's behavior)
     WORKFLOW = "workflow"  # the assigned workflow graph drives turn-to-turn flow
+
+
+class WorkflowStatus(str, enum.Enum):
+    """Lifecycle status of a workflow container."""
+    DRAFT = "draft"          # never published
+    PUBLISHED = "published"  # has at least one published version

--- a/core/models/workflow.py
+++ b/core/models/workflow.py
@@ -1,5 +1,3 @@
-import uuid
-
 from sqlalchemy import (
     Column,
     String,
@@ -15,6 +13,7 @@ from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
 
 from core.models.base import OrgScopedModel
+from core.models.enums import WorkflowStatus
 
 
 class Workflow(OrgScopedModel):
@@ -27,13 +26,23 @@ class Workflow(OrgScopedModel):
 
     __tablename__ = "workflows"
     __table_args__ = (
-        UniqueConstraint("organization_id", "name", name="uq_workflows_org_name"),
+        # Partial unique index: names are unique per org among LIVE rows only, so a
+        # soft-deleted workflow's name can be reused.
+        Index(
+            "uq_workflows_org_name",
+            "organization_id",
+            "name",
+            unique=True,
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
         Index("ix_workflows_organization_id", "organization_id"),
     )
 
     name = Column(String(200), nullable=False)
     description = Column(String(500), nullable=True)
-    status = Column(String(16), nullable=False, default="draft")  # draft | published
+    status = Column(
+        String(16), nullable=False, default=WorkflowStatus.DRAFT.value
+    )  # draft | published
 
     published_version_id = Column(
         UUID(as_uuid=True),

--- a/core/services/agent_service.py
+++ b/core/services/agent_service.py
@@ -1224,8 +1224,37 @@ class AgentService(BaseService):
                 continue
             val = data[field]
             if val is not None and field in self._CONFIG_UUID_FIELDS:
-                val = UUID(str(val))
+                try:
+                    val = UUID(str(val))
+                except (ValueError, TypeError):
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=f"Invalid {field}",
+                    )
+            if field == "workflow_id" and val is not None:
+                self._assert_assignable_workflow(val)
             setattr(target, field, val)
+
+    def _assert_assignable_workflow(self, workflow_id: UUID) -> None:
+        """Guard workflow assignment: the workflow must exist, belong to the caller's org
+        (``self.query`` is org-scoped), and have a published version. Prevents assigning
+        another org's workflow (IDOR) or an unpublished draft."""
+        from core.models.workflow import Workflow
+
+        wf = (
+            self.query(Workflow)
+            .filter(Workflow.id == workflow_id, Workflow.deleted_at.is_(None))
+            .first()
+        )
+        if not wf:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Workflow not found"
+            )
+        if not wf.published_version_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Workflow must be published before it can be assigned to an agent",
+            )
 
     def _apply_config_fields_audited(
         self,

--- a/core/services/custom_tool_service.py
+++ b/core/services/custom_tool_service.py
@@ -121,8 +121,56 @@ def build_custom_tool_schemas(tools: List[Tool]) -> Optional[ToolsSchema]:
     return ToolsSchema(standard_tools=function_schemas)
 
 
+_MAX_RESPONSE_CHARS = 8000
+_BLOCKED_HOST_SUFFIXES = (".internal", ".local")
+_BLOCKED_HOSTS = {"localhost", "metadata.google.internal"}
+
+
+def _assert_safe_url(url: str) -> None:
+    """SSRF guard: require https:// and reject loopback/private/link-local/metadata hosts.
+    Hostnames are not DNS-resolved here (DNS-rebinding SSRF is out of scope for v1)."""
+    import ipaddress
+    import socket
+    import urllib.parse
+
+    parsed = urllib.parse.urlparse(url or "")
+    if parsed.scheme != "https":
+        raise ValueError("Only https:// URLs are allowed")
+    host = (parsed.hostname or "").lower()
+    if not host:
+        raise ValueError("URL has no host")
+    if host in _BLOCKED_HOSTS or any(host.endswith(s) for s in _BLOCKED_HOST_SUFFIXES):
+        raise ValueError("Blocked host")
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        ip = None
+        try:
+            ip = ipaddress.ip_address(socket.inet_aton(host))
+        except (OSError, ValueError):
+            ip = None
+    if ip is not None and (
+        ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast
+    ):
+        raise ValueError("Blocked private/loopback/link-local IP")
+
+
+def _interp(text, ctx: dict):
+    """Interpolate {{var}} in a string from ctx (LLM args). Non-strings pass through.
+    Header values get CR/LF stripped to prevent header injection."""
+    if not isinstance(text, str):
+        return text
+    from core.services.pipeline.prompt_variables import substitute_variables
+
+    return substitute_variables(text, ctx) or ""
+
+
 def create_custom_tool_handler(tool: Tool, tool_call_entries: Optional[list] = None, current_turn: Optional[dict] = None):
-    """Create a handler function for a custom tool that calls the customer's webhook."""
+    """Create a handler function for a custom tool that calls the customer's webhook.
+
+    Also powers workflow **API Request** nodes: if the tool object carries ``headers``
+    (dict) and/or ``static_body`` (dict), those are merged in and ``{{var}}``-interpolated
+    from the LLM-provided args, with an SSRF/HTTPS guard and a response-size cap."""
 
     async def handle_tool_call(params: FunctionCallParams) -> None:
         import time as _time
@@ -158,8 +206,15 @@ def create_custom_tool_handler(tool: Tool, tool_call_entries: Optional[list] = N
                 credentials = base64.b64encode(f"{username}:{password}".encode()).decode()
                 headers["Authorization"] = f"Basic {credentials}"
 
-            # Build the URL — replace {placeholder} with argument values
-            url = tool.url
+            extra_headers = getattr(tool, "headers", None)
+            if isinstance(extra_headers, dict):
+                for hk, hv in extra_headers.items():
+                    if not hk:
+                        continue
+                    val = _interp(hv, arguments)
+                    headers[str(hk)] = str(val).replace("\r", "").replace("\n", "")
+
+            url = _interp(tool.url, arguments)
             remaining_args = dict(arguments)
             for key, value in arguments.items():
                 placeholder = "{" + key + "}"
@@ -167,24 +222,36 @@ def create_custom_tool_handler(tool: Tool, tool_call_entries: Optional[list] = N
                     url = url.replace(placeholder, str(value))
                     remaining_args.pop(key)
 
-            # Make HTTP request to the customer's webhook
+            if getattr(tool, "is_workflow_api_request", False):
+                _assert_safe_url(url)
+
+            static_body = getattr(tool, "static_body", None)
+            if isinstance(static_body, dict) and static_body:
+                body = {k: _interp(v, arguments) for k, v in static_body.items()}
+                body.update(remaining_args)
+            else:
+                body = remaining_args
+
             async with httpx.AsyncClient(timeout=30.0) as client:
                 if tool.method.upper() == "GET":
-                    response = await client.get(url, params=remaining_args, headers=headers)
+                    response = await client.get(url, params=body, headers=headers)
                 else:
                     response = await client.request(
                         method=tool.method.upper(),
                         url=url,
-                        json=remaining_args,
+                        json=body,
                         headers=headers,
                     )
 
-            # Parse and return the response
             try:
                 result = response.json()
                 result_text = json.dumps(result)
             except Exception:
                 result_text = response.text
+            if isinstance(result_text, str) and len(result_text) > _MAX_RESPONSE_CHARS:
+                result_text = result_text[:_MAX_RESPONSE_CHARS] + "…(truncated)"
+            if response.status_code >= 400:
+                result_text = f"(HTTP {response.status_code}) {result_text}"
 
             logger.info(
                 "🔧 Custom tool result ← tool='{}' status={} args={} output={}",
@@ -202,13 +269,20 @@ def create_custom_tool_handler(tool: Tool, tool_call_entries: Optional[list] = N
 
             await params.result_callback(result_text)
 
+        except httpx.TimeoutException:
+            logger.warning("Custom tool '{}' timed out", tool.name)
+            tool_call_entry["result"] = "error: timeout"
+            tool_call_entry["duration_ms"] = round((_time.monotonic() - _t_start) * 1000)
+            if tool_call_entries is not None:
+                tool_call_entries.append(tool_call_entry)
+            await params.result_callback("The request timed out. Please tell the caller and continue.")
         except Exception as e:
             logger.error("Custom tool '{}' failed: {}", tool.name, e)
             tool_call_entry["result"] = f"error: {str(e)}"
             tool_call_entry["duration_ms"] = round((_time.monotonic() - _t_start) * 1000)
             if tool_call_entries is not None:
                 tool_call_entries.append(tool_call_entry)
-            await params.result_callback(f"Error calling tool: {str(e)}")
+            await params.result_callback(f"The request could not be completed: {str(e)}")
 
     return handle_tool_call
 

--- a/core/services/mcp_tool_service.py
+++ b/core/services/mcp_tool_service.py
@@ -25,7 +25,7 @@ from core.utils.tool_idempotency import booking_signature, is_cacheable_result
 # Hard ceiling on how long discovering tools from a single MCP server may take at
 # pipeline-build time. A dead or mis-authenticated server must fail fast and
 # visibly rather than silently yielding zero tools (or blocking call setup).
-MCP_REGISTER_TIMEOUT_S = 25.0
+MCP_REGISTER_TIMEOUT_S = 60.0
 
 
 def _install_mcp_call_logging(llm, server_name: str, server_id=None, tool_call_entries=None, current_turn=None, tool_dedup=None):

--- a/core/services/pipeline/service_resolver.py
+++ b/core/services/pipeline/service_resolver.py
@@ -42,7 +42,7 @@ from core.utils.encryption import decrypt
 # removed in `load_agent_service_config`'s `result` dict). It is folded into every cache
 # version stamp, so a deploy that changes the shape invalidates all persisted entries
 # instead of serving them with a stale shape — there is no TTL to clear them otherwise.
-PAYLOAD_FORMAT_VERSION = "v2"
+PAYLOAD_FORMAT_VERSION = "v4"  # v4: workflow mode uses the workflow prompt alone (no base persona)
 
 
 def _resolve_org_id(org_id):
@@ -277,6 +277,187 @@ def _config_service_ids(config) -> dict:
     }
 
 
+def _published_workflow_graph(db: Session, config, org_id=None) -> Optional[dict]:
+    """Return the assigned workflow's published-version graph (org-scoped), or None outside
+    workflow mode / when no workflow is assigned / there is no published version with a graph.
+
+    Loaded once per resolve so the playbook text and the synthesized apiRequest tools derive
+    from the same graph and share one node_id -> fn-name map (names never drift)."""
+    if getattr(config, "mode", "prompt") != "workflow":
+        return None
+    workflow_id = getattr(config, "workflow_id", None)
+    if not workflow_id:
+        return None
+
+    from core.models.workflow import Workflow, WorkflowVersion
+
+    wf_q = db.query(Workflow).filter(Workflow.id == workflow_id)
+    if org_id:
+        wf_q = wf_q.filter(Workflow.organization_id == org_id)
+    wf = wf_q.first()
+    if not wf or not wf.published_version_id:
+        return None
+    ver_q = db.query(WorkflowVersion).filter(WorkflowVersion.id == wf.published_version_id)
+    if org_id:
+        ver_q = ver_q.filter(WorkflowVersion.organization_id == org_id)
+    ver = ver_q.first()
+    if not ver or not ver.graph:
+        return None
+    return ver.graph
+
+
+def _workflow_tool_names(db: Session, graph: dict, org_id=None) -> dict:
+    """Map each tool node's ``toolId`` / ``mcpServerId`` → display name so the serialized
+    steps can name the exact (agent-attached) tool or MCP server to use. Org-scoped;
+    returns {} when there are no tool/MCP ids."""
+    nodes = graph.get("nodes") or []
+    tool_ids, mcp_ids = [], []
+    for n in nodes:
+        data = (n or {}).get("data") or {}
+        if data.get("toolId"):
+            tool_ids.append(data["toolId"])
+        if data.get("mcpServerId"):
+            mcp_ids.append(data["mcpServerId"])
+    names: dict = {}
+    if tool_ids:
+        from core.models.tool import Tool
+
+        q = db.query(Tool).filter(Tool.id.in_(tool_ids))
+        if org_id:
+            q = q.filter(Tool.organization_id == org_id)
+        names.update({str(t.id): t.name for t in q.all()})
+    if mcp_ids:
+        from core.models.mcp_server import McpServer
+
+        q = db.query(McpServer).filter(McpServer.id.in_(mcp_ids))
+        if org_id:
+            q = q.filter(McpServer.organization_id == org_id)
+        names.update({str(m.id): m.name for m in q.all()})
+    return names
+
+
+def _kv_to_dict(rows, decrypt: bool) -> dict:
+    """Turn a [{key, value, encrypt?}] list into a {key: value} dict, decrypting
+    encrypt-flagged values (stored AES-encrypted in the graph). Bad/blank rows dropped."""
+    out: dict = {}
+    if not isinstance(rows, list):
+        return out
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        k = (r.get("key") or "").strip()
+        if not k:
+            continue
+        v = r.get("value") or ""
+        if decrypt and r.get("encrypt") and v:
+            try:
+                from core.utils.encryption import decrypt as _dec
+                v = _dec(v)
+            except Exception:
+                continue
+        out[k] = v
+    return out
+
+
+def _merge_tools(real_tools: list, api_tools: list) -> list:
+    """Append synthesized apiRequest tools to the agent's real tools, renaming any
+    apiRequest tool whose (sanitized) name collides with a real tool so both stay callable."""
+    if not api_tools:
+        return real_tools
+    from core.services.custom_tool_service import sanitize_tool_name
+
+    taken = {sanitize_tool_name(t.get("name") or "") for t in (real_tools or [])}
+    merged = list(real_tools or [])
+    for t in api_tools:
+        name = t.get("name") or "api_request"
+        if name in taken:
+            i = 2
+            while f"{name}_{i}" in taken:
+                i += 1
+            name = f"{name}_{i}"
+            t = {**t, "name": name}
+        taken.add(name)
+        merged.append(t)
+    return merged
+
+
+def _workflow_api_fn_names(graph: dict, taken: Optional[set] = None) -> dict:
+    """Map each apiRequest node id → the unique sanitized function name it is registered
+    under, deduped among themselves AND against ``taken`` (the agent's real tool names). The
+    playbook serializer and the synthesized tools share this map so the function names the
+    model is told to call match the names actually registered."""
+    from core.services.custom_tool_service import sanitize_tool_name
+
+    claimed = set(taken or ())
+    names: dict = {}
+    for n in (graph.get("nodes") or []):
+        if not isinstance(n, dict) or n.get("type") != "apiRequest":
+            continue
+        nid = n.get("id")
+        d = n.get("data") or {}
+        raw = (d.get("name") or nid or "api_request").strip()
+        fn = sanitize_tool_name(raw)
+        if fn in claimed:
+            i = 2
+            while f"{fn}_{i}" in claimed:
+                i += 1
+            fn = f"{fn}_{i}"
+        claimed.add(fn)
+        names[str(nid)] = fn
+    return names
+
+
+def _build_api_request_tools(graph: dict, fn_names: dict) -> list:
+    """Synthesize the graph's apiRequest nodes into webhook-tool dicts (same shape as
+    serialize_agent_tools) so the existing builder loop registers them as callable HTTP
+    functions. ``fn_names`` (from _workflow_api_fn_names) supplies each node's already-deduped
+    function name. Secrets in headers/static body are decrypted here for runtime use."""
+    from core.services.custom_tool_service import sanitize_tool_name
+
+    tools: list = []
+    for n in (graph.get("nodes") or []):
+        if not isinstance(n, dict) or n.get("type") != "apiRequest":
+            continue
+        nid = n.get("id")
+        d = n.get("data") or {}
+        raw_name = (d.get("name") or nid or "api_request").strip()
+        fn_name = fn_names.get(str(nid)) or sanitize_tool_name(raw_name)
+
+        props, required = {}, []
+        for p in (d.get("requestBody") or []):
+            if not isinstance(p, dict) or not (p.get("name") or "").strip():
+                continue
+            pname = p["name"].strip()
+            props[pname] = {"type": p.get("type") or "string", "description": p.get("description") or ""}
+            if p.get("required"):
+                required.append(pname)
+
+        tools.append({
+            "id": None,
+            "name": fn_name,
+            "description": (d.get("description") or f"API request: {raw_name}"),
+            "tool_type": "custom",
+            "parameters": {"type": "object", "properties": props, "required": required},
+            "url": d.get("url") or "",
+            "method": (d.get("method") or "GET").upper(),
+            "auth_type": "none",
+            "auth_config": None,
+            "meta_data": None,
+            "oauth_connection_id": None,
+            "mcp_server_id": None,
+            "is_workflow_api_request": True,
+            "headers": _kv_to_dict(d.get("headers"), decrypt=True),
+            "static_body": _kv_to_dict(d.get("staticBody"), decrypt=True),
+        })
+    return tools
+
+
+def _compose_system_prompt(base_prompt: Optional[str], workflow_prompt: Optional[str]) -> str:
+    """Layer the agent persona prompt above the workflow playbook (either may be empty)."""
+    parts = [p.strip() for p in (base_prompt, workflow_prompt) if p and p.strip()]
+    return "\n\n".join(parts)
+
+
 def compute_agent_cache_version(db: Session, agent: Any, org_id=None) -> Tuple[Optional[str], Optional[Any]]:
     """Return (version_stamp, active_config) for an agent.
 
@@ -393,20 +574,41 @@ def compute_agent_cache_version(db: Session, agent: Any, org_id=None) -> Tuple[O
         .where(*_mcp_where).scalar_subquery()
     )
 
+    # Workflow assignment: the assigned workflow's published-version id + updated_at are
+    # folded into the SAME combined query (as scalar subqueries) so re-assigning or
+    # re-publishing invalidates the cache without a second per-call round-trip. When the
+    # config isn't in workflow mode the id is NULL → the joins yield NULL (no extra cost).
+    from core.models.workflow import Workflow, WorkflowVersion
+
+    mode = getattr(config, "mode", "prompt") or "prompt"
+    workflow_id = getattr(config, "workflow_id", None) if mode == "workflow" else None
+    wf_id_sq = (
+        select(WorkflowVersion.id).select_from(Workflow)
+        .join(WorkflowVersion, WorkflowVersion.id == Workflow.published_version_id)
+        .where(Workflow.id == workflow_id).scalar_subquery()
+    )
+    wf_ts_sq = (
+        select(WorkflowVersion.updated_at).select_from(Workflow)
+        .join(WorkflowVersion, WorkflowVersion.id == Workflow.published_version_id)
+        .where(Workflow.id == workflow_id).scalar_subquery()
+    )
+
     (
         prov_max, model_max, voice_ts, key_count, key_max,
         tool_count, tool_link_max, tool_max, kb_count, kb_link_max, kb_max,
-        mcp_count, mcp_link_max, mcp_max,
+        mcp_count, mcp_link_max, mcp_max, wf_ver_id, wf_ver_ts,
     ) = db.execute(
         select(
             prov_sq, model_sq, voice_sq, key_cnt_sq, key_max_sq,
             tool_cnt_sq, tool_link_sq, tool_max_sq, kb_cnt_sq, kb_link_sq, kb_max_sq,
-            mcp_cnt_sq, mcp_link_sq, mcp_max_sq,
+            mcp_cnt_sq, mcp_link_sq, mcp_max_sq, wf_id_sq, wf_ts_sq,
         )
     ).one()
 
     def _s(ts):
         return ts.isoformat() if ts is not None else "none"
+
+    wf_stamp = f"{wf_ver_id}:{_s(wf_ver_ts)}" if wf_ver_id is not None else "none"
 
     version = "|".join([
         f"fmt:{PAYLOAD_FORMAT_VERSION}",
@@ -418,6 +620,7 @@ def compute_agent_cache_version(db: Session, agent: Any, org_id=None) -> Tuple[O
         f"tools:{tool_count}:{_s(tool_link_max)}:{_s(tool_max)}",
         f"kb:{kb_count}:{_s(kb_link_max)}:{_s(kb_max)}",
         f"mcp:{mcp_count}:{_s(mcp_link_max)}:{_s(mcp_max)}",
+        f"wf:{mode}:{workflow_id}:{wf_stamp}",
     ])
     return version, config
 
@@ -445,7 +648,15 @@ def load_agent_service_config(
     org_id = _resolve_org_id(org_id)
 
     version, config = compute_agent_cache_version(db, agent, org_id=org_id)
-    if config is None or not config.system_prompt_template:
+    if config is None:
+        return None
+    # A runnable agent needs either a system prompt or an assigned workflow (workflow mode
+    # can drive the call with no standalone prompt). Cheap signal check — the workflow graph
+    # itself is only serialized below on a cache miss.
+    _in_workflow_mode = (
+        getattr(config, "mode", "prompt") == "workflow" and getattr(config, "workflow_id", None)
+    )
+    if not config.system_prompt_template and not _in_workflow_mode:
         return None
 
     cache_key = f"agent_pipeline_config:{agent_id}"
@@ -461,9 +672,68 @@ def load_agent_service_config(
     if not is_s2s and (not stt_spec or not tts_spec):
         return None
 
-    messages = [{"role": "system", "content": config.system_prompt_template}]
-    if getattr(config, "first_message", None) and config.first_message.strip():
-        messages.append({"role": "assistant", "content": config.first_message.strip()})
+    real_tools = serialize_agent_tools(agent_id)
+
+    workflow_prompt = None
+    workflow_greeting = None
+    api_request_tools: list = []
+    try:
+        graph = _published_workflow_graph(db, config, org_id)
+        if graph:
+            from core.services.custom_tool_service import sanitize_tool_name
+            from core.services.workflow.prompt_serializer import (
+                serialize_graph_for_llm,
+                workflow_first_message,
+            )
+
+            taken = {sanitize_tool_name(t.get("name") or "") for t in real_tools}
+            api_fn_names = _workflow_api_fn_names(graph, taken)
+            workflow_prompt = (
+                serialize_graph_for_llm(
+                    graph, _workflow_tool_names(db, graph, org_id), api_fn_names
+                )
+                or None
+            )
+            workflow_greeting = workflow_first_message(graph) or None
+            api_request_tools = _build_api_request_tools(graph, api_fn_names)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[workflow] failed to load workflow for agent={}: {}", agent_id, exc)
+        workflow_prompt = None
+        workflow_greeting = None
+        api_request_tools = []
+
+    if _in_workflow_mode and workflow_prompt:
+        # Workflow selected and loaded: drive the call ENTIRELY from the workflow playbook.
+        # The agent's base persona prompt is intentionally dropped — keeping it would let its
+        # own greeting/flow/instructions conflict with and override the workflow's steps.
+        system_content = workflow_prompt.strip()
+    else:
+        # Prompt mode, or workflow mode but the workflow failed/empty → fall back to the
+        # base persona prompt (compose handles either part being empty).
+        system_content = _compose_system_prompt(
+            getattr(config, "system_prompt_template", None), workflow_prompt
+        )
+    if not system_content:
+        return None
+
+    # S2S models read the system prompt from the LLM metadata (set in _build_service_specs
+    # from system_prompt_template); override it with the composed content so workflow mode
+    # reaches realtime models too.
+    if is_s2s and isinstance(llm_spec.get("metadata"), dict):
+        llm_spec["metadata"]["system_prompt"] = system_content
+        llm_spec["metadata"]["system_instruction"] = system_content
+
+    messages = [{"role": "system", "content": system_content}]
+    # Greeting spoken on connect. In workflow mode the workflow's start step owns the
+    # opening line — use it and ignore config.first_message, falling back to
+    # config.first_message only when the workflow defines no start message.
+    cfg_first = (getattr(config, "first_message", None) or "").strip()
+    if _in_workflow_mode and workflow_prompt:
+        greeting = (workflow_greeting or "").strip() or cfg_first
+    else:
+        greeting = cfg_first
+    if greeting:
+        messages.append({"role": "assistant", "content": greeting})
 
     result = {
         "_cache_version": version,
@@ -473,7 +743,7 @@ def load_agent_service_config(
         "is_s2s": is_s2s,
         "messages": messages,
         "end_call_message": getattr(config, "end_call_message", None),
-        "tools": serialize_agent_tools(agent_id),
+        "tools": _merge_tools(real_tools, api_request_tools),
         "kb": get_kb_document_names(agent_id),
         # `{id, name}` refs for the call-log snapshot. Cached here so the runner can
         # write them in the same INSERT that creates the call row — no per-call queries.

--- a/core/services/pipeline/workflow/conditions.py
+++ b/core/services/pipeline/workflow/conditions.py
@@ -88,11 +88,18 @@ def evaluate_logic(expr: str, variables: Dict[str, Any]) -> bool:
     body = _strip_liquid(expr)
     if not body:
         return True  # empty == always
-    # Bare value like "paid" → truthiness of the coerced literal.
+    # Recognized bare boolean literal (true/yes/false/no) → its truthiness.
+    low = body.lower()
+    if low in ("true", "yes"):
+        return True
+    if low in ("false", "no", "null", "nil", "none"):
+        return False
     try:
         tree = ast.parse(body, mode="eval")
     except SyntaxError:
-        return bool(_coerce(body))
+        # Unparseable expression (e.g. natural-language prose on a logic edge) never
+        # matches — fail-closed so a malformed condition can't silently fire every turn.
+        return False
     try:
         return bool(_eval(tree, variables))
     except Exception:

--- a/core/services/pipeline/workflow/engine.py
+++ b/core/services/pipeline/workflow/engine.py
@@ -25,6 +25,7 @@ Extractor = Callable[[Dict[str, Any], WorkflowCallContext, str], Dict[str, Any]]
 
 _VAR = re.compile(r"\{\{\s*([a-zA-Z0-9_.]+)\s*\}\}")
 _MAX_SETTLE = 25  # guard against router cycles
+_DEFAULT_MAX_VISITS = 10  # per-node re-entry cap (overridable via node data.maxVisits)
 
 
 def substitute(text: Optional[str], variables: Dict[str, Any]) -> str:
@@ -92,6 +93,8 @@ class WorkflowEngine:
         nxt = self._route(cur, user_text)
         if nxt is None:
             return self._directive_for(cur, stay=True)
+        if self._exceeds_visits(nxt):
+            return self._end_directive()
         self._enter(nxt, "edge")
         return self._settle(user_text)
 
@@ -103,12 +106,31 @@ class WorkflowEngine:
         nxt = self._route(cur, user_text)
         if nxt is None:
             return self._directive_for(cur, stay=True)
+        if self._exceeds_visits(nxt):
+            return self._end_directive()
         self._enter(nxt, "edge")
         return self._settle(user_text)
 
     # ── internals ──
     def _enter(self, node_id: str, reason: str) -> None:
         self.ctx.enter(node_id, self.graph.node_type(node_id), reason)
+
+    def _max_visits(self, node_id: str) -> int:
+        raw = (self.graph.node_data(node_id) or {}).get("maxVisits")
+        try:
+            return int(raw) if raw else _DEFAULT_MAX_VISITS
+        except (TypeError, ValueError):
+            return _DEFAULT_MAX_VISITS
+
+    def _exceeds_visits(self, node_id: str) -> bool:
+        """True once a node has been entered as many times as its cap allows — stops
+        infinite re-prompt / cross-turn loops the per-pass _MAX_SETTLE guard can't catch."""
+        return self.ctx.visits(node_id) >= self._max_visits(node_id)
+
+    def _end_directive(self) -> NodeDirective:
+        return NodeDirective(
+            node_id=self.ctx.current_node_id or "", node_type="endCall", end_call=True
+        )
 
     def _check_globals(self) -> Optional[str]:
         for gid in self.graph.global_ids:
@@ -150,6 +172,8 @@ class WorkflowEngine:
                 nxt = self._route(cur, user_text)
                 if nxt is None:
                     return self._directive_for(cur, stay=True)
+                if self._exceeds_visits(nxt):
+                    return self._end_directive()
                 self._enter(nxt, "router")
                 continue
             return self._directive_for(cur)

--- a/core/services/pipeline/workflow/graph.py
+++ b/core/services/pipeline/workflow/graph.py
@@ -36,7 +36,9 @@ class WorkflowGraphRuntime:
                 continue
             self._nodes[nid] = n
             data = n.get("data") or {}
-            if data.get("isStart"):
+            # First start node wins deterministically (matches the LLM-mode serializer,
+            # which also treats the first isStart node as the entry point).
+            if data.get("isStart") and self._start_id is None:
                 self._start_id = nid
             if data.get("isGlobal"):
                 self._global_ids.append(nid)

--- a/core/services/workflow/prompt_serializer.py
+++ b/core/services/workflow/prompt_serializer.py
@@ -1,0 +1,274 @@
+"""Render a workflow graph into plain text the LLM can follow.
+
+When an agent runs in ``mode == "workflow"`` (single-prompt pipeline, no turn-by-turn
+engine) the assigned workflow's published graph is flattened into a human-readable
+"playbook" and appended to the agent's system prompt. The LLM then walks the steps and
+branches itself, guided by each node's prompt / first message / extracted variables and
+the edge conditions.
+
+The input is the canonical React-Flow-native graph:
+    {nodes: [{id, type, position, data:{...}}], edges: [{id, source, target, data:{condition}}],
+     globalPrompt, artifactPlan}
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List
+
+_TYPE_LABEL = {
+    "conversation": "Talk step",
+    "decision": "Decision step",
+    "tool": "Tool / action step",
+    "transferCall": "Transfer step",
+    "endCall": "End step",
+    "apiRequest": "API request step",
+}
+
+
+def _s(v: Any) -> str:
+    return v.strip() if isinstance(v, str) else ""
+
+
+def _fn_name(name: str) -> str:
+    """Mirror custom_tool_service.sanitize_tool_name so the playbook names the exact
+    function the runtime registers for this API Request node."""
+    cleaned = re.sub(r"[^a-zA-Z0-9_-]", "_", (name or "").strip())
+    return (cleaned or "tool")[:64]
+
+
+def _first_message(data: Dict[str, Any]) -> str:
+    plan = data.get("messagePlan")
+    if isinstance(plan, dict):
+        return _s(plan.get("firstMessage"))
+    return ""
+
+
+def _variables(data: Dict[str, Any]) -> List[str]:
+    plan = data.get("variableExtractionPlan")
+    out = plan.get("output") if isinstance(plan, dict) else None
+    if not isinstance(out, list):
+        return []
+    names: List[str] = []
+    for item in out:
+        if isinstance(item, dict):
+            title = _s(item.get("title"))
+            if title:
+                vtype = _s(item.get("type")) or "string"
+                names.append(f"{title} ({vtype})")
+    return names
+
+
+def workflow_first_message(graph: Dict[str, Any]) -> str:
+    """Return the START node's first message — the opening line the agent speaks on connect.
+
+    Mirrors the entry-point selection in ``serialize_graph_for_llm`` (first ``isStart``
+    node). Returns "" when the graph has no start node or it defines no first message.
+    """
+    if not isinstance(graph, dict):
+        return ""
+    nodes = graph.get("nodes") or []
+    if not isinstance(nodes, list):
+        return ""
+    start = next(
+        (
+            n for n in nodes
+            if isinstance(n, dict)
+            and isinstance(n.get("data"), dict)
+            and n["data"].get("isStart")
+        ),
+        None,
+    )
+    if start is None:
+        return ""
+    return _first_message(start.get("data") or {})
+
+
+def serialize_graph_for_llm(
+    graph: Dict[str, Any],
+    tool_names: Dict[str, str] | None = None,
+    api_fn_names: Dict[str, str] | None = None,
+) -> str:
+    """Flatten a workflow graph into an instruction block for the system prompt.
+
+    ``tool_names`` maps a tool node's ``toolId`` to the tool's display name so the step
+    instruction can tell the model exactly which (attached) tool to call.
+
+    ``api_fn_names`` maps an apiRequest node's id to the (already-deduped) function name the
+    runtime registers it under. When provided it is used verbatim so the name the model is
+    told to call matches the registered tool even when names collide; otherwise the name is
+    derived locally via ``_fn_name``. Returns an empty string when the graph has no usable
+    nodes.
+    """
+    tool_names = tool_names or {}
+    api_fn_names = api_fn_names or {}
+    if not isinstance(graph, dict):
+        return ""
+
+    nodes = graph.get("nodes") or []
+    edges = graph.get("edges") or []
+    if not isinstance(nodes, list) or not nodes:
+        return ""
+
+    # Outgoing edges grouped by source node id.
+    outgoing: Dict[str, List[Dict[str, Any]]] = {}
+    for e in edges if isinstance(edges, list) else []:
+        if not isinstance(e, dict):
+            continue
+        src = _s(e.get("source"))
+        if src:
+            outgoing.setdefault(src, []).append(e)
+
+    # Friendly name per node id (falls back to the id).
+    name_by_id: Dict[str, str] = {}
+    for n in nodes:
+        if isinstance(n, dict):
+            nid = _s(n.get("id"))
+            data = n.get("data") if isinstance(n.get("data"), dict) else {}
+            name_by_id[nid] = _s(data.get("name")) or nid
+
+    lines: List[str] = [
+        "# Conversation Workflow",
+        "",
+        "Follow this step-by-step conversation pathway. Begin at the start step and move "
+        "to the next step whose condition matches the caller's response. Speak each step's "
+        "message, do what its instructions say, and collect the listed details before moving on.",
+    ]
+
+    global_prompt = _s(graph.get("globalPrompt"))
+    if global_prompt:
+        lines += ["", "## Overall instructions", global_prompt]
+
+    # Order: the (single) start node first, then the rest in their given order. Only the
+    # FIRST isStart node is treated as the entry point, matching the runtime engine.
+    def _is_start(n: Dict[str, Any]) -> bool:
+        data = n.get("data") if isinstance(n.get("data"), dict) else {}
+        return bool(data.get("isStart"))
+
+    start_id = next((_s(n.get("id")) for n in nodes if isinstance(n, dict) and _is_start(n)), "")
+    start_nodes = [n for n in nodes if isinstance(n, dict) and _s(n.get("id")) == start_id and start_id]
+    ordered = start_nodes + [
+        n for n in nodes if isinstance(n, dict) and _s(n.get("id")) != start_id
+    ]
+
+    lines += ["", "## Steps"]
+    for n in ordered:
+        nid = _s(n.get("id"))
+        ntype = _s(n.get("type")) or "conversation"
+        data = n.get("data") if isinstance(n.get("data"), dict) else {}
+        label = _TYPE_LABEL.get(ntype, "Step")
+        title = name_by_id.get(nid, nid)
+
+        header = f"### {title} — {label}"
+        if nid == start_id and start_id:
+            header += " [START]"
+        if data.get("isGlobal"):
+            header += " [GLOBAL — reachable anytime]"
+        lines.append("")
+        lines.append(header)
+
+        enter_cond = _s(data.get("condition"))
+        if data.get("isGlobal") and enter_cond:
+            lines.append(f"- Jump here whenever: {enter_cond}")
+
+        fm = _first_message(data)
+        if fm:
+            # Collapse newlines and escape quotes so the message can't distort the
+            # playbook structure injected into the system prompt.
+            safe_fm = fm.replace("\n", " ").replace('"', "'")
+            lines.append(f'- Say: "{safe_fm}"')
+
+        prompt = _s(data.get("prompt"))
+        if prompt:
+            lines.append(f"- Do: {prompt}")
+
+        if ntype == "tool":
+            tool = data.get("tool") if isinstance(data.get("tool"), dict) else None
+            tool_id = _s(data.get("toolId"))
+            mcp_id = _s(data.get("mcpServerId"))
+            if tool and _s(tool.get("type")):
+                lines.append(f"- Run the built-in '{_s(tool.get('type'))}' action.")
+            elif tool_id and tool_names.get(tool_id):
+                lines.append(
+                    f"- Call the `{tool_names[tool_id]}` tool to complete this step. "
+                    "Only call it at this step (after the guest has confirmed the details) — "
+                    "never earlier in the conversation."
+                )
+            elif mcp_id and tool_names.get(mcp_id):
+                mcp_tool = _s(data.get("mcpToolName"))
+                if mcp_tool:
+                    lines.append(
+                        f"- Call the `{mcp_tool}` tool (from the `{tool_names[mcp_id]}` MCP server) "
+                        "to complete this step. Only call it at this step (after the guest has "
+                        "confirmed the details) — never earlier in the conversation."
+                    )
+                else:
+                    lines.append(
+                        f"- Use the `{tool_names[mcp_id]}` MCP server's tools to complete this step. "
+                        "Only use them at this step (after the guest has confirmed the details) — "
+                        "never earlier in the conversation."
+                    )
+            else:
+                lines.append("- Run the configured tool/action for this step.")
+            notes = _s(data.get("notes"))
+            if notes:
+                lines.append(f"- Details: {notes}")
+
+        if ntype == "apiRequest":
+            fn = api_fn_names.get(nid) or _fn_name(_s(data.get("name")) or nid)
+            method = (_s(data.get("method")) or "GET").upper()
+            lines.append(
+                f"- Call the `{fn}` tool to complete this step (it makes an HTTP {method} request). "
+                "Only call it at this step, after the guest has confirmed the details — "
+                "never earlier in the conversation."
+            )
+            returned: List[str] = []
+            for f in (data.get("responseFields") or []):
+                if isinstance(f, dict) and _s(f.get("name")):
+                    returned.append(_s(f.get("name")))
+            for a in (data.get("aliases") or []):
+                if isinstance(a, dict) and _s(a.get("alias")):
+                    src = _s(a.get("responseField"))
+                    returned.append(f"{_s(a.get('alias'))}" + (f" (from {src})" if src else ""))
+            if returned:
+                lines.append(
+                    f"- It returns: {', '.join(returned)} — remember these for later steps."
+                )
+            msgs = data.get("messages") if isinstance(data.get("messages"), dict) else {}
+            if _s(msgs.get("start")):
+                lines.append(f'- Before calling, say: "{_s(msgs.get("start"))}"')
+
+        if ntype == "transferCall":
+            dest = data.get("destination") if isinstance(data.get("destination"), dict) else {}
+            number = _s(dest.get("number"))
+            lines.append(f"- Transfer the call{f' to {number}' if number else ''}.")
+
+        if ntype == "endCall":
+            lines.append("- End the call after speaking.")
+
+        variables = _variables(data)
+        if variables:
+            lines.append(f"- Collect: {', '.join(variables)}.")
+
+        branches = outgoing.get(nid, [])
+        if branches:
+            lines.append("- Next:")
+            for e in branches:
+                tgt = name_by_id.get(_s(e.get("target")), _s(e.get("target")))
+                edata = e.get("data") if isinstance(e.get("data"), dict) else {}
+                cond = edata.get("condition") if isinstance(edata.get("condition"), dict) else {}
+                cond_prompt = _s(cond.get("prompt"))
+                cond_type = _s(cond.get("type")) or "ai"
+                if cond_prompt:
+                    desc = (
+                        f"if this expression is true: {cond_prompt}"
+                        if cond_type == "logic"
+                        else f'if "{cond_prompt}"'
+                    )
+                else:
+                    desc = "otherwise (always)"
+                lines.append(f"    → go to '{tgt}' {desc}")
+        elif ntype not in ("endCall", "transferCall"):
+            lines.append("- Next: end the conversation politely.")
+
+    return "\n".join(lines).strip()

--- a/core/services/workflow/schema.py
+++ b/core/services/workflow/schema.py
@@ -71,6 +71,8 @@ class ConversationData(_BaseNodeData):
 
 class ToolData(_BaseNodeData):
     toolId: Optional[str] = None
+    mcpServerId: Optional[str] = None
+    mcpToolName: Optional[str] = None
     tool: Optional[InlineTool] = None
 
 
@@ -86,6 +88,59 @@ class EndCallData(_BaseNodeData):
 
 class DecisionData(_BaseNodeData):
     prompt: Optional[str] = None
+
+
+class KeyValueField(BaseModel):
+    """A header or static-body entry. ``value`` may contain ``{{var}}`` templates.
+    ``encrypt`` marks the value to be stored AES-encrypted in the graph at rest."""
+    model_config = ConfigDict(extra="allow")
+    key: str
+    value: str = ""
+    encrypt: bool = False
+
+
+class RequestBodyProp(BaseModel):
+    """A request-body property the LLM fills (becomes a tool parameter)."""
+    model_config = ConfigDict(extra="allow")
+    name: str
+    type: str = "string"
+    required: bool = False
+    description: str = ""
+
+
+class ResponseField(BaseModel):
+    """A field to extract from the JSON response (prompt-guided)."""
+    model_config = ConfigDict(extra="allow")
+    name: str
+    type: str = "string"
+    required: bool = False
+
+
+class ResponseAlias(BaseModel):
+    """Map a response field to a different workflow-variable name (prompt-guided)."""
+    model_config = ConfigDict(extra="allow")
+    responseField: str
+    alias: str
+
+
+class ApiMessages(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    start: Optional[str] = None
+    success: Optional[str] = None
+    failed: Optional[str] = None
+    delayed: Optional[str] = None
+
+
+class ApiRequestData(_BaseNodeData):
+    description: str = ""
+    method: str = "GET"
+    url: str = ""
+    headers: List[KeyValueField] = Field(default_factory=list)
+    requestBody: List[RequestBodyProp] = Field(default_factory=list)
+    staticBody: List[KeyValueField] = Field(default_factory=list)
+    responseFields: List[ResponseField] = Field(default_factory=list)
+    aliases: List[ResponseAlias] = Field(default_factory=list)
+    messages: Optional[ApiMessages] = None
 
 
 # ---------------------------------------------------------------------------
@@ -123,8 +178,15 @@ class DecisionNode(_NodeBase):
     data: DecisionData
 
 
+class ApiRequestNode(_NodeBase):
+    type: Literal["apiRequest"]
+    data: ApiRequestData
+
+
 WorkflowNode = Annotated[
-    Union[ConversationNode, ToolNode, TransferCallNode, EndCallNode, DecisionNode],
+    Union[
+        ConversationNode, ToolNode, TransferCallNode, EndCallNode, DecisionNode, ApiRequestNode
+    ],
     Field(discriminator="type"),
 ]
 
@@ -168,8 +230,27 @@ class WorkflowGraph(BaseModel):
     artifactPlan: Optional[Dict[str, Any]] = None
 
 
+# Hard caps on untrusted graph size — bound parse/checksum/validation/storage cost.
+MAX_NODES = 300
+MAX_EDGES = 1000
+
+
+def graph_size_error(graph: Dict[str, Any]) -> Optional[str]:
+    """Return a human message if the graph exceeds node/edge caps, else None."""
+    if not isinstance(graph, dict):
+        return None
+    nodes = graph.get("nodes")
+    edges = graph.get("edges")
+    if isinstance(nodes, list) and len(nodes) > MAX_NODES:
+        return f"Workflow exceeds the maximum of {MAX_NODES} nodes."
+    if isinstance(edges, list) and len(edges) > MAX_EDGES:
+        return f"Workflow exceeds the maximum of {MAX_EDGES} edges."
+    return None
+
+
 def empty_graph(start_node_name: str = "start") -> Dict[str, Any]:
-    """A minimal valid graph: a single Start conversation node."""
+    """A minimal graph: a single Start conversation node. Not yet *valid* — it has no
+    terminal/outgoing edge, so validate_graph reports DEAD_END/NO_TERMINAL until built out."""
     return {
         "schemaVersion": 1,
         "nodes": [
@@ -201,6 +282,11 @@ def validate_graph(graph: Dict[str, Any]) -> List[Dict[str, Any]]:
 
     if not isinstance(graph, dict):
         return [{"code": "BAD_GRAPH", "node_name": None, "message": "Graph must be an object."}]
+
+    # 0. Size cap — refuse to parse/validate an oversized graph.
+    size_err = graph_size_error(graph)
+    if size_err:
+        return [{"code": "TOO_LARGE", "node_name": None, "message": size_err}]
 
     # 1. Parse against the typed model (per-type config validation).
     try:
@@ -257,6 +343,30 @@ def validate_graph(graph: Dict[str, Any]) -> List[Dict[str, Any]]:
             issues.append({"code": "TERMINAL_OUTGOING", "node_name": n.id, "message": "Terminal node must not have outgoing edges."})
         if not is_terminal and out_map[n.id] == 0 and n.id not in global_ids:
             issues.append({"code": "DEAD_END", "node_name": n.id, "message": "Non-terminal node has no outgoing edge."})
+
+    _METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE"}
+    for n in nodes:
+        if n.type != "apiRequest":
+            continue
+        d = n.data
+        url = (getattr(d, "url", "") or "").strip()
+        if not url:
+            issues.append({"code": "INVALID_URL", "node_name": n.id, "message": "API Request needs a URL."})
+        elif not (url.startswith("https://") or url.startswith("{{")):
+            issues.append({"code": "INVALID_URL", "node_name": n.id, "message": "API Request URL must use https://."})
+        if (getattr(d, "method", "GET") or "GET").upper() not in _METHODS:
+            issues.append({"code": "INVALID_METHOD", "node_name": n.id, "message": "Unsupported HTTP method."})
+        for label, rows, keyattr in (
+            ("header", getattr(d, "headers", None) or [], "key"),
+            ("static body field", getattr(d, "staticBody", None) or [], "key"),
+            ("body property", getattr(d, "requestBody", None) or [], "name"),
+        ):
+            seen_keys = set()
+            for row in rows:
+                k = (getattr(row, keyattr, "") or "").strip()
+                if k and k in seen_keys:
+                    issues.append({"code": "DUPLICATE_KEY", "node_name": n.id, "message": f"Duplicate {label} '{k}'."})
+                seen_keys.add(k)
 
     # 6. Reachability from start (global nodes are reachable by definition).
     if starts:

--- a/core/services/workflow/service.py
+++ b/core/services/workflow/service.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException, status
 from sqlalchemy.exc import IntegrityError
 
 from core.models.agent_config import AgentConfig
+from core.models.enums import WorkflowStatus
 from core.models.workflow import Workflow, WorkflowVersion
 from core.services.base import BaseService
 from core.services.workflow import schema as wf_schema
@@ -25,12 +26,68 @@ def _checksum(graph: Dict[str, Any]) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _api_request_secret_rows(graph: Dict[str, Any]):
+    """Yield (node_id, row) for every apiRequest header/staticBody row marked encrypt."""
+    for n in (graph or {}).get("nodes") or []:
+        if not isinstance(n, dict) or n.get("type") != "apiRequest":
+            continue
+        nid = n.get("id")
+        data = n.get("data") or {}
+        for field in ("headers", "staticBody"):
+            for row in data.get(field) or []:
+                if isinstance(row, dict) and row.get("encrypt"):
+                    yield nid, field, row
+
+
+def _encrypt_graph_secrets(graph: Dict[str, Any], prev_graph: Optional[Dict[str, Any]] = None) -> None:
+    """Encrypt encrypt-flagged header/static values in place (AES, idempotent via the
+    ``_encrypted`` marker). An empty value carries over the previously-saved secret from
+    ``prev_graph`` so masking-then-saving (the UI never receives plaintext) doesn't wipe it."""
+    from core.utils.encryption import encrypt
+
+    prev: Dict[tuple, str] = {}
+    if prev_graph:
+        for nid, field, row in _api_request_secret_rows(prev_graph):
+            if row.get("_encrypted") and row.get("value"):
+                prev[(nid, field, (row.get("key") or "").strip())] = row["value"]
+
+    for nid, field, row in _api_request_secret_rows(graph):
+        val = row.get("value") or ""
+        if row.get("_encrypted") and val:
+            continue
+        if not val:
+            carried = prev.get((nid, field, (row.get("key") or "").strip()))
+            if carried:
+                row["value"] = carried
+                row["_encrypted"] = True
+            continue
+        row["value"] = encrypt(val)
+        row["_encrypted"] = True
+
+
+def _mask_graph_secrets(graph: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a deep copy with encrypted secret values blanked so the editor never receives
+    ciphertext or plaintext — the row keeps ``encrypt``/``_encrypted`` so the UI shows a
+    'saved' placeholder and an empty submit carries the secret over."""
+    import copy
+
+    g = copy.deepcopy(graph or {})
+    for _nid, _field, row in _api_request_secret_rows(g):
+        if row.get("_encrypted"):
+            row["value"] = ""
+    return g
+
+
 class WorkflowService(BaseService):
     # ── lookups ────────────────────────────────────────────────────────────
     def _get(self, workflow_id: str) -> Workflow:
+        try:
+            wid = UUID(str(workflow_id))
+        except (ValueError, TypeError):
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workflow not found")
         wf = (
             self.query(Workflow)
-            .filter(Workflow.id == UUID(str(workflow_id)), Workflow.deleted_at.is_(None))
+            .filter(Workflow.id == wid, Workflow.deleted_at.is_(None))
             .first()
         )
         if not wf:
@@ -47,9 +104,14 @@ class WorkflowService(BaseService):
         )
 
     def _agents_using(self, workflow_id: UUID) -> int:
+        # Count DISTINCT agents — agent_configs are versioned, so a single agent can have
+        # several config rows referencing the same workflow; without distinct this over-counts
+        # (and could wrongly block delete for a workflow only referenced by a stale version).
         return (
             self.query(AgentConfig)
+            .with_entities(AgentConfig.agent_id)
             .filter(AgentConfig.workflow_id == workflow_id, AgentConfig.deleted_at.is_(None))
+            .distinct()
             .count()
         )
 
@@ -87,11 +149,14 @@ class WorkflowService(BaseService):
             "draft_version_id": str(wf.draft_version_id) if wf.draft_version_id else None,
             "published_version_id": str(wf.published_version_id) if wf.published_version_id else None,
             "latest_version": wf.latest_version,
-            "graph": (draft.graph if draft else wf_schema.empty_graph()),
+            "graph": _mask_graph_secrets(draft.graph if draft else wf_schema.empty_graph()),
             "graph_checksum": draft.graph_checksum if draft else None,
             "is_valid": bool(draft.is_valid) if draft else False,
             "validation_errors": (draft.validation_errors or []) if draft else [],
             "has_published": published is not None,
+            "has_unpublished_changes": bool(
+                published and draft and draft.graph_checksum != published.graph_checksum
+            ),
             "created_at": wf.created_at.isoformat() if wf.created_at else None,
             "updated_at": wf.updated_at.isoformat() if wf.updated_at else None,
         }
@@ -126,13 +191,17 @@ class WorkflowService(BaseService):
             )
 
         graph = graph or wf_schema.empty_graph()
+        size_err = wf_schema.graph_size_error(graph)
+        if size_err:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=size_err)
+        _encrypt_graph_secrets(graph)
         errors = wf_schema.validate_graph(graph)
 
         wf = Workflow(
             organization_id=self.org_id,
             name=name,
             description=description,
-            status="draft",
+            status=WorkflowStatus.DRAFT.value,
             latest_version=0,
             created_by_user_id=user_id,
         )
@@ -174,6 +243,9 @@ class WorkflowService(BaseService):
         expected_checksum: Optional[str],
         user_id: Optional[UUID],
     ) -> Dict[str, Any]:
+        size_err = wf_schema.graph_size_error(graph)
+        if size_err:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=size_err)
         wf = self._get(workflow_id)
         draft = self._version(wf.draft_version_id)
         if not draft:
@@ -196,6 +268,7 @@ class WorkflowService(BaseService):
                 detail="This workflow was changed elsewhere. Reload before saving.",
             )
 
+        _encrypt_graph_secrets(graph, prev_graph=draft.graph)
         errors = wf_schema.validate_graph(graph)
         draft.graph = graph
         draft.start_node_name = wf_schema.find_start_node_name(graph)
@@ -240,7 +313,7 @@ class WorkflowService(BaseService):
         self.db.add(snapshot)
         self.db.flush()
         wf.published_version_id = snapshot.id
-        wf.status = "published"
+        wf.status = WorkflowStatus.PUBLISHED.value
         self.db.commit()
 
         self._invalidate_assigned_agents(wf.id)
@@ -296,7 +369,7 @@ class WorkflowService(BaseService):
         published = self._version(wf.published_version_id)
         draft = self._version(wf.draft_version_id)
         graph = (published or draft).graph if (published or draft) else wf_schema.empty_graph()
-        return vapi_adapter.to_vapi(graph)
+        return vapi_adapter.to_vapi(_mask_graph_secrets(graph))
 
     # ── helpers ────────────────────────────────────────────────────────────
     def _invalidate_assigned_agents(self, workflow_id: UUID) -> None:

--- a/frontend/src/atoms/WorkflowAtom.tsx
+++ b/frontend/src/atoms/WorkflowAtom.tsx
@@ -3,6 +3,7 @@ import { atom } from 'jotai';
 import {
   createWorkflow,
   deleteWorkflow,
+  exportVapiWorkflow,
   getWorkflow,
   listWorkflows,
   publishWorkflow,
@@ -77,19 +78,10 @@ export const publishWorkflowAtom = atom(
   async (_get, _set, workflowId: string): Promise<WorkflowDetail> => publishWorkflow(workflowId),
 );
 
-// ─── editor UI status (coarse, mirrored from the canvas) ────────────────────
-export interface WorkflowEditorStatus {
-  saving: boolean;
-  dirty: boolean;
-  issues: ValidationIssue[];
-  selectedNodeId: string | null;
-  lastSavedAt: number | null;
-}
+export const exportWorkflowAtom = atom(
+  null,
+  async (_get, _set, workflowId: string): Promise<Record<string, unknown>> =>
+    exportVapiWorkflow(workflowId),
+);
 
-export const workflowEditorStatusAtom = atom<WorkflowEditorStatus>({
-  saving: false,
-  dirty: false,
-  issues: [],
-  selectedNodeId: null,
-  lastSavedAt: null,
-});
+export const workflowIssuesAtom = atom<ValidationIssue[]>([]);

--- a/frontend/src/components/agents/agent-form/steps/PromptStep.tsx
+++ b/frontend/src/components/agents/agent-form/steps/PromptStep.tsx
@@ -1,14 +1,19 @@
 'use client';
 
-import { MessageSquare, Sparkles, Wand2 } from 'lucide-react';
-import { useState } from 'react';
+import { ExternalLink, GitBranch, MessageSquare, Sparkles, Wand2, Workflow } from 'lucide-react';
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
+import { useAtomValue, useSetAtom } from 'jotai';
 
 import SectionCard, { ACCENTS } from '@/components/agents/agent-form/SectionCard';
 import { CustomButton, RichPromptEditorField } from '@/components/shared';
+import SearchableSelect from '@/components/shared/SearchableSelect';
 import { Badge } from '@/components/ui/badge';
+import { fetchWorkflowListAtom, workflowsAtom } from '@/atoms/WorkflowAtom';
 import { generateSystemPrompt, improveSystemPrompt } from '@/services/aiService';
 import type { AgentFormState } from '@/types/agent';
+import { cn } from '@/utils/cn';
 import { handleApiError } from '@/utils/helpers';
 import { showToast } from '@/utils/toast';
 
@@ -26,14 +31,71 @@ Never:
 const HELPER_TEXT =
   'Type {{ to insert a variable, or use “Insert variable”. Variables are substituted at runtime.';
 
+type Mode = 'prompt' | 'workflow';
+
+const MODES: { key: Mode; label: string; icon: typeof MessageSquare; hint: string }[] = [
+  {
+    key: 'prompt',
+    label: 'Single prompt',
+    icon: MessageSquare,
+    hint: 'One instruction set drives the whole call',
+  },
+  {
+    key: 'workflow',
+    label: 'Workflow',
+    icon: Workflow,
+    hint: 'A visual conversation pathway drives the call',
+  },
+];
+
 export default function PromptStep() {
   const { control, setValue } = useFormContext<AgentFormState>();
+  const mode = (useWatch({ control, name: 'config.mode' }) ?? 'prompt') as Mode;
+  const workflowId = useWatch({ control, name: 'config.workflow_id' }) ?? '';
   const prompt = useWatch({ control, name: 'config.system_prompt_template' }) ?? '';
   const name = useWatch({ control, name: 'name' }) ?? '';
   const description = useWatch({ control, name: 'description' }) ?? '';
   const agentType = useWatch({ control, name: 'agent_type' }) ?? '';
 
   const [busy, setBusy] = useState(false);
+
+  const { list, loading } = useAtomValue(workflowsAtom);
+  const fetchList = useSetAtom(fetchWorkflowListAtom);
+
+  useEffect(() => {
+    if (mode === 'workflow' && list.length === 0 && !loading) {
+      fetchList().catch(() => {});
+    }
+  }, [mode, list.length, loading, fetchList]);
+
+  const publishedOptions = useMemo(
+    () => list.filter((w) => w.status === 'published').map((w) => ({ value: w.id, label: w.name })),
+    [list],
+  );
+
+  // If the agent already references a workflow that is no longer published (unpublished or
+  // deleted), keep it visible in the dropdown so the assignment isn't silently lost.
+  const assignedMissing =
+    !!workflowId && !publishedOptions.some((o) => o.value === workflowId) && !loading;
+  const wfOptions = useMemo(() => {
+    const known = list.find((w) => w.id === workflowId);
+    return assignedMissing
+      ? [
+          ...publishedOptions,
+          {
+            value: String(workflowId),
+            label: `${known?.name ?? 'Assigned workflow'} (unpublished)`,
+          },
+        ]
+      : publishedOptions;
+  }, [publishedOptions, assignedMissing, workflowId, list]);
+
+  const needsSelection = mode === 'workflow' && !workflowId;
+
+  const setMode = (m: Mode) => {
+    setValue('config.mode', m, { shouldDirty: true });
+    if (m === 'prompt') setValue('config.workflow_id', null, { shouldDirty: true });
+  };
 
   const hasContent = prompt.trim().length > 0;
 
@@ -90,31 +152,141 @@ export default function PromptStep() {
 
   return (
     <div className="flex h-full flex-col gap-4">
-      <SectionCard
-        icon={<MessageSquare className="size-3.5" strokeWidth={2.25} />}
-        iconClassName={ACCENTS.violet}
-        title="System prompt"
-        description="Steers every turn after the call connects. Keep it short and instruction-style."
-        action={actions}
-        className="min-h-0 flex-1"
-        bodyClassName="min-h-0 flex-1"
-      >
-        {/* fill mode: the editor flex-grows and scrolls internally, so only the
-            prompt content scrolls — not the whole page. */}
-        <RichPromptEditorField
-          id="system_prompt_template"
-          name="config.system_prompt_template"
-          label="Prompt template"
-          control={control}
-          fill
-          placeholder={PLACEHOLDER}
-          helperText={HELPER_TEXT}
-        />
-        <p className="inline-flex shrink-0 items-center gap-1.5 text-[11px] text-muted-foreground">
-          <Sparkles className="size-3" />
-          Tip: short, instruction-style prompts work best for voice.
-        </p>
-      </SectionCard>
+      {/* conversation-flow driver toggle */}
+      <div className="grid grid-cols-2 gap-2 rounded-xl border border-border bg-muted/30 p-1.5">
+        {MODES.map((m) => {
+          const Icon = m.icon;
+          const active = mode === m.key;
+          return (
+            <button
+              key={m.key}
+              type="button"
+              aria-pressed={active}
+              onClick={() => setMode(m.key)}
+              className={cn(
+                'flex cursor-pointer items-center gap-3 rounded-lg px-3.5 py-2.5 text-left transition-all',
+                active
+                  ? 'bg-card shadow-sm ring-1 ring-border'
+                  : 'opacity-70 hover:bg-card/60 hover:opacity-100',
+              )}
+            >
+              <span
+                className={cn(
+                  'inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg',
+                  active
+                    ? 'bg-primary/10 text-primary ring-1 ring-inset ring-primary/20'
+                    : 'bg-muted text-muted-foreground',
+                )}
+              >
+                <Icon className="size-4" strokeWidth={2} />
+              </span>
+              <span className="min-w-0">
+                <span className="block text-sm font-semibold text-foreground">{m.label}</span>
+                <span className="block truncate text-[11.5px] text-muted-foreground">{m.hint}</span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {mode === 'prompt' ? (
+        <SectionCard
+          icon={<MessageSquare className="size-3.5" strokeWidth={2.25} />}
+          iconClassName={ACCENTS.violet}
+          title="System prompt"
+          description="Steers every turn after the call connects. Keep it short and instruction-style."
+          action={actions}
+          className="min-h-0 flex-1"
+          bodyClassName="min-h-0 flex-1"
+        >
+          <RichPromptEditorField
+            id="system_prompt_template"
+            name="config.system_prompt_template"
+            label="Prompt template"
+            control={control}
+            fill
+            placeholder={PLACEHOLDER}
+            helperText={HELPER_TEXT}
+          />
+          <p className="inline-flex shrink-0 items-center gap-1.5 text-[11px] text-muted-foreground">
+            <Sparkles className="size-3" />
+            Tip: short, instruction-style prompts work best for voice.
+          </p>
+        </SectionCard>
+      ) : (
+        <SectionCard
+          icon={<Workflow className="size-3.5" strokeWidth={2.25} />}
+          iconClassName={ACCENTS.violet}
+          title="Assigned workflow"
+          description="The selected workflow's flow is sent to the model so it follows the pathway. Only published workflows can be assigned."
+        >
+          <div className="flex flex-col gap-4">
+            <SearchableSelect
+              name="config.workflow_id"
+              label="Workflow"
+              options={wfOptions}
+              value={String(workflowId)}
+              onValueChange={(v) => setValue('config.workflow_id', v, { shouldDirty: true })}
+              loading={loading}
+              placeholder={
+                publishedOptions.length
+                  ? 'Select a published workflow'
+                  : 'No published workflows yet'
+              }
+            />
+
+            {needsSelection && (
+              <p className="text-xs font-medium text-destructive">
+                Select a published workflow, or switch back to Single prompt — Workflow mode needs
+                an assigned workflow.
+              </p>
+            )}
+            {assignedMissing && (
+              <p className="text-xs font-medium text-amber-600 dark:text-amber-400">
+                The assigned workflow is no longer published. Re-publish it or choose another before
+                saving.
+              </p>
+            )}
+
+            {!loading && publishedOptions.length === 0 && (
+              <div className="rounded-lg border border-dashed border-border bg-muted/30 p-4 text-center">
+                <span className="mx-auto mb-2 inline-flex h-9 w-9 items-center justify-center rounded-lg bg-muted text-muted-foreground ring-1 ring-inset ring-border">
+                  <GitBranch className="size-4" />
+                </span>
+                <p className="text-sm font-medium text-foreground">No published workflows</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Create a workflow and publish it before assigning it here.
+                </p>
+                <Link href="/workflows" className="mt-3 inline-block">
+                  <CustomButton
+                    type="default"
+                    size="sm"
+                    icon={<ExternalLink className="size-3.5" />}
+                  >
+                    Open Workflows
+                  </CustomButton>
+                </Link>
+              </div>
+            )}
+
+            {workflowId && (
+              <Link
+                href={`/workflows/${workflowId}`}
+                className="inline-flex w-fit items-center gap-1.5 text-xs font-medium text-primary hover:underline"
+              >
+                <ExternalLink className="size-3.5" />
+                Edit this workflow
+              </Link>
+            )}
+
+            <div className="rounded-lg border border-border bg-muted/30 p-3 text-[12px] text-muted-foreground">
+              <span className="font-medium text-foreground/80">Note:</span> in workflow mode the
+              workflow drives the call on its own — your Single-prompt system prompt is not used.
+              Put any persona or tone guidance in the workflow&apos;s global prompt instead.
+            </div>
+          </div>
+        </SectionCard>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -40,7 +40,7 @@ const NAV_SECTIONS: SidebarNavGroup[] = [
     heading: 'Build',
     items: [
       { label: 'Agents', href: '/agents', icon: Bot },
-      // { label: 'Workflows', href: '/workflows', icon: Workflow },
+      { label: 'Workflows', href: '/workflows', icon: Workflow },
       { label: 'Tools', href: '/tools', icon: Wrench },
       { label: 'MCP', href: '/mcp', icon: Boxes },
       { label: 'Knowledge Base', href: '/knowledge-base', icon: BookOpen },

--- a/frontend/src/components/shared/TextAreaField.tsx
+++ b/frontend/src/components/shared/TextAreaField.tsx
@@ -35,6 +35,7 @@ const PlainTextAreaField = forwardRef<HTMLTextAreaElement, TextAreaFieldBaseProp
       className,
       labelClassName,
       rows = 3,
+      autoResize = false,
       ...props
     },
     ref,
@@ -69,7 +70,7 @@ const PlainTextAreaField = forwardRef<HTMLTextAreaElement, TextAreaFieldBaseProp
           rows={rows}
           aria-invalid={error || undefined}
           className={cn(
-            'resize-none',
+            autoResize ? 'resize-y' : 'resize-none',
             error &&
               'border-destructive focus-visible:border-destructive focus-visible:ring-destructive/50',
             className,

--- a/frontend/src/components/workflows/CreateWorkflowModal.tsx
+++ b/frontend/src/components/workflows/CreateWorkflowModal.tsx
@@ -5,6 +5,8 @@ import { useSetAtom } from 'jotai';
 import { useRouter } from 'next/navigation';
 
 import CustomModal from '@/components/shared/CustomModal';
+import TextInput from '@/components/shared/TextInput';
+import TextAreaField from '@/components/shared/TextAreaField';
 import { createWorkflowAtom } from '@/atoms/WorkflowAtom';
 import { showToast } from '@/utils/toast';
 import { handleApiError } from '@/utils/helpers';
@@ -13,9 +15,6 @@ interface Props {
   open: boolean;
   onClose: () => void;
 }
-
-const inputCls =
-  'w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-sm outline-none ring-primary/40 placeholder:text-muted-foreground focus:ring-2';
 
 const CreateWorkflowModal: React.FC<Props> = ({ open, onClose }) => {
   const router = useRouter();
@@ -60,28 +59,23 @@ const CreateWorkflowModal: React.FC<Props> = ({ open, onClose }) => {
       onConfirm={submit}
     >
       <div className="flex flex-col gap-4 py-1">
-        <div>
-          <label className="mb-1.5 block text-sm font-medium text-foreground">Name</label>
-          <input
-            autoFocus
-            className={inputCls}
-            placeholder="e.g. Inbound triage"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            onKeyDown={(e) => e.key === 'Enter' && submit()}
-          />
-        </div>
-        <div>
-          <label className="mb-1.5 block text-sm font-medium text-foreground">
-            Description (optional)
-          </label>
-          <textarea
-            className={`${inputCls} min-h-[70px] resize-y`}
-            placeholder="What does this workflow do?"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-          />
-        </div>
+        <TextInput
+          name="workflow-name"
+          label="Name"
+          autoFocus
+          placeholder="e.g. Inbound triage"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && submit()}
+        />
+        <TextAreaField
+          name="workflow-description"
+          label="Description (optional)"
+          rows={3}
+          placeholder="What does this workflow do?"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
       </div>
     </CustomModal>
   );

--- a/frontend/src/components/workflows/WorkflowBuilder.tsx
+++ b/frontend/src/components/workflows/WorkflowBuilder.tsx
@@ -22,6 +22,8 @@ import {
   type NodeChange,
   type ReactFlowInstance,
 } from '@xyflow/react';
+import { Layers, Plus, Sparkles } from 'lucide-react';
+
 import AppLoader from '@/components/shared/AppLoader';
 import CustomButton from '@/components/shared/CustomButton';
 import CustomDrawer from '@/components/shared/CustomDrawer';
@@ -29,10 +31,11 @@ import TextAreaField from '@/components/shared/TextAreaField';
 import { showToast } from '@/utils/toast';
 import { handleApiError } from '@/utils/helpers';
 import {
+  exportWorkflowAtom,
   fetchWorkflowAtom,
   publishWorkflowAtom,
   saveDraftAtom,
-  workflowEditorStatusAtom,
+  workflowIssuesAtom,
 } from '@/atoms/WorkflowAtom';
 import type {
   ConditionEdgeData,
@@ -51,6 +54,14 @@ import WorkflowToolbar from '@/components/workflows/WorkflowToolbar';
 interface Props {
   workflowId: string;
 }
+
+/** One-tap building blocks for the global prompt drawer. */
+const GLOBAL_PROMPT_SNIPPETS = [
+  'Be warm, professional, and concise.',
+  'Ask only one question at a time and wait for the answer.',
+  'Always read key details back to confirm before acting.',
+  'Never make up information you have not been given.',
+];
 
 const defaultEdgeOptions = {
   type: 'condition',
@@ -74,7 +85,8 @@ function BuilderInner({ workflowId }: Props) {
   const fetchWorkflow = useSetAtom(fetchWorkflowAtom);
   const saveDraft = useSetAtom(saveDraftAtom);
   const publish = useSetAtom(publishWorkflowAtom);
-  const setStatus = useSetAtom(workflowEditorStatusAtom);
+  const exportWorkflow = useSetAtom(exportWorkflowAtom);
+  const setIssuesAtom = useSetAtom(workflowIssuesAtom);
 
   const [loading, setLoading] = useState(true);
   const [name, setName] = useState('');
@@ -91,6 +103,7 @@ function BuilderInner({ workflowId }: Props) {
   const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
   const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
+  const [hasUnpublishedChanges, setHasUnpublishedChanges] = useState(false);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [selectedEdgeId, setSelectedEdgeId] = useState<string | null>(null);
 
@@ -103,6 +116,7 @@ function BuilderInner({ workflowId }: Props) {
         if (!active) return;
         setName(wf.name);
         setWfStatus(wf.status);
+        setHasUnpublishedChanges(wf.has_unpublished_changes);
         setGlobalPrompt(wf.graph.globalPrompt ?? '');
         artifactPlanRef.current = wf.graph.artifactPlan ?? null;
         checksumRef.current = wf.graph_checksum;
@@ -127,14 +141,17 @@ function BuilderInner({ workflowId }: Props) {
     const t = setTimeout(() => {
       const found = validateGraph(nodes, edges);
       setIssues(found);
-      setStatus((s) => ({ ...s, issues: found }));
+      setIssuesAtom(found);
     }, 250);
     return () => clearTimeout(t);
-  }, [nodes, edges, loading, setStatus]);
+  }, [nodes, edges, loading, setIssuesAtom]);
 
-  useEffect(() => {
-    setStatus((s) => ({ ...s, dirty, saving }));
-  }, [dirty, saving, setStatus]);
+  useEffect(
+    () => () => {
+      setIssuesAtom([]);
+    },
+    [setIssuesAtom],
+  );
 
   // warn on unload while dirty
   useEffect(() => {
@@ -254,15 +271,21 @@ function BuilderInner({ workflowId }: Props) {
   );
 
   const handleSave = useCallback(async () => {
+    if (saving) return;
     setSaving(true);
+    const sent = buildGraph();
+    const sentJson = JSON.stringify(sent);
     try {
       const detail = await saveDraft({
         workflowId,
-        graph: buildGraph(),
+        graph: sent,
         expectedChecksum: checksumRef.current,
       });
       checksumRef.current = detail.graph_checksum;
-      setDirty(false);
+      setHasUnpublishedChanges(detail.has_unpublished_changes);
+      // Only mark clean if nothing was edited during the in-flight save — otherwise the
+      // newest edits would be silently shown as "saved".
+      if (JSON.stringify(buildGraph()) === sentJson) setDirty(false);
       setLastSavedAt(Date.now());
       showToast.success('Draft saved');
     } catch (err) {
@@ -270,16 +293,20 @@ function BuilderInner({ workflowId }: Props) {
     } finally {
       setSaving(false);
     }
-  }, [buildGraph, saveDraft, workflowId]);
+  }, [buildGraph, saveDraft, workflowId, saving]);
 
   const handlePublish = useCallback(async () => {
+    if (saving) return; // avoid double-submit / checksum conflict with an in-flight save
     setSaving(true);
+    const sent = buildGraph();
+    const sentJson = JSON.stringify(sent);
     try {
-      await saveDraft({ workflowId, graph: buildGraph(), expectedChecksum: checksumRef.current });
+      await saveDraft({ workflowId, graph: sent, expectedChecksum: checksumRef.current });
       const detail = await publish(workflowId);
       checksumRef.current = detail.graph_checksum;
       setWfStatus(detail.status);
-      setDirty(false);
+      setHasUnpublishedChanges(detail.has_unpublished_changes);
+      if (JSON.stringify(buildGraph()) === sentJson) setDirty(false);
       setLastSavedAt(Date.now());
       showToast.success(
         'Workflow published',
@@ -290,7 +317,24 @@ function BuilderInner({ workflowId }: Props) {
     } finally {
       setSaving(false);
     }
-  }, [buildGraph, publish, saveDraft, workflowId]);
+  }, [buildGraph, publish, saveDraft, workflowId, saving]);
+
+  const handleExport = useCallback(async () => {
+    try {
+      const vapi = await exportWorkflow(workflowId);
+      const blob = new Blob([JSON.stringify(vapi, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${(name || 'workflow').replace(/\s+/g, '-').toLowerCase()}.vapi.json`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      handleApiError(err);
+    }
+  }, [exportWorkflow, workflowId, name]);
 
   const focusNode = useCallback(
     (nodeName: string) => {
@@ -343,15 +387,14 @@ function BuilderInner({ workflowId }: Props) {
         status={status}
         saving={saving}
         dirty={dirty}
+        hasUnpublishedChanges={hasUnpublishedChanges}
         lastSavedAt={lastSavedAt}
         issues={issues}
         onBack={() => router.push('/workflows')}
         onSave={handleSave}
         onPublish={handlePublish}
         onOpenGlobalPrompt={() => setGlobalOpen(true)}
-        onExport={() =>
-          window.open(`/api/v1/workflow/export_vapi?workflow_id=${workflowId}`, '_blank')
-        }
+        onExport={handleExport}
         onFocusNode={focusNode}
       />
 
@@ -359,8 +402,26 @@ function BuilderInner({ workflowId }: Props) {
         <div
           ref={canvasRef}
           className="workflow-canvas relative min-h-0 flex-1"
+          tabIndex={0}
+          role="application"
+          aria-label="Workflow canvas. Select a node or edge and press Enter to edit it."
           onDrop={onDrop}
           onDragOver={onDragOver}
+          onKeyDown={(e) => {
+            // Keyboard access: Enter opens the config drawer for the selected node/edge.
+            if (e.key !== 'Enter') return;
+            const selNode = getNodes().find((n) => n.selected);
+            if (selNode) {
+              setSelectedNodeId(selNode.id);
+              setSelectedEdgeId(null);
+              return;
+            }
+            const selEdge = edges.find((ed) => ed.selected);
+            if (selEdge) {
+              setSelectedEdgeId(selEdge.id);
+              setSelectedNodeId(null);
+            }
+          }}
         >
           <NodeActionsContext.Provider value={nodeActions}>
             <EdgeActionsContext.Provider value={edgeActions}>
@@ -438,16 +499,86 @@ function BuilderInner({ workflowId }: Props) {
           </div>
         }
       >
-        <TextAreaField
-          name="global-prompt"
-          rows={9}
-          placeholder="e.g. Be calm, warm, and concise. Always read details back to confirm."
-          value={globalPrompt}
-          onChange={(e) => {
-            setGlobalPrompt(e.target.value);
-            setDirty(true);
-          }}
-        />
+        <div className="flex flex-col gap-4">
+          {/* layered-prompt explainer */}
+          <div className="rounded-xl border border-border bg-muted/40 p-3.5">
+            <div className="flex items-center gap-2 text-xs font-semibold text-foreground">
+              <Layers className="h-3.5 w-3.5 text-primary" />
+              How prompts apply
+            </div>
+            <p className="mt-1.5 text-[12px] text-muted-foreground">
+              In workflow mode the workflow drives the call on its own — the agent&apos;s system
+              prompt is not used. Set the call-wide persona and tone here.
+            </p>
+            <ol className="mt-2.5 space-y-1.5 text-[12px] text-muted-foreground">
+              <li className="flex items-start gap-2">
+                <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
+                <span>
+                  <span className="font-medium text-foreground/80">Global prompt</span> — this text,
+                  applied to every node.
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/40" />
+                <span>
+                  <span className="font-medium text-foreground/80">Node prompt</span> — what to do
+                  at each step.
+                </span>
+              </li>
+            </ol>
+          </div>
+
+          <TextAreaField
+            name="global-prompt"
+            label="Global instructions"
+            rows={10}
+            maxLength={4000}
+            placeholder="e.g. Be calm, warm, and concise. Always read details back to confirm before acting."
+            helperText="Keep it about call-wide tone and rules — leave step-specific instructions to each node."
+            value={globalPrompt}
+            onChange={(e) => {
+              setGlobalPrompt(e.target.value);
+              setDirty(true);
+            }}
+          />
+
+          <div className="-mt-1 flex items-center justify-between">
+            <span className="text-[11px] text-muted-foreground">
+              Use <code className="font-mono text-foreground/70">{'{{variables}}'}</code> to insert
+              collected values.
+            </span>
+            <span className="font-mono text-[11px] text-muted-foreground">
+              {globalPrompt.length}/4000
+            </span>
+          </div>
+
+          {/* quick starters */}
+          <div>
+            <div className="mb-2 flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              <Sparkles className="h-3 w-3" />
+              Quick add
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {GLOBAL_PROMPT_SNIPPETS.map((snippet) => (
+                <CustomButton
+                  key={snippet}
+                  type="default"
+                  size="xs"
+                  icon={<Plus className="h-3 w-3" />}
+                  onClick={() => {
+                    setGlobalPrompt((prev) =>
+                      prev.trim() ? `${prev.trim()}\n${snippet}` : snippet,
+                    );
+                    setDirty(true);
+                  }}
+                  className="!h-auto whitespace-normal py-1 text-left text-[11px] font-normal"
+                >
+                  {snippet}
+                </CustomButton>
+              ))}
+            </div>
+          </div>
+        </div>
       </CustomDrawer>
     </div>
   );

--- a/frontend/src/components/workflows/WorkflowListPage.tsx
+++ b/frontend/src/components/workflows/WorkflowListPage.tsx
@@ -1,21 +1,167 @@
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { motion } from 'framer-motion';
-import { Plus, RefreshCw, TriangleAlert, Workflow as WorkflowIcon } from 'lucide-react';
+import {
+  CheckCircle2,
+  Clock,
+  PencilRuler,
+  Plus,
+  RefreshCw,
+  SearchX,
+  TriangleAlert,
+  Users,
+  Workflow as WorkflowIcon,
+} from 'lucide-react';
 
 import { cn } from '@/utils/cn';
 import CustomButton from '@/components/shared/CustomButton';
+import TokenSearchBar from '@/components/shared/TokenSearchBar';
 import ActionMenu from '@/components/shared/ActionMenu';
 import { deleteWorkflowAtom, fetchWorkflowListAtom, workflowsAtom } from '@/atoms/WorkflowAtom';
 import { showToast } from '@/utils/toast';
 import { handleApiError } from '@/utils/helpers';
+import { formatRelative } from '@/utils/date';
+import type { SearchToken, TokenSearchField } from '@/types/components';
 import type { WorkflowSummary } from '@/types/workflow';
 import CreateWorkflowModal from './CreateWorkflowModal';
 import WorkflowEmptyState from './WorkflowEmptyState';
 
+// Vercel-style `field:value` search fields (mirrors the Agents list search).
+const SEARCH_FIELDS: TokenSearchField[] = [
+  { key: 'name', label: 'Name', type: 'text' },
+  {
+    key: 'status',
+    label: 'Status',
+    type: 'enum',
+    fetchValues: async () => ['draft', 'published'],
+    formatValue: (v) => (v === 'published' ? 'Published' : 'Draft'),
+  },
+];
+
+// ── status pill ───────────────────────────────────────────────────────────────
+const StatusPill: React.FC<{ status: WorkflowSummary['status'] }> = ({ status }) => {
+  const published = status === 'published';
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium ring-1 ring-inset',
+        published
+          ? 'bg-emerald-500/10 text-emerald-600 ring-emerald-500/20 dark:text-emerald-300'
+          : 'bg-amber-500/10 text-amber-600 ring-amber-500/20 dark:text-amber-300',
+      )}
+    >
+      <span
+        className={cn('h-1.5 w-1.5 rounded-full', published ? 'bg-emerald-500' : 'bg-amber-500')}
+      />
+      {published ? 'Published' : 'Draft'}
+    </span>
+  );
+};
+
+// ── one workflow card ─────────────────────────────────────────────────────────
+interface CardProps {
+  wf: WorkflowSummary;
+  index: number;
+  onOpen: (id: string) => void;
+  onDelete: (wf: WorkflowSummary) => void;
+}
+
+const WorkflowCard: React.FC<CardProps> = ({ wf, index, onOpen, onDelete }) => {
+  const published = wf.status === 'published';
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2, delay: Math.min(index, 10) * 0.035, ease: 'easeOut' }}
+      role="button"
+      tabIndex={0}
+      aria-label={`Open workflow ${wf.name}`}
+      onClick={() => onOpen(wf.id)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onOpen(wf.id);
+        }
+      }}
+      className="group relative flex cursor-pointer flex-col overflow-hidden rounded-xl border border-border bg-card text-left outline-none transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-lg hover:shadow-primary/5 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+    >
+      {/* status accent rail */}
+      <span
+        aria-hidden
+        className={cn(
+          'absolute inset-x-0 top-0 h-[2.5px] opacity-70 transition-opacity group-hover:opacity-100',
+          published
+            ? 'bg-gradient-to-r from-emerald-500/80 via-emerald-400/60 to-transparent'
+            : 'bg-gradient-to-r from-amber-500/80 via-amber-400/60 to-transparent',
+        )}
+      />
+
+      <div className="flex flex-1 flex-col p-4">
+        {/* header */}
+        <div className="mb-3 flex items-start justify-between gap-2">
+          <span className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-indigo-500/10 text-indigo-600 ring-1 ring-inset ring-indigo-500/20 dark:text-indigo-300">
+            <WorkflowIcon className="h-5 w-5" strokeWidth={1.75} />
+          </span>
+          <div
+            className="opacity-60 transition-opacity group-hover:opacity-100"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <ActionMenu
+              itemName={wf.name}
+              onEdit={() => onOpen(wf.id)}
+              onDelete={() => Promise.resolve(onDelete(wf))}
+              deleteDescription={`This permanently removes "${wf.name}". Workflows assigned to an agent must be unassigned first.`}
+            />
+          </div>
+        </div>
+
+        {/* title + description */}
+        <h3 className="truncate text-[15px] font-semibold tracking-tight text-foreground">
+          {wf.name}
+        </h3>
+        <p className="mt-1 line-clamp-2 min-h-[2.25rem] text-xs leading-relaxed text-muted-foreground">
+          {wf.description || 'No description'}
+        </p>
+
+        {/* meta pills */}
+        <div className="mt-3.5 flex flex-wrap items-center gap-1.5">
+          <StatusPill status={wf.status} />
+          <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+            <Users className="h-3 w-3" />
+            {wf.agents_using} agent{wf.agents_using === 1 ? '' : 's'}
+          </span>
+          {wf.is_valid ? (
+            <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+              <CheckCircle2 className="h-3 w-3 text-emerald-500" />
+              Valid
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-1 rounded-full bg-destructive/10 px-2 py-0.5 text-[11px] font-medium text-destructive ring-1 ring-inset ring-destructive/20">
+              <TriangleAlert className="h-3 w-3" />
+              Has issues
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* footer */}
+      <div className="flex items-center justify-between border-t border-border/60 bg-muted/30 px-4 py-2">
+        <span className="inline-flex items-center gap-1.5 font-mono text-[11px] text-muted-foreground">
+          <Clock className="h-3 w-3" />
+          {wf.updated_at ? `Updated ${formatRelative(wf.updated_at)}` : 'Not yet edited'}
+        </span>
+        <span className="text-[11px] font-medium text-primary opacity-0 transition-opacity group-hover:opacity-100">
+          Open →
+        </span>
+      </div>
+    </motion.div>
+  );
+};
+
+// ── page ──────────────────────────────────────────────────────────────────────
 const WorkflowListPage: React.FC = () => {
   const router = useRouter();
   const { list, loading } = useAtomValue(workflowsAtom);
@@ -25,16 +171,22 @@ const WorkflowListPage: React.FC = () => {
   const [createOpen, setCreateOpen] = useState(false);
   const [errored, setErrored] = useState(false);
   const [loadedOnce, setLoadedOnce] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [tokens, setTokens] = useState<SearchToken[]>([]);
 
   const load = useCallback(
     (silent = false) => {
       setErrored(false);
+      setRefreshing(true);
       fetchList()
         .catch((err) => {
           setErrored(true);
           if (!silent) handleApiError(err);
         })
-        .finally(() => setLoadedOnce(true));
+        .finally(() => {
+          setLoadedOnce(true);
+          setRefreshing(false);
+        });
     },
     [fetchList],
   );
@@ -43,21 +195,56 @@ const WorkflowListPage: React.FC = () => {
     load(true);
   }, [load]);
 
-  const handleDelete = async (wf: WorkflowSummary) => {
-    try {
-      await remove(wf.id);
-      showToast.success('Workflow deleted');
-      load(true);
-    } catch (err) {
-      handleApiError(err);
-    }
-  };
+  const open = useCallback((id: string) => router.push(`/workflows/${id}`), [router]);
+
+  const handleDelete = useCallback(
+    async (wf: WorkflowSummary) => {
+      try {
+        await remove(wf.id);
+        showToast.success('Workflow deleted');
+        load(true);
+      } catch (err) {
+        handleApiError(err);
+      }
+    },
+    [remove, load],
+  );
+
+  const filtered = useMemo(() => {
+    const statusVals = tokens.filter((t) => t.field === 'status').map((t) => t.value);
+    const textVals = tokens
+      .filter((t) => t.field === 'name')
+      .map((t) => t.value.trim().toLowerCase())
+      .filter(Boolean);
+    return list.filter((w) => {
+      if (statusVals.length && !statusVals.includes(w.status)) return false;
+      if (textVals.length) {
+        const hay = `${w.name} ${w.description ?? ''}`.toLowerCase();
+        if (!textVals.every((t) => hay.includes(t))) return false;
+      }
+      return true;
+    });
+  }, [list, tokens]);
 
   const showSkeleton = (loading || !loadedOnce) && list.length === 0 && !errored;
+  const isTrulyEmpty = loadedOnce && !errored && list.length === 0;
 
   return (
-    <div className={cn('h-full')}>
-      <div className="mb-7 flex items-end justify-between gap-4">
+    <div className="relative h-full">
+      {/* atmospheric backdrop */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10 opacity-[0.55]"
+        style={{
+          backgroundImage: 'radial-gradient(hsl(var(--border)) 1px, transparent 1px)',
+          backgroundSize: '22px 22px',
+          maskImage: 'radial-gradient(70% 55% at 50% 0%, black, transparent 75%)',
+          WebkitMaskImage: 'radial-gradient(70% 55% at 50% 0%, black, transparent 75%)',
+        }}
+      />
+
+      {/* header */}
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <div className="flex items-center gap-2.5">
             <h1 className="text-2xl font-semibold tracking-tight text-foreground">Workflows</h1>
@@ -80,12 +267,41 @@ const WorkflowListPage: React.FC = () => {
         </CustomButton>
       </div>
 
+      {/* toolbar — only once there is at least one workflow */}
+      {!showSkeleton && !isTrulyEmpty && !errored && (
+        <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <TokenSearchBar
+            fields={SEARCH_FIELDS}
+            value={tokens}
+            onChange={setTokens}
+            onClear={() => setTokens([])}
+            placeholder="Filter workflows… (e.g. status:draft)"
+            className="w-full sm:max-w-xl"
+          />
+
+          <div className="flex items-center gap-3">
+            <span className="hidden whitespace-nowrap font-mono text-xs text-muted-foreground sm:inline">
+              {tokens.length ? `${filtered.length} of ${list.length}` : `${list.length} total`}
+            </span>
+            <CustomButton
+              type="default"
+              size="icon-sm"
+              aria-label="Refresh workflows"
+              loading={refreshing}
+              onClick={() => load()}
+              icon={<RefreshCw className="h-4 w-4" />}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* body */}
       {showSkeleton ? (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {Array.from({ length: 3 }).map((_, i) => (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
             <div
               key={i}
-              className="h-36 animate-pulse rounded-xl border border-border bg-muted/40"
+              className="h-[180px] animate-pulse rounded-xl border border-border bg-muted/40"
             />
           ))}
         </div>
@@ -107,76 +323,30 @@ const WorkflowListPage: React.FC = () => {
             Retry
           </CustomButton>
         </div>
-      ) : list.length === 0 ? (
+      ) : isTrulyEmpty ? (
         <WorkflowEmptyState onCreate={() => setCreateOpen(true)} />
+      ) : filtered.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-border py-20 text-center">
+          <span className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-muted text-muted-foreground ring-1 ring-inset ring-border">
+            <SearchX className="h-6 w-6" />
+          </span>
+          <h2 className="text-base font-semibold text-foreground">No matching workflows</h2>
+          <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+            No workflows match your current search and filters.
+          </p>
+          <CustomButton
+            type="default"
+            className="mt-5"
+            icon={<PencilRuler className="h-4 w-4" />}
+            onClick={() => setTokens([])}
+          >
+            Clear filters
+          </CustomButton>
+        </div>
       ) : (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {list.map((wf, i) => (
-            <motion.div
-              key={wf.id}
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.2, delay: Math.min(i, 8) * 0.04, ease: 'easeOut' }}
-              role="button"
-              tabIndex={0}
-              onClick={() => router.push(`/workflows/${wf.id}`)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  router.push(`/workflows/${wf.id}`);
-                }
-              }}
-              className="group relative flex cursor-pointer flex-col rounded-xl border border-border bg-card p-4 text-left shadow-sm outline-none transition-all hover:-translate-y-px hover:border-primary/40 hover:shadow-md focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-            >
-              <span
-                aria-hidden
-                className="absolute inset-x-0 top-0 h-[3px] rounded-t-xl bg-gradient-to-r from-indigo-500/60 via-violet-500/50 to-transparent opacity-0 transition-opacity group-hover:opacity-100"
-              />
-              <div className="mb-2.5 flex items-start justify-between gap-2">
-                <span className="inline-flex h-9 w-9 items-center justify-center rounded-lg bg-indigo-500/10 text-indigo-600 ring-1 ring-inset ring-indigo-500/20 dark:text-indigo-300">
-                  <WorkflowIcon className="h-5 w-5" />
-                </span>
-                <div onClick={(e) => e.stopPropagation()}>
-                  <ActionMenu
-                    itemName={wf.name}
-                    onEdit={() => router.push(`/workflows/${wf.id}`)}
-                    onDelete={() => handleDelete(wf)}
-                    deleteDescription={`This permanently removes "${wf.name}". Workflows assigned to an agent must be unassigned first.`}
-                  />
-                </div>
-              </div>
-              <div className="truncate text-sm font-semibold text-foreground">{wf.name}</div>
-              <div className="mt-0.5 line-clamp-2 min-h-[2rem] text-xs text-muted-foreground">
-                {wf.description || 'No description'}
-              </div>
-              <div className="mt-3 flex flex-wrap items-center gap-2">
-                <span
-                  className={cn(
-                    'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ring-1 ring-inset',
-                    wf.status === 'published'
-                      ? 'bg-emerald-500/10 text-emerald-600 ring-emerald-500/20 dark:text-emerald-300'
-                      : 'bg-amber-500/10 text-amber-600 ring-amber-500/20 dark:text-amber-300',
-                  )}
-                >
-                  <span
-                    className={cn(
-                      'h-1.5 w-1.5 rounded-full',
-                      wf.status === 'published' ? 'bg-emerald-500' : 'bg-amber-500',
-                    )}
-                  />
-                  {wf.status === 'published' ? 'Published' : 'Draft'}
-                </span>
-                <span className="rounded-full bg-muted px-2 py-0.5 font-mono text-[11px] text-muted-foreground">
-                  {wf.agents_using} agent{wf.agents_using === 1 ? '' : 's'}
-                </span>
-                {!wf.is_valid && (
-                  <span className="inline-flex items-center gap-1 rounded-full bg-destructive/10 px-2 py-0.5 text-[11px] font-medium text-destructive ring-1 ring-inset ring-destructive/20">
-                    <TriangleAlert className="h-3 w-3" />
-                    Has issues
-                  </span>
-                )}
-              </div>
-            </motion.div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
+          {filtered.map((wf, i) => (
+            <WorkflowCard key={wf.id} wf={wf} index={i} onOpen={open} onDelete={handleDelete} />
           ))}
         </div>
       )}

--- a/frontend/src/components/workflows/WorkflowToolbar.tsx
+++ b/frontend/src/components/workflows/WorkflowToolbar.tsx
@@ -20,6 +20,7 @@ interface Props {
   status: 'draft' | 'published';
   saving: boolean;
   dirty: boolean;
+  hasUnpublishedChanges: boolean;
   lastSavedAt: number | null;
   issues: ValidationIssue[];
   onBack: () => void;
@@ -35,6 +36,7 @@ const WorkflowToolbar: React.FC<Props> = ({
   status,
   saving,
   dirty,
+  hasUnpublishedChanges,
   lastSavedAt,
   issues,
   onBack,
@@ -48,13 +50,18 @@ const WorkflowToolbar: React.FC<Props> = ({
   const [moreOpen, setMoreOpen] = useState(false);
   const valid = issues.length === 0;
 
+  const pendingPublish = status === 'published' && (hasUnpublishedChanges || dirty);
+  const nothingToPublish = status === 'published' && !hasUnpublishedChanges && !dirty;
+
   const savedLabel = saving
     ? 'Saving…'
     : dirty
       ? 'Unsaved changes'
-      : lastSavedAt
-        ? 'All changes saved'
-        : 'Up to date';
+      : status === 'published' && hasUnpublishedChanges
+        ? 'Saved · not published yet'
+        : lastSavedAt
+          ? 'All changes saved'
+          : 'Up to date';
 
   return (
     <div className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-border bg-card/80 px-3 backdrop-blur">
@@ -88,6 +95,15 @@ const WorkflowToolbar: React.FC<Props> = ({
               />
               {status === 'published' ? 'Published' : 'Draft'}
             </span>
+            {pendingPublish && (
+              <span
+                title="Your edits are saved as a draft but aren't live yet. Publish to update assigned agents."
+                className="inline-flex shrink-0 items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-600 ring-1 ring-inset ring-amber-500/20 dark:text-amber-300"
+              >
+                <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+                Unpublished changes
+              </span>
+            )}
           </div>
           <div className="font-mono text-[11px] text-muted-foreground">{savedLabel}</div>
         </div>
@@ -206,8 +222,16 @@ const WorkflowToolbar: React.FC<Props> = ({
         <CustomButton type="default" size="sm" loading={saving} onClick={onSave}>
           Save draft
         </CustomButton>
-        <CustomButton type="primary" size="sm" disabled={!valid} onClick={onPublish}>
-          Publish
+        <CustomButton
+          type="primary"
+          size="sm"
+          disabled={!valid || saving || nothingToPublish}
+          onClick={onPublish}
+          title={
+            nothingToPublish ? 'No changes to publish — the live version is up to date.' : undefined
+          }
+        >
+          {pendingPublish ? 'Publish changes' : 'Publish'}
         </CustomButton>
       </div>
     </div>

--- a/frontend/src/components/workflows/canvas/nodes/BaseNode.tsx
+++ b/frontend/src/components/workflows/canvas/nodes/BaseNode.tsx
@@ -114,10 +114,11 @@ const BaseNode: React.FC<BaseNodeProps> = ({
 
         <div
           className={cn(
-            'px-4 text-[13px] leading-relaxed line-clamp-2',
+            'truncate px-4 text-[13px] leading-snug',
             variables && variables.length ? 'pb-2' : 'pb-3.5',
             summary ? 'text-muted-foreground' : 'italic text-muted-foreground/55',
           )}
+          title={summary || undefined}
         >
           {summary || 'No content yet'}
         </div>

--- a/frontend/src/components/workflows/canvas/nodes/index.tsx
+++ b/frontend/src/components/workflows/canvas/nodes/index.tsx
@@ -4,7 +4,7 @@ import React, { createContext, useContext, useMemo } from 'react';
 import type { NodeProps } from '@xyflow/react';
 import { useAtomValue } from 'jotai';
 
-import { workflowEditorStatusAtom } from '@/atoms/WorkflowAtom';
+import { workflowIssuesAtom } from '@/atoms/WorkflowAtom';
 import { NODE_REGISTRY } from '@/components/workflows/nodeRegistry';
 import BaseNode from './BaseNode';
 
@@ -15,8 +15,8 @@ interface NodeActions {
 export const NodeActionsContext = createContext<NodeActions>({});
 
 function useNodeIssues(id: string) {
-  const status = useAtomValue(workflowEditorStatusAtom);
-  return useMemo(() => status.issues.filter((i) => i.node_name === id), [status.issues, id]);
+  const issues = useAtomValue(workflowIssuesAtom);
+  return useMemo(() => issues.filter((i) => i.node_name === id), [issues, id]);
 }
 
 function useNodeDelete(id: string) {
@@ -77,9 +77,11 @@ function ToolNode({ id, data, selected }: NodeProps) {
   const inline = (d.tool as D | undefined)?.type;
   const summary = inline
     ? `Built-in: ${str(inline)}`
-    : str(d.toolId)
-      ? `Tool ${str(d.toolId).slice(0, 8)}…`
-      : '';
+    : str(d.mcpServerId)
+      ? `MCP server ${str(d.mcpServerId).slice(0, 8)}…`
+      : str(d.toolId)
+        ? `Tool ${str(d.toolId).slice(0, 8)}…`
+        : '';
   return (
     <BaseNode
       meta={NODE_REGISTRY.tool}
@@ -132,10 +134,31 @@ function EndCallNode({ id, data, selected }: NodeProps) {
   );
 }
 
+function ApiRequestNode({ id, data, selected }: NodeProps) {
+  const d = data as D;
+  const issues = useNodeIssues(id);
+  const onDelete = useNodeDelete(id);
+  const method = (str(d.method) || 'GET').toUpperCase();
+  const url = str(d.url);
+  return (
+    <BaseNode
+      meta={NODE_REGISTRY.apiRequest}
+      title={str(d.name) || id}
+      summary={url ? `${method} ${url}` : str(d.description) || 'No endpoint set'}
+      selected={selected}
+      isGlobal={Boolean(d.isGlobal)}
+      onDelete={onDelete}
+      errorCount={issues.length}
+      errorMessages={issues.map((i) => i.message)}
+    />
+  );
+}
+
 export const nodeTypes = {
   conversation: ConversationNode,
   decision: DecisionNode,
   tool: ToolNode,
   transferCall: TransferCallNode,
   endCall: EndCallNode,
+  apiRequest: ApiRequestNode,
 };

--- a/frontend/src/components/workflows/config/ApiRequestForm.tsx
+++ b/frontend/src/components/workflows/config/ApiRequestForm.tsx
@@ -1,0 +1,395 @@
+'use client';
+
+import React, { useState } from 'react';
+import { ChevronDown, Cog, KeyRound, ListTree, Plus, Repeat2, Send, Trash2 } from 'lucide-react';
+
+import { cn } from '@/utils/cn';
+import CustomButton from '@/components/shared/CustomButton';
+import TextInput from '@/components/shared/TextInput';
+import TextAreaField from '@/components/shared/TextAreaField';
+import SelectInput from '@/components/shared/SelectInput';
+import CheckboxField from '@/components/shared/CheckboxField';
+
+type D = Record<string, unknown>;
+type Row = Record<string, unknown>;
+
+interface Props {
+  data: D;
+  patch: (p: D) => void;
+}
+
+const METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].map((m) => ({ value: m, label: m }));
+const PROP_TYPES = ['string', 'number', 'boolean', 'object', 'array'].map((t) => ({
+  value: t,
+  label: t,
+}));
+
+const s = (v: unknown) => (typeof v === 'string' ? v : '');
+
+/** Collapsible config section (icon + title + one-line description), keyboard-operable. */
+const Section: React.FC<{
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}> = ({ title, description, icon, defaultOpen = false, children }) => {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="overflow-hidden rounded-lg border border-border bg-muted/20">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full cursor-pointer items-center gap-2.5 px-3 py-2.5 text-left hover:bg-muted/40"
+      >
+        <span className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground ring-1 ring-inset ring-border">
+          {icon}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-[13px] font-medium text-foreground">{title}</span>
+          <span className="block truncate text-[11px] text-muted-foreground">{description}</span>
+        </span>
+        <ChevronDown
+          className={cn(
+            'h-4 w-4 shrink-0 text-muted-foreground transition-transform',
+            open && 'rotate-180',
+          )}
+        />
+      </button>
+      {open && <div className="flex flex-col gap-3 border-t border-border p-3">{children}</div>}
+    </div>
+  );
+};
+
+const RemoveBtn: React.FC<{ onClick: () => void; label: string }> = ({ onClick, label }) => (
+  <CustomButton
+    type="text"
+    size="icon-sm"
+    aria-label={label}
+    onClick={onClick}
+    className="mt-1 shrink-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+    icon={<Trash2 className="h-4 w-4" />}
+  />
+);
+
+const Empty: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <p className="rounded-md border border-dashed border-border px-3 py-2 text-center text-xs text-muted-foreground">
+    {children}
+  </p>
+);
+
+const ApiRequestForm: React.FC<Props> = ({ data, patch }) => {
+  const arr = (k: string): Row[] => (Array.isArray(data[k]) ? (data[k] as Row[]) : []);
+  const setArr = (k: string, next: Row[]) => patch({ [k]: next });
+  const add = (k: string, row: Row) => setArr(k, [...arr(k), row]);
+  const upd = (k: string, i: number, p: Row) =>
+    setArr(
+      k,
+      arr(k).map((r, j) => (j === i ? { ...r, ...p } : r)),
+    );
+  const del = (k: string, i: number) =>
+    setArr(
+      k,
+      arr(k).filter((_, j) => j !== i),
+    );
+
+  const messages = (data.messages as D | undefined) ?? {};
+  const setMsg = (key: string, v: string) => patch({ messages: { ...messages, [key]: v } });
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Section
+        title="Base Configuration"
+        description="Description, URL and HTTP method"
+        icon={<Cog className="h-3.5 w-3.5" />}
+        defaultOpen
+      >
+        <TextAreaField
+          name="api-description"
+          label="Description"
+          rows={2}
+          value={s(data.description)}
+          onChange={(e) => patch({ description: e.target.value })}
+          placeholder="A clear description helps the AI know when to call this."
+        />
+        <TextInput
+          name="api-url"
+          label="Request URL"
+          value={s(data.url)}
+          onChange={(e) => patch({ url: e.target.value })}
+          placeholder="https://api.example.com/endpoint"
+          className="font-mono"
+          helperText="Must use https://. Supports {{variables}}."
+        />
+        <SelectInput
+          name="api-method"
+          label="HTTP method"
+          options={METHODS}
+          value={s(data.method) || 'GET'}
+          onValueChange={(v) => patch({ method: v })}
+        />
+      </Section>
+
+      <Section
+        title="Authorization & Headers"
+        description="Custom headers (values support {{variables}})"
+        icon={<KeyRound className="h-3.5 w-3.5" />}
+      >
+        {arr('headers').length === 0 ? (
+          <Empty>No headers. Add one for auth (e.g. Authorization).</Empty>
+        ) : (
+          arr('headers').map((h, i) => (
+            <div key={i} className="flex items-start gap-2">
+              <div className="flex flex-1 flex-col gap-2">
+                <div className="flex gap-2">
+                  <TextInput
+                    name={`hk-${i}`}
+                    value={s(h.key)}
+                    onChange={(e) => upd('headers', i, { key: e.target.value })}
+                    placeholder="Header name"
+                    className="flex-1 font-mono"
+                  />
+                  <TextInput
+                    name={`hv-${i}`}
+                    type={h.encrypt ? 'password' : 'text'}
+                    value={s(h.value)}
+                    onChange={(e) =>
+                      upd('headers', i, { value: e.target.value, _encrypted: false })
+                    }
+                    placeholder={h.encrypt && h._encrypted ? '•••••• (saved)' : 'Value or {{var}}'}
+                    className="flex-1 font-mono"
+                  />
+                </div>
+                <CheckboxField
+                  id={`he-${i}`}
+                  label="Encrypt this value (stored secret)"
+                  checked={Boolean(h.encrypt)}
+                  onCheckedChange={(c) => upd('headers', i, { encrypt: c })}
+                />
+              </div>
+              <RemoveBtn onClick={() => del('headers', i)} label="Remove header" />
+            </div>
+          ))
+        )}
+        <CustomButton
+          type="text"
+          size="xs"
+          icon={<Plus className="h-3.5 w-3.5" />}
+          onClick={() => add('headers', { key: '', value: '', encrypt: false })}
+        >
+          Add Header
+        </CustomButton>
+      </Section>
+
+      <Section
+        title="Request Body"
+        description="Properties the AI fills in and sends"
+        icon={<Send className="h-3.5 w-3.5" />}
+      >
+        {arr('requestBody').length === 0 ? (
+          <Empty>No body properties. The AI sends nothing unless you add some.</Empty>
+        ) : (
+          arr('requestBody').map((p, i) => (
+            <div key={i} className="flex items-start gap-2">
+              <div className="flex flex-1 flex-col gap-2">
+                <div className="flex gap-2">
+                  <TextInput
+                    name={`bp-${i}`}
+                    value={s(p.name)}
+                    onChange={(e) => upd('requestBody', i, { name: e.target.value })}
+                    placeholder="property_name"
+                    className="flex-1 font-mono"
+                  />
+                  <div className="w-28 shrink-0">
+                    <SelectInput
+                      name={`bt-${i}`}
+                      options={PROP_TYPES}
+                      value={s(p.type) || 'string'}
+                      onValueChange={(v) => upd('requestBody', i, { type: v })}
+                    />
+                  </div>
+                </div>
+                <TextInput
+                  name={`bd-${i}`}
+                  value={s(p.description)}
+                  onChange={(e) => upd('requestBody', i, { description: e.target.value })}
+                  placeholder="What the AI should put here"
+                />
+                <CheckboxField
+                  id={`br-${i}`}
+                  label="Required"
+                  checked={Boolean(p.required)}
+                  onCheckedChange={(c) => upd('requestBody', i, { required: c })}
+                />
+              </div>
+              <RemoveBtn onClick={() => del('requestBody', i)} label="Remove property" />
+            </div>
+          ))
+        )}
+        <CustomButton
+          type="text"
+          size="xs"
+          icon={<Plus className="h-3.5 w-3.5" />}
+          onClick={() =>
+            add('requestBody', { name: '', type: 'string', required: false, description: '' })
+          }
+        >
+          Add Property
+        </CustomButton>
+      </Section>
+
+      <Section
+        title="Static Body Fields"
+        description="Always-sent key/values ({{variables}} supported)"
+        icon={<ListTree className="h-3.5 w-3.5" />}
+      >
+        {arr('staticBody').length === 0 ? (
+          <Empty>No static fields configured.</Empty>
+        ) : (
+          arr('staticBody').map((f, i) => (
+            <div key={i} className="flex items-start gap-2">
+              <div className="flex flex-1 flex-col gap-2">
+                <div className="flex gap-2">
+                  <TextInput
+                    name={`sk-${i}`}
+                    value={s(f.key)}
+                    onChange={(e) => upd('staticBody', i, { key: e.target.value })}
+                    placeholder="field"
+                    className="flex-1 font-mono"
+                  />
+                  <TextInput
+                    name={`sv-${i}`}
+                    type={f.encrypt ? 'password' : 'text'}
+                    value={s(f.value)}
+                    onChange={(e) =>
+                      upd('staticBody', i, { value: e.target.value, _encrypted: false })
+                    }
+                    placeholder={f.encrypt && f._encrypted ? '•••••• (saved)' : 'value or {{var}}'}
+                    className="flex-1 font-mono"
+                  />
+                </div>
+                <CheckboxField
+                  id={`se-${i}`}
+                  label="Encrypt this value (stored secret)"
+                  checked={Boolean(f.encrypt)}
+                  onCheckedChange={(c) => upd('staticBody', i, { encrypt: c })}
+                />
+              </div>
+              <RemoveBtn onClick={() => del('staticBody', i)} label="Remove field" />
+            </div>
+          ))
+        )}
+        <CustomButton
+          type="text"
+          size="xs"
+          icon={<Plus className="h-3.5 w-3.5" />}
+          onClick={() => add('staticBody', { key: '', value: '', encrypt: false })}
+        >
+          Add Field
+        </CustomButton>
+      </Section>
+
+      <Section
+        title="Response Body"
+        description="Fields to read from the API response"
+        icon={<ListTree className="h-3.5 w-3.5" />}
+      >
+        {arr('responseFields').length === 0 ? (
+          <Empty>No response fields. The AI uses the raw response.</Empty>
+        ) : (
+          arr('responseFields').map((f, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <TextInput
+                name={`rf-${i}`}
+                value={s(f.name)}
+                onChange={(e) => upd('responseFields', i, { name: e.target.value })}
+                placeholder="field_name"
+                className="flex-1 font-mono"
+              />
+              <div className="w-28 shrink-0">
+                <SelectInput
+                  name={`rt-${i}`}
+                  options={PROP_TYPES}
+                  value={s(f.type) || 'string'}
+                  onValueChange={(v) => upd('responseFields', i, { type: v })}
+                />
+              </div>
+              <RemoveBtn onClick={() => del('responseFields', i)} label="Remove field" />
+            </div>
+          ))
+        )}
+        <CustomButton
+          type="text"
+          size="xs"
+          icon={<Plus className="h-3.5 w-3.5" />}
+          onClick={() => add('responseFields', { name: '', type: 'string', required: false })}
+        >
+          Add Property
+        </CustomButton>
+      </Section>
+
+      <Section
+        title="Aliases"
+        description="Rename response fields for use in later steps"
+        icon={<Repeat2 className="h-3.5 w-3.5" />}
+      >
+        {arr('aliases').length === 0 ? (
+          <Empty>No aliases configured.</Empty>
+        ) : (
+          arr('aliases').map((a, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <TextInput
+                name={`af-${i}`}
+                value={s(a.responseField)}
+                onChange={(e) => upd('aliases', i, { responseField: e.target.value })}
+                placeholder="response.field"
+                className="flex-1 font-mono"
+              />
+              <span className="text-muted-foreground">→</span>
+              <TextInput
+                name={`aa-${i}`}
+                value={s(a.alias)}
+                onChange={(e) => upd('aliases', i, { alias: e.target.value })}
+                placeholder="alias_name"
+                className="flex-1 font-mono"
+              />
+              <RemoveBtn onClick={() => del('aliases', i)} label="Remove alias" />
+            </div>
+          ))
+        )}
+        <CustomButton
+          type="text"
+          size="xs"
+          icon={<Plus className="h-3.5 w-3.5" />}
+          onClick={() => add('aliases', { responseField: '', alias: '' })}
+        >
+          Add Alias
+        </CustomButton>
+      </Section>
+
+      <Section
+        title="Messages"
+        description="What the agent says around the call"
+        icon={<Send className="h-3.5 w-3.5" />}
+      >
+        <TextInput
+          name="msg-start"
+          label="Before calling (optional)"
+          value={s(messages.start)}
+          onChange={(e) => setMsg('start', e.target.value)}
+          placeholder="One moment while I look that up…"
+        />
+        <TextInput
+          name="msg-failed"
+          label="On failure (optional)"
+          value={s(messages.failed)}
+          onChange={(e) => setMsg('failed', e.target.value)}
+          placeholder="Sorry, I couldn't complete that right now."
+        />
+      </Section>
+    </div>
+  );
+};
+
+export default ApiRequestForm;

--- a/frontend/src/components/workflows/config/NodeConfigDrawer.tsx
+++ b/frontend/src/components/workflows/config/NodeConfigDrawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { Plus, Trash2 } from 'lucide-react';
 
@@ -12,7 +12,9 @@ import TextAreaField from '@/components/shared/TextAreaField';
 import CheckboxField from '@/components/shared/CheckboxField';
 import SelectInput from '@/components/shared/SelectInput';
 import SearchableSelect from '@/components/shared/SearchableSelect';
+import ApiRequestForm from './ApiRequestForm';
 import { fetchToolsAtom, toolsAtom } from '@/atoms/ToolAtom';
+import { fetchMcpServersAtom, mcpServersAtom } from '@/atoms/MCPAtom';
 import { NODE_REGISTRY } from '@/components/workflows/nodeRegistry';
 import type {
   ConditionEdgeData,
@@ -23,6 +25,14 @@ import type {
 } from '@/types/workflow';
 
 type D = Record<string, unknown>;
+
+/** Variable value types the extractor supports. */
+const VAR_TYPE_OPTIONS = [
+  { value: 'string', label: 'Text' },
+  { value: 'number', label: 'Number' },
+  { value: 'boolean', label: 'Yes / No' },
+  { value: 'date', label: 'Date' },
+];
 
 interface Props {
   node: WorkflowNode | null;
@@ -59,12 +69,30 @@ const NodeConfigDrawer: React.FC<Props> = ({
   const { tools, loading: toolsLoading } = useAtomValue(toolsAtom);
   const fetchTools = useSetAtom(fetchToolsAtom);
 
+  const { servers: mcpServers, loading: mcpLoading } = useAtomValue(mcpServersAtom);
+  const fetchMcp = useSetAtom(fetchMcpServersAtom);
+
+  // Tool node "source" (Tool vs MCP) — local so picking MCP switches the picker before an
+  // id is chosen. Re-synced whenever a different node opens.
+  const [toolSource, setToolSource] = useState<'tool' | 'mcp'>('tool');
+  useEffect(() => {
+    if (node?.type === 'tool') {
+      setToolSource((node.data as D)?.mcpServerId ? 'mcp' : 'tool');
+    }
+  }, [node?.id, node?.type]);
+
   const isToolNode = node?.type === 'tool';
   useEffect(() => {
-    if (isToolNode && tools.length === 0 && !toolsLoading) fetchTools();
-  }, [isToolNode, tools.length, toolsLoading, fetchTools]);
+    if (!isToolNode) return;
+    if (tools.length === 0 && !toolsLoading) fetchTools();
+    if (mcpServers.length === 0 && !mcpLoading) fetchMcp();
+  }, [isToolNode, tools.length, toolsLoading, fetchTools, mcpServers.length, mcpLoading, fetchMcp]);
 
   const toolOptions = useMemo(() => tools.map((t) => ({ value: t.id, label: t.name })), [tools]);
+  const mcpOptions = useMemo(
+    () => mcpServers.map((s) => ({ value: s.id, label: s.name })),
+    [mcpServers],
+  );
 
   // ── node editing ──
   const renderNode = () => {
@@ -144,16 +172,91 @@ const NodeConfigDrawer: React.FC<Props> = ({
 
         {/* tool */}
         {type === 'tool' && (
-          <SearchableSelect
-            name="tool"
-            label="Tool"
-            options={toolOptions}
-            value={String(data.toolId ?? '')}
-            onValueChange={(v) => patch({ toolId: v, tool: undefined })}
-            loading={toolsLoading}
-            placeholder="Select a tool (webhook / custom / MCP)"
-          />
+          <div className="flex flex-col gap-3">
+            <SelectInput
+              name="tool-source"
+              label="Action source"
+              options={[
+                { value: 'tool', label: 'Tool (webhook / custom)' },
+                { value: 'mcp', label: 'MCP server' },
+              ]}
+              value={toolSource}
+              onValueChange={(src) => {
+                const next = src === 'mcp' ? 'mcp' : 'tool';
+                setToolSource(next);
+                // Clear the other source's selection so only one is set on the node.
+                patch(
+                  next === 'mcp'
+                    ? { toolId: undefined, tool: undefined }
+                    : { mcpServerId: undefined },
+                );
+              }}
+            />
+
+            {toolSource === 'mcp' ? (
+              <>
+                <SearchableSelect
+                  name="mcp-server"
+                  label="MCP server"
+                  options={mcpOptions}
+                  value={String(data.mcpServerId ?? '')}
+                  onValueChange={(v) =>
+                    patch({ mcpServerId: v, toolId: undefined, tool: undefined })
+                  }
+                  loading={mcpLoading}
+                  placeholder="Select an MCP server"
+                />
+                <TextInput
+                  name="mcp-tool-name"
+                  label="MCP tool to call (optional)"
+                  value={String(data.mcpToolName ?? '')}
+                  onChange={(e) => patch({ mcpToolName: e.target.value || undefined })}
+                  placeholder="e.g. clickup_create_task"
+                  className="font-mono"
+                  helperText="Name the exact tool so the model calls it directly instead of guessing."
+                />
+              </>
+            ) : (
+              <SearchableSelect
+                name="tool"
+                label="Tool"
+                options={toolOptions}
+                value={String(data.toolId ?? '')}
+                onValueChange={(v) =>
+                  patch({
+                    toolId: v,
+                    mcpServerId: undefined,
+                    mcpToolName: undefined,
+                    tool: undefined,
+                  })
+                }
+                loading={toolsLoading}
+                placeholder="Select a tool (webhook / custom)"
+              />
+            )}
+
+            <TextAreaField
+              name="tool-notes"
+              label="Step details / instructions"
+              rows={4}
+              autoResize
+              value={String(data.notes ?? '')}
+              onChange={(e) => patch({ notes: e.target.value })}
+              placeholder={
+                'How to call the tool — e.g. list_id, exact field values, what to put in the ' +
+                'description. Use {{variables}} for collected values.'
+              }
+              helperText="Passed to the model as the step's details so it calls the tool with the right arguments."
+            />
+
+            <p className="text-[11px] text-muted-foreground">
+              The selected tool / MCP server must also be attached to the agent (Tools &amp; MCP) so
+              the model can call it at this step.
+            </p>
+          </div>
         )}
+
+        {type === 'apiRequest' && <ApiRequestForm data={data} patch={patch} />}
 
         {/* transfer destination */}
         {type === 'transferCall' && (
@@ -194,17 +297,28 @@ const NodeConfigDrawer: React.FC<Props> = ({
                   <Card key={i} className="bg-card">
                     <div className="flex items-start gap-2">
                       <div className="flex flex-1 flex-col gap-2">
-                        <TextInput
-                          name={`var-name-${i}`}
-                          value={String(v.title ?? '')}
-                          onChange={(e) =>
-                            setVars(
-                              vars.map((x, j) => (j === i ? { ...x, title: e.target.value } : x)),
-                            )
-                          }
-                          placeholder="variable_name"
-                          className="font-mono"
-                        />
+                        <div className="flex items-center gap-2">
+                          <TextInput
+                            name={`var-name-${i}`}
+                            value={String(v.title ?? '')}
+                            onChange={(e) =>
+                              setVars(
+                                vars.map((x, j) => (j === i ? { ...x, title: e.target.value } : x)),
+                              )
+                            }
+                            placeholder="variable_name"
+                            className="flex-1 font-mono"
+                          />
+                          <SelectInput
+                            name={`var-type-${i}`}
+                            options={VAR_TYPE_OPTIONS}
+                            value={String(v.type ?? 'string')}
+                            onValueChange={(val) =>
+                              setVars(vars.map((x, j) => (j === i ? { ...x, type: val } : x)))
+                            }
+                            className="w-28 shrink-0"
+                          />
+                        </div>
                         <TextInput
                           name={`var-desc-${i}`}
                           value={String(v.description ?? '')}

--- a/frontend/src/components/workflows/nodeRegistry.ts
+++ b/frontend/src/components/workflows/nodeRegistry.ts
@@ -1,5 +1,6 @@
 import {
   GitBranch,
+  Globe,
   MessageSquare,
   PhoneForwarded,
   PhoneOff,
@@ -58,6 +59,11 @@ const ACCENTS: Record<WorkflowNodeType, NodeAccent> = {
     chip: 'bg-rose-500/10 ring-1 ring-inset ring-rose-500/20 text-rose-600 dark:text-rose-300',
     bar: 'bg-rose-500/70',
     mini: '#f43f5e',
+  },
+  apiRequest: {
+    chip: 'bg-teal-500/10 ring-1 ring-inset ring-teal-500/20 text-teal-600 dark:text-teal-300',
+    bar: 'bg-teal-500/70',
+    mini: '#14b8a6',
   },
 };
 
@@ -130,6 +136,28 @@ export const NODE_REGISTRY: Record<WorkflowNodeType, NodeTypeMeta> = {
     deletable: true,
     defaultData: () => ({ messagePlan: { firstMessage: 'Thanks for calling. Goodbye!' } }),
   },
+  apiRequest: {
+    type: 'apiRequest',
+    label: 'API Request',
+    description: 'Call an HTTP API and use the response',
+    icon: Globe,
+    category: 'Actions',
+    accent: ACCENTS.apiRequest,
+    hasTarget: true,
+    terminal: false,
+    deletable: true,
+    defaultData: () => ({
+      description: 'API request tool',
+      method: 'GET',
+      url: '',
+      headers: [],
+      requestBody: [],
+      staticBody: [],
+      responseFields: [],
+      aliases: [],
+      messages: {},
+    }),
+  },
 };
 
 export const NODE_CATEGORIES: { heading: string; items: NodeTypeMeta[] }[] = [
@@ -137,7 +165,12 @@ export const NODE_CATEGORIES: { heading: string; items: NodeTypeMeta[] }[] = [
   { heading: 'Logic', items: [NODE_REGISTRY.decision] },
   {
     heading: 'Actions',
-    items: [NODE_REGISTRY.tool, NODE_REGISTRY.transferCall, NODE_REGISTRY.endCall],
+    items: [
+      NODE_REGISTRY.tool,
+      NODE_REGISTRY.apiRequest,
+      NODE_REGISTRY.transferCall,
+      NODE_REGISTRY.endCall,
+    ],
   },
 ];
 

--- a/frontend/src/components/workflows/palette/NodePalette.tsx
+++ b/frontend/src/components/workflows/palette/NodePalette.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import React, { useMemo, useState } from 'react';
-import { GripVertical, Search } from 'lucide-react';
+import { GripVertical } from 'lucide-react';
 
 import { cn } from '@/utils/cn';
 import CustomButton from '@/components/shared/CustomButton';
+import SearchBar from '@/components/shared/SearchBar';
 import { NODE_CATEGORIES, type NodeTypeMeta } from '@/components/workflows/nodeRegistry';
 import type { WorkflowNodeType } from '@/types/workflow';
 
@@ -36,15 +37,14 @@ const NodePalette: React.FC<NodePaletteProps> = ({ onAdd }) => {
       <div className="border-b border-border px-4 py-3.5">
         <div className="text-sm font-semibold text-foreground">Add node</div>
         <p className="mt-0.5 text-xs text-muted-foreground">Drag onto the canvas or click to add</p>
-        <div className="relative mt-3">
-          <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <input
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search nodes…"
-            className="w-full rounded-lg border border-border bg-background py-2 pl-8 pr-2.5 text-sm outline-none ring-primary/40 placeholder:text-muted-foreground focus:ring-2"
-          />
-        </div>
+        <SearchBar
+          value={query}
+          onChange={setQuery}
+          debounceMs={0}
+          placeholder="Search nodes…"
+          aria-label="Search node types"
+          containerClassName="mt-3 max-w-none"
+        />
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto p-3">

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -38,6 +38,10 @@ export interface AgentConfig {
   /** Optional closing line the agent reads before hanging up. Stored on
    * config; backend's AgentConfig accepts extra keys. */
   end_call_message?: string | null;
+  /** Conversation-flow driver: a single prompt, or an assigned workflow graph. */
+  mode?: 'prompt' | 'workflow' | null;
+  /** When `mode === 'workflow'`, the assigned (published) workflow. */
+  workflow_id?: string | null;
   system_prompt_template?: string | null;
   conversation_history_token_limit?: number | null;
   language_id?: string | null;
@@ -211,6 +215,8 @@ export interface AgentFormState {
   config: {
     first_message: string;
     end_call_message: string;
+    mode: 'prompt' | 'workflow';
+    workflow_id: string | null;
     system_prompt_template: string;
     conversation_history_token_limit: number | null;
     language_id: string | null;

--- a/frontend/src/types/components.ts
+++ b/frontend/src/types/components.ts
@@ -183,6 +183,7 @@ export interface TextAreaFieldBaseProps extends Omit<React.ComponentProps<'texta
   error?: boolean;
   helperText?: string;
   labelClassName?: string;
+  autoResize?: boolean;
 }
 
 export interface FormTextAreaFieldProps

--- a/frontend/src/types/workflow.ts
+++ b/frontend/src/types/workflow.ts
@@ -1,77 +1,20 @@
 import type { Edge, Node } from '@xyflow/react';
 
 // ── node types ──────────────────────────────────────────────────────────────
-export type WorkflowNodeType = 'conversation' | 'decision' | 'tool' | 'transferCall' | 'endCall';
+export type WorkflowNodeType =
+  | 'conversation'
+  | 'decision'
+  | 'tool'
+  | 'transferCall'
+  | 'endCall'
+  | 'apiRequest';
 
 export type EdgeConditionType = 'ai' | 'logic';
 
-export interface MessagePlan {
-  firstMessage?: string;
-}
-
-export interface ExtractVar {
-  title: string;
-  type: string; // string | number | boolean | date
-  enum: string[];
-  description: string;
-}
-
-export interface VariableExtractionPlan {
-  output: ExtractVar[];
-}
-
-export interface InlineTool {
-  type: string; // endCall | transferCall | sms
-}
-
-// ── per-type node data (discriminated by the node's `type`) ──────────────────
-interface BaseNodeData {
-  name: string;
-  isStart?: boolean;
-  isGlobal?: boolean;
-  condition?: string; // enter-condition (Liquid) for a global node
-}
-
-export interface ConversationData extends BaseNodeData {
-  kind: 'conversation';
-  prompt?: string;
-  messagePlan?: MessagePlan;
-  variableExtractionPlan?: VariableExtractionPlan;
-  toolIds?: string[];
-  maxVisits?: number;
-}
-
-export interface DecisionData extends BaseNodeData {
-  kind: 'decision';
-  prompt?: string;
-}
-
-export interface ToolData extends BaseNodeData {
-  kind: 'tool';
-  toolId?: string;
-  tool?: InlineTool;
-}
-
-export interface TransferCallData extends BaseNodeData {
-  kind: 'transferCall';
-  destination?: Record<string, unknown>;
-  transferPlan?: Record<string, unknown>;
-  messagePlan?: MessagePlan;
-}
-
-export interface EndCallData extends BaseNodeData {
-  kind: 'endCall';
-  messagePlan?: MessagePlan;
-}
-
-// `kind` is a client-only discriminant mirroring the node `type`, kept off the wire.
-export type WorkflowNodeData =
-  | ConversationData
-  | DecisionData
-  | ToolData
-  | TransferCallData
-  | EndCallData;
-
+// Node `data` is intentionally an open record on the wire (React Flow renders it directly
+// and the editor reads fields by key). The authoritative per-type field set lives in the
+// backend schema (`core/services/workflow/schema.py`) and serializer; nodes are kept as a
+// generic record here so the canonical graph round-trips without a transform.
 export type WorkflowNode = Node<Record<string, unknown>, WorkflowNodeType>;
 
 export interface ConditionEdgeData extends Record<string, unknown> {
@@ -119,6 +62,7 @@ export interface WorkflowDetail {
   is_valid: boolean;
   validation_errors: ValidationIssue[];
   has_published: boolean;
+  has_unpublished_changes: boolean;
   created_at: string | null;
   updated_at: string | null;
 }

--- a/frontend/src/utils/agentFormUtils.ts
+++ b/frontend/src/utils/agentFormUtils.ts
@@ -18,7 +18,10 @@ export const defaultFormState = (agentType: AgentDirection): AgentFormState => (
   config: {
     first_message: '',
     end_call_message: '',
+    mode: 'prompt',
+    workflow_id: null,
     system_prompt_template: '',
+    conversation_history_token_limit: null,
     language_id: null,
     knowledge_model_id: null,
     llm_settings: {},
@@ -50,7 +53,11 @@ export function agentDetailToFormState(detail: AgentDetail): AgentFormState {
     config: {
       first_message: cfg.first_message ?? base.config.first_message,
       end_call_message: cfg.end_call_message ?? base.config.end_call_message,
+      mode: cfg.mode === 'workflow' ? 'workflow' : 'prompt',
+      workflow_id: cfg.workflow_id ?? null,
       system_prompt_template: cfg.system_prompt_template ?? base.config.system_prompt_template,
+      conversation_history_token_limit:
+        cfg.conversation_history_token_limit ?? base.config.conversation_history_token_limit,
       language_id: cfg.language_id ?? null,
       knowledge_model_id: cfg.knowledge_model_id ?? null,
       llm_settings: cfg.llm_settings ?? {},

--- a/frontend/src/utils/workflowGraphUtils.ts
+++ b/frontend/src/utils/workflowGraphUtils.ts
@@ -155,6 +155,18 @@ export function validateGraph(nodes: WorkflowNode[], edges: WorkflowEdge[]): Val
       });
     if (!terminal && out[n.id] === 0 && !globalIds.has(n.id))
       issues.push({ code: 'DEAD_END', node_name: n.id, message: 'Node has no outgoing edge.' });
+
+    if (n.type === 'apiRequest') {
+      const url = String((n.data as { url?: unknown }).url ?? '').trim();
+      if (!url)
+        issues.push({ code: 'INVALID_URL', node_name: n.id, message: 'API request needs a URL.' });
+      else if (!url.startsWith('https://') && !url.startsWith('{{'))
+        issues.push({
+          code: 'INVALID_URL',
+          node_name: n.id,
+          message: 'API request URL must use https://.',
+        });
+    }
   });
 
   if (starts.length === 1) {
@@ -194,9 +206,17 @@ export function validateGraph(nodes: WorkflowNode[], edges: WorkflowEdge[]): Val
 // ── Vapi import/export (client mirror of the backend adapter) ────────────────
 export function fromVapi(vapi: Record<string, unknown>): WorkflowGraph {
   const vNodes = (vapi.nodes as Record<string, unknown>[]) ?? [];
+  const seenNodeIds = new Set<string>();
   const nodes = vNodes.map((vn, idx) => {
     const node = { ...vn };
-    const name = (node.name as string) || (node.id as string) || `node_${idx}`;
+    let name = (node.name as string) || (node.id as string) || `node_${idx}`;
+    // De-dupe ids so two Vapi nodes sharing a name don't collide (mirrors the edge de-dupe).
+    if (seenNodeIds.has(name)) {
+      let i = 1;
+      while (seenNodeIds.has(`${name}#${i}`)) i += 1;
+      name = `${name}#${i}`;
+    }
+    seenNodeIds.add(name);
     const type = (node.type as WorkflowNodeType) ?? 'conversation';
     const metadata = (node.metadata as { position?: { x: number; y: number } }) ?? {};
     const position = metadata.position ?? { x: 0, y: 0 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -31,7 +31,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz"
   integrity sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0-0", "@babel/core@^7.28.0", "@babel/core@>=7.0.0":
+"@babel/core@^7.28.0":
   version "7.29.0"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz"
   integrity sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==
@@ -227,7 +227,7 @@
     "@babel/plugin-transform-modules-commonjs" "^7.27.1"
     "@babel/plugin-transform-typescript" "^7.28.5"
 
-"@babel/template@^7.28.6", "@babel/template@>=7.0.0":
+"@babel/template@^7.28.6":
   version "7.28.6"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz"
   integrity sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==
@@ -286,6 +286,28 @@
   version "0.2.5"
   resolved "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.5.tgz"
   integrity sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A==
+
+"@emnapi/core@^1.4.3", "@emnapi/core@^1.8.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.11.1.tgz#b9e1064f3a6b1631e241e638eb48d736bfd372a6"
+  integrity sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==
+  dependencies:
+    "@emnapi/wasi-threads" "1.2.2"
+    tslib "^2.4.0"
+
+"@emnapi/runtime@^1.4.3", "@emnapi/runtime@^1.4.4", "@emnapi/runtime@^1.8.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.11.1.tgz#58f1f3d5d81a9b12f793ab688c96371901027c24"
+  integrity sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@1.2.2", "@emnapi/wasi-threads@^1.1.0":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz#4c93becf5bfa3b13d1bbdcc06aee38321ad8139a"
+  integrity sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==
+  dependencies:
+    tslib "^2.4.0"
 
 "@eslint-community/eslint-utils@^4.7.0", "@eslint-community/eslint-utils@^4.8.0":
   version "4.8.0"
@@ -423,7 +445,7 @@
     "@firebase/util" "1.13.0"
     tslib "^2.1.0"
 
-"@firebase/app-compat@0.5.2", "@firebase/app-compat@0.x":
+"@firebase/app-compat@0.5.2":
   version "0.5.2"
   resolved "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.2.tgz"
   integrity sha512-cn+U27GDaBS/irsbvrfnPZdcCzeZPRGKieSlyb7vV6LSOL6mdECnB86PgYjYGxSNg8+U48L/NeevTV1odU+mOQ==
@@ -434,12 +456,12 @@
     "@firebase/util" "1.13.0"
     tslib "^2.1.0"
 
-"@firebase/app-types@0.9.3", "@firebase/app-types@0.x":
+"@firebase/app-types@0.9.3":
   version "0.9.3"
   resolved "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz"
   integrity sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==
 
-"@firebase/app@0.14.2", "@firebase/app@0.x":
+"@firebase/app@0.14.2":
   version "0.14.2"
   resolved "https://registry.npmjs.org/@firebase/app/-/app-0.14.2.tgz"
   integrity sha512-Ecx2ig/JLC9ayIQwZHqm41Tzlf4c1WUuFhFUZB1y+JIJqDRE579x7Uil7tKT8MwDpOPwrK5ZtpxdSsrfy/LF8Q==
@@ -732,7 +754,7 @@
     "@firebase/util" "1.13.0"
     tslib "^2.1.0"
 
-"@firebase/util@1.13.0", "@firebase/util@1.x":
+"@firebase/util@1.13.0":
   version "1.13.0"
   resolved "https://registry.npmjs.org/@firebase/util/-/util-1.13.0.tgz"
   integrity sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==
@@ -751,14 +773,6 @@
   dependencies:
     "@floating-ui/utils" "^0.2.11"
 
-"@floating-ui/dom@^1.0.0", "@floating-ui/dom@^1.7.6":
-  version "1.7.6"
-  resolved "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz"
-  integrity sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==
-  dependencies:
-    "@floating-ui/core" "^1.7.5"
-    "@floating-ui/utils" "^0.2.11"
-
 "@floating-ui/dom@1.7.4":
   version "1.7.4"
   resolved "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz"
@@ -766,6 +780,14 @@
   dependencies:
     "@floating-ui/core" "^1.7.3"
     "@floating-ui/utils" "^0.2.10"
+
+"@floating-ui/dom@^1.0.0", "@floating-ui/dom@^1.7.6":
+  version "1.7.6"
+  resolved "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz"
+  integrity sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==
+  dependencies:
+    "@floating-ui/core" "^1.7.5"
+    "@floating-ui/utils" "^0.2.11"
 
 "@floating-ui/react-dom@^2.0.0":
   version "2.1.8"
@@ -839,10 +861,128 @@
   optionalDependencies:
     "@img/sharp-libvips-darwin-arm64" "1.2.0"
 
+"@img/sharp-darwin-x64@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.3.tgz#edf93fb01479604f14ad6a64a716e2ef2bb23100"
+  integrity sha512-yHpJYynROAj12TA6qil58hmPmAwxKKC7reUqtGLzsOHfP7/rniNGTL8tjWX6L3CTV4+5P4ypcS7Pp+7OB+8ihA==
+  optionalDependencies:
+    "@img/sharp-libvips-darwin-x64" "1.2.0"
+
 "@img/sharp-libvips-darwin-arm64@1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.0.tgz"
   integrity sha512-sBZmpwmxqwlqG9ueWFXtockhsxefaV6O84BMOrhtg/YqbTaRdqDE7hxraVE3y6gVM4eExmfzW4a8el9ArLeEiQ==
+
+"@img/sharp-libvips-darwin-x64@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.0.tgz#918ca81c5446f31114834cb908425a7532393185"
+  integrity sha512-M64XVuL94OgiNHa5/m2YvEQI5q2cl9d/wk0qFTDVXcYzi43lxuiFTftMR1tOnFQovVXNZJ5TURSDK2pNe9Yzqg==
+
+"@img/sharp-libvips-linux-arm64@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.0.tgz#1a5beafc857b43f378c3030427aa981ee3edbc54"
+  integrity sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==
+
+"@img/sharp-libvips-linux-arm@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.0.tgz#bff51182d5238ca35c5fe9e9f594a18ad6a5480d"
+  integrity sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==
+
+"@img/sharp-libvips-linux-ppc64@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.0.tgz#10c53ccf6f2d47d71fb3fa282697072c8fe9e40e"
+  integrity sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==
+
+"@img/sharp-libvips-linux-s390x@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.0.tgz#392fd7557ddc5c901f1bed7ab3c567c08833ef3b"
+  integrity sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==
+
+"@img/sharp-libvips-linux-x64@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.0.tgz#9315cf90a2fdcdc0e29ea7663cbd8b0f15254400"
+  integrity sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==
+
+"@img/sharp-libvips-linuxmusl-arm64@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.0.tgz#705e03e67d477f6f842f37eb7f66285b1150dc06"
+  integrity sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==
+
+"@img/sharp-libvips-linuxmusl-x64@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.0.tgz#ec905071cc538df64848d5900e0d386d77c55f13"
+  integrity sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==
+
+"@img/sharp-linux-arm64@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.3.tgz#476f8f13ce192555391ae9d4bc658637a6acf3e5"
+  integrity sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-arm64" "1.2.0"
+
+"@img/sharp-linux-arm@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.3.tgz#9898cd68ea3e3806b94fe25736d5d7ecb5eac121"
+  integrity sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-arm" "1.2.0"
+
+"@img/sharp-linux-ppc64@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.3.tgz#6a7cd4c608011333a0ddde6d96e03ac042dd9079"
+  integrity sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-ppc64" "1.2.0"
+
+"@img/sharp-linux-s390x@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.3.tgz#48e27ab969efe97d270e39297654c0e0c9b42919"
+  integrity sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-s390x" "1.2.0"
+
+"@img/sharp-linux-x64@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.3.tgz#5aa77ad4aa447ddf6d642e2a2c5599eb1292dfaa"
+  integrity sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-x64" "1.2.0"
+
+"@img/sharp-linuxmusl-arm64@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.3.tgz#62053a9d77c7d4632c677619325b741254689dd7"
+  integrity sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==
+  optionalDependencies:
+    "@img/sharp-libvips-linuxmusl-arm64" "1.2.0"
+
+"@img/sharp-linuxmusl-x64@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.3.tgz#5107c7709c7e0a44fe5abef59829f1de86fa0a3a"
+  integrity sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==
+  optionalDependencies:
+    "@img/sharp-libvips-linuxmusl-x64" "1.2.0"
+
+"@img/sharp-wasm32@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-wasm32/-/sharp-wasm32-0.34.3.tgz#c1dcabb834ec2f71308a810b399bb6e6e3b79619"
+  integrity sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==
+  dependencies:
+    "@emnapi/runtime" "^1.4.4"
+
+"@img/sharp-win32-arm64@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.3.tgz#3e8654e368bb349d45799a0d7aeb29db2298628e"
+  integrity sha512-MjnHPnbqMXNC2UgeLJtX4XqoVHHlZNd+nPt1kRPmj63wURegwBhZlApELdtxM2OIZDRv/DFtLcNhVbd1z8GYXQ==
+
+"@img/sharp-win32-ia32@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.3.tgz#9d4c105e8d5074a351a81a0b6d056e0af913bf76"
+  integrity sha512-xuCdhH44WxuXgOM714hn4amodJMZl3OEvf0GVTm0BEyMeA2to+8HEdRPShH0SLYptJY1uBw+SCFP9WVQi1Q/cw==
+
+"@img/sharp-win32-x64@0.34.3":
+  version "0.34.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.3.tgz#d20c89bd41b1dd3d76d8575714aaaa3c43204b6a"
+  integrity sha512-OWwz05d++TxzLEv4VnsTz5CmZ6mI6S05sfQGEMrNrQcOEERbX46332IvE7pO/EUiw7jUrrS40z/M7kPyjfl04g==
 
 "@inquirer/ansi@^1.0.2":
   version "1.0.2"
@@ -987,6 +1127,22 @@
     outvariant "^1.4.3"
     strict-event-emitter "^0.5.1"
 
+"@napi-rs/wasm-runtime@^0.2.11":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz#3e78a8b96e6c33a6c517e1894efbd5385a7cb6f2"
+  integrity sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==
+  dependencies:
+    "@emnapi/core" "^1.4.3"
+    "@emnapi/runtime" "^1.4.3"
+    "@tybys/wasm-util" "^0.10.0"
+
+"@napi-rs/wasm-runtime@^1.1.1":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz#ed33806d0f9be98dc76d0c3d4fd872fda701b5d5"
+  integrity sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==
+  dependencies:
+    "@tybys/wasm-util" "^0.10.3"
+
 "@next/env@15.5.19":
   version "15.5.19"
   resolved "https://registry.npmjs.org/@next/env/-/env-15.5.19.tgz"
@@ -1004,7 +1160,42 @@
   resolved "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.19.tgz"
   integrity sha512-jx9wWlTKueHKPvVOndyr7WuaevWCkuYqsQ8gC0TMPKAVWG3MhcdMrjfo9tvIZNXd0QOUYXXvAcZ325y8Uq7uzg==
 
-"@noble/ciphers@^1.0.0", "@noble/ciphers@^1.3.0":
+"@next/swc-darwin-x64@15.5.19":
+  version "15.5.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.19.tgz#fd36d8a74eace4ee50d37dd41d3d6355c92ed661"
+  integrity sha512-291KFcsIQ3OenRdiUDFOR6W3wezzH4auENXm1gbm1Bjd4ANMMRgxPrWTUztQN43BnVoVuMnHCrLeECIMwgFKbA==
+
+"@next/swc-linux-arm64-gnu@15.5.19":
+  version "15.5.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.19.tgz#a812c64be14475b9d5d10fc34b4aea66d384e387"
+  integrity sha512-WeH+nelQyyMeE2f8FxBRZNrGipya5zHZV2vjzfCOAYyiI6am+NbnWAAldOBFQBB2w0DjJcsvrKqoFT2b7+5YoA==
+
+"@next/swc-linux-arm64-musl@15.5.19":
+  version "15.5.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.19.tgz#a61c81f227358a25918e0c27847a28cfda743f1c"
+  integrity sha512-5xTOE0lDlDCSSfp+BAif7j17VRRCjWp//ZPZy6NI0QpdrhxtQnsZguSx0xAAZ0c9XZLrLLwCe/XVe5YPrRilKw==
+
+"@next/swc-linux-x64-gnu@15.5.19":
+  version "15.5.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.19.tgz#38a9ba9a7ff388592adc9abd6394b749e35ba21b"
+  integrity sha512-LTxRmMgqqMv05Had879W00Fm53quiJd3Zuz8h1JSNJ3nGSlbZ/7Tjs1tKyScgN3Au3t3MyPsjPlq60fMmSHLsg==
+
+"@next/swc-linux-x64-musl@15.5.19":
+  version "15.5.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.19.tgz#ca1c0319aef657109c3466ca0fc70e3cab14008b"
+  integrity sha512-eoNQSpA5PQfB9wBO4RA47MTDXWz1fizy9Y3Z6e4DetYIF3dvjuu8sj7aIGn/bFCU6lnFzTK34NtCaffP4NsQ7Q==
+
+"@next/swc-win32-arm64-msvc@15.5.19":
+  version "15.5.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.19.tgz#bc18eb3301245851472a699ed622952f6e3aa3f2"
+  integrity sha512-6UNt2dFuCHOe446sm/Kp69nUe8/wIhnh9bm6Xcqw4qEWCOppLMOvhTBVgvM7invVUNr4SPpP6NOQsACtn2IN9Q==
+
+"@next/swc-win32-x64-msvc@15.5.19":
+  version "15.5.19"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.19.tgz#5f4c849f10c5907ad595611de0b29ae6c8a73ec9"
+  integrity sha512-PhmojAHyqMne56HBLGu9dhDnHPuFmEjrXSQMM/nW0J6j849lk3ESrVtqNJcCk8CKOV7brpTTbaYAjwKPzKM69w==
+
+"@noble/ciphers@^1.3.0":
   version "1.3.0"
   resolved "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz"
   integrity sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==
@@ -1016,7 +1207,7 @@
   dependencies:
     "@noble/hashes" "1.8.0"
 
-"@noble/hashes@^1.8.0", "@noble/hashes@1.8.0":
+"@noble/hashes@1.8.0", "@noble/hashes@^1.8.0":
   version "1.8.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
@@ -1029,7 +1220,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -1065,10 +1256,70 @@
   resolved "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz"
   integrity sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==
 
+"@parcel/watcher-android-arm64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz#507f836d7e2042f798c7d07ad19c3546f9848ac1"
+  integrity sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==
+
 "@parcel/watcher-darwin-arm64@2.5.1":
   version "2.5.1"
   resolved "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz"
   integrity sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==
+
+"@parcel/watcher-darwin-x64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz#99f3af3869069ccf774e4ddfccf7e64fd2311ef8"
+  integrity sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==
+
+"@parcel/watcher-freebsd-x64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz#14d6857741a9f51dfe51d5b08b7c8afdbc73ad9b"
+  integrity sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==
+
+"@parcel/watcher-linux-arm-glibc@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz#43c3246d6892381db473bb4f663229ad20b609a1"
+  integrity sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==
+
+"@parcel/watcher-linux-arm-musl@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz#663750f7090bb6278d2210de643eb8a3f780d08e"
+  integrity sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==
+
+"@parcel/watcher-linux-arm64-glibc@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz#ba60e1f56977f7e47cd7e31ad65d15fdcbd07e30"
+  integrity sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==
+
+"@parcel/watcher-linux-arm64-musl@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz#f7fbcdff2f04c526f96eac01f97419a6a99855d2"
+  integrity sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==
+
+"@parcel/watcher-linux-x64-glibc@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz#4d2ea0f633eb1917d83d483392ce6181b6a92e4e"
+  integrity sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==
+
+"@parcel/watcher-linux-x64-musl@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz#277b346b05db54f55657301dd77bdf99d63606ee"
+  integrity sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==
+
+"@parcel/watcher-win32-arm64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz#7e9e02a26784d47503de1d10e8eab6cceb524243"
+  integrity sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==
+
+"@parcel/watcher-win32-ia32@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz#2d0f94fa59a873cdc584bf7f6b1dc628ddf976e6"
+  integrity sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==
+
+"@parcel/watcher-win32-x64@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz#ae52693259664ba6f2228fa61d7ee44b64ea0947"
+  integrity sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==
 
 "@parcel/watcher@^2.4.1":
   version "2.5.1"
@@ -1099,7 +1350,7 @@
   resolved "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@playwright/test@^1.50.0", "@playwright/test@^1.51.1":
+"@playwright/test@^1.50.0":
   version "1.58.2"
   resolved "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz"
   integrity sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==
@@ -1878,10 +2129,72 @@
     source-map-js "^1.2.1"
     tailwindcss "4.2.1"
 
+"@tailwindcss/oxide-android-arm64@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.1.tgz#a7c24919b607e7f884e6ab97799d12c7fb5b47bd"
+  integrity sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg==
+
 "@tailwindcss/oxide-darwin-arm64@4.2.1":
   version "4.2.1"
   resolved "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.1.tgz"
   integrity sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw==
+
+"@tailwindcss/oxide-darwin-x64@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.1.tgz#1e59ef0665f6cb9e658bf0ebcb3cb50f21b2c175"
+  integrity sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw==
+
+"@tailwindcss/oxide-freebsd-x64@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.1.tgz#6b0c75e9dac7f1a241cb9a5eaa89f0d9664835b6"
+  integrity sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA==
+
+"@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.1.tgz#717044d8fe746b1f0760485946c0c9a900174f7b"
+  integrity sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw==
+
+"@tailwindcss/oxide-linux-arm64-gnu@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.1.tgz#f544b0faf166d80791347911b2dd4372a893129d"
+  integrity sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ==
+
+"@tailwindcss/oxide-linux-arm64-musl@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.1.tgz#9fbaf8dc00b858a2b955526abb15d88f5678d1ef"
+  integrity sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==
+
+"@tailwindcss/oxide-linux-x64-gnu@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.1.tgz#6ab4e6b8d308d037a1155b8443df5941dbfa6aa1"
+  integrity sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==
+
+"@tailwindcss/oxide-linux-x64-musl@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.1.tgz#52c55593394dff85f1fa88172f69f8fdcde182b6"
+  integrity sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==
+
+"@tailwindcss/oxide-wasm32-wasi@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.1.tgz#7401e35f881d3654b6180badd1243d75a2702ea5"
+  integrity sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==
+  dependencies:
+    "@emnapi/core" "^1.8.1"
+    "@emnapi/runtime" "^1.8.1"
+    "@emnapi/wasi-threads" "^1.1.0"
+    "@napi-rs/wasm-runtime" "^1.1.1"
+    "@tybys/wasm-util" "^0.10.1"
+    tslib "^2.8.1"
+
+"@tailwindcss/oxide-win32-arm64-msvc@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.1.tgz#63a502e7b696dcd976aa356b94ce0f4f8f832c44"
+  integrity sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA==
+
+"@tailwindcss/oxide-win32-x64-msvc@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.1.tgz#8cc59b28ebc4dc866c0c14d7057f07f0ed04c4a8"
+  integrity sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ==
 
 "@tailwindcss/oxide@4.2.1":
   version "4.2.1"
@@ -2150,6 +2463,13 @@
     minimatch "^10.0.1"
     path-browserify "^1.0.1"
 
+"@tybys/wasm-util@^0.10.0", "@tybys/wasm-util@^0.10.1", "@tybys/wasm-util@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.3.tgz#015cba9e9dd47ce14d03d2a8c5d547bfb169665d"
+  integrity sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==
+  dependencies:
+    tslib "^2.4.0"
+
 "@types/d3-color@*":
   version "3.1.3"
   resolved "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz"
@@ -2188,11 +2508,6 @@
   dependencies:
     "@types/d3-interpolate" "*"
     "@types/d3-selection" "*"
-
-"@types/dom-mediacapture-record@^1":
-  version "1.0.22"
-  resolved "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz"
-  integrity sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==
 
 "@types/estree@^1.0.6":
   version "1.0.8"
@@ -2237,19 +2552,19 @@
   resolved "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz"
   integrity sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==
 
-"@types/node@^20", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@>=18":
+"@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^20":
   version "20.19.12"
   resolved "https://registry.npmjs.org/@types/node/-/node-20.19.12.tgz"
   integrity sha512-lSOjyS6vdO2G2g2CWrETTV3Jz2zlCXHpu1rcubLKpz9oj+z/1CceHlj+yq53W+9zgb98nSov/wjEKYDNauD+Hw==
   dependencies:
     undici-types "~6.21.0"
 
-"@types/react-dom@*", "@types/react-dom@^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom@^19", "@types/react-dom@>=17":
+"@types/react-dom@^19":
   version "19.1.9"
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz"
   integrity sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==
 
-"@types/react@*", "@types/react@^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react@^19", "@types/react@^19.0.0", "@types/react@>=16.8", "@types/react@>=17", "@types/react@>=17.0.0", "@types/react@>=18.0.0":
+"@types/react@^19":
   version "19.1.12"
   resolved "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz"
   integrity sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==
@@ -2314,7 +2629,7 @@
     "@typescript-eslint/types" "8.44.0"
     "@typescript-eslint/visitor-keys" "8.44.0"
 
-"@typescript-eslint/tsconfig-utils@^8.44.0", "@typescript-eslint/tsconfig-utils@8.44.0":
+"@typescript-eslint/tsconfig-utils@8.44.0", "@typescript-eslint/tsconfig-utils@^8.44.0":
   version "8.44.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz"
   integrity sha512-x5Y0+AuEPqAInc6yd0n5DAcvtoQ/vyaGwuX5HE9n6qAefk1GaedqrLQF8kQGylLUb9pnZyLf+iEiL9fr8APDtQ==
@@ -2330,7 +2645,7 @@
     debug "^4.3.4"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/types@^8.44.0", "@typescript-eslint/types@8.44.0":
+"@typescript-eslint/types@8.44.0", "@typescript-eslint/types@^8.44.0":
   version "8.44.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.0.tgz"
   integrity sha512-ZSl2efn44VsYM0MfDQe68RKzBz75NPgLQXuGypmym6QVOWL5kegTZuZ02xRAT9T+onqvM6T8CdQk0OwYMB6ZvA==
@@ -2369,10 +2684,102 @@
     "@typescript-eslint/types" "8.44.0"
     eslint-visitor-keys "^4.2.1"
 
+"@unrs/resolver-binding-android-arm-eabi@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz#9f5b04503088e6a354295e8ea8fe3cb99e43af81"
+  integrity sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==
+
+"@unrs/resolver-binding-android-arm64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz#7414885431bd7178b989aedc4d25cccb3865bc9f"
+  integrity sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==
+
 "@unrs/resolver-binding-darwin-arm64@1.11.1":
   version "1.11.1"
   resolved "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz"
   integrity sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==
+
+"@unrs/resolver-binding-darwin-x64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz#fd4d81257b13f4d1a083890a6a17c00de571f0dc"
+  integrity sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==
+
+"@unrs/resolver-binding-freebsd-x64@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz#d2513084d0f37c407757e22f32bd924a78cfd99b"
+  integrity sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==
+
+"@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz#844d2605d057488d77fab09705f2866b86164e0a"
+  integrity sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==
+
+"@unrs/resolver-binding-linux-arm-musleabihf@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz#204892995cefb6bd1d017d52d097193bc61ddad3"
+  integrity sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==
+
+"@unrs/resolver-binding-linux-arm64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz#023eb0c3aac46066a10be7a3f362e7b34f3bdf9d"
+  integrity sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==
+
+"@unrs/resolver-binding-linux-arm64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz#9e6f9abb06424e3140a60ac996139786f5d99be0"
+  integrity sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==
+
+"@unrs/resolver-binding-linux-ppc64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz#b111417f17c9d1b02efbec8e08398f0c5527bb44"
+  integrity sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==
+
+"@unrs/resolver-binding-linux-riscv64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz#92ffbf02748af3e99873945c9a8a5ead01d508a9"
+  integrity sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==
+
+"@unrs/resolver-binding-linux-riscv64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz#0bec6f1258fc390e6b305e9ff44256cb207de165"
+  integrity sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==
+
+"@unrs/resolver-binding-linux-s390x-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz#577843a084c5952f5906770633ccfb89dac9bc94"
+  integrity sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==
+
+"@unrs/resolver-binding-linux-x64-gnu@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz#36fb318eebdd690f6da32ac5e0499a76fa881935"
+  integrity sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==
+
+"@unrs/resolver-binding-linux-x64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz#bfb9af75f783f98f6a22c4244214efe4df1853d6"
+  integrity sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==
+
+"@unrs/resolver-binding-wasm32-wasi@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz#752c359dd875684b27429500d88226d7cc72f71d"
+  integrity sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==
+  dependencies:
+    "@napi-rs/wasm-runtime" "^0.2.11"
+
+"@unrs/resolver-binding-win32-arm64-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz#ce5735e600e4c2fbb409cd051b3b7da4a399af35"
+  integrity sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==
+
+"@unrs/resolver-binding-win32-ia32-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz#72fc57bc7c64ec5c3de0d64ee0d1810317bc60a6"
+  integrity sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==
+
+"@unrs/resolver-binding-win32-x64-msvc@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
+  integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
 "@xyflow/react@^12.11.0":
   version "12.11.1"
@@ -2411,15 +2818,10 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.15.0:
+acorn@^8.15.0:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
-
-agent-base@^7.1.2:
-  version "7.1.4"
-  resolved "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz"
-  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
 agent-base@6:
   version "6.0.2"
@@ -2427,6 +2829,11 @@ agent-base@6:
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
+
+agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
 ajv-formats@^3.0.1:
   version "3.0.1"
@@ -2445,17 +2852,7 @@ ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0:
-  version "8.18.0"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz"
-  integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
-  dependencies:
-    fast-deep-equal "^3.1.3"
-    fast-uri "^3.0.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-
-ajv@^8.17.1:
+ajv@^8.0.0, ajv@^8.17.1:
   version "8.18.0"
   resolved "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz"
   integrity sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==
@@ -2478,11 +2875,6 @@ ansi-regex@^5.0.1:
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-regex@^6.0.1:
-  version "6.2.2"
-  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz"
-  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
-
-ansi-regex@^6.2.2:
   version "6.2.2"
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz"
   integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
@@ -2737,7 +3129,7 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0, browserslist@^4.24.4, browserslist@^4.26.2, "browserslist@>= 4.21.0":
+browserslist@^4.24.0, browserslist@^4.24.4, browserslist@^4.26.2:
   version "4.28.1"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz"
   integrity sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==
@@ -2827,12 +3219,7 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^5.3.0:
-  version "5.6.2"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz"
-  integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
-
-chalk@^5.6.0:
+chalk@^5.3.0, chalk@^5.6.0:
   version "5.6.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz"
   integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
@@ -2900,7 +3287,7 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
-clsx@^2.1.1, clsx@2.1.1:
+clsx@2.1.1, clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz"
   integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
@@ -3059,7 +3446,7 @@ csstype@^3.0.2:
   resolved "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz"
   integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
 
-d3-drag@^3.0.0, "d3-drag@2 - 3":
+"d3-drag@2 - 3", d3-drag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz"
   integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
@@ -3072,14 +3459,14 @@ d3-drag@^3.0.0, "d3-drag@2 - 3":
   resolved "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz"
   integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
 
-d3-interpolate@^3.0.1, "d3-interpolate@1 - 3":
+"d3-interpolate@1 - 3", d3-interpolate@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz"
   integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
   dependencies:
     d3-color "1 - 3"
 
-d3-selection@^3.0.0, "d3-selection@2 - 3", d3-selection@3:
+"d3-selection@2 - 3", d3-selection@3, d3-selection@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz"
   integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
@@ -3163,19 +3550,19 @@ dayjs@^1.11.19:
   resolved "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz"
   integrity sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==
 
+debug@4, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0, debug@^4.4.1, debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0, debug@^4.4.1, debug@^4.4.3, debug@4:
-  version "4.4.3"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
 
 dedent@^1.6.0:
   version "1.7.2"
@@ -3505,7 +3892,7 @@ eslint-config-next@^15.5.9:
     eslint-plugin-react "^7.37.0"
     eslint-plugin-react-hooks "^5.0.0"
 
-eslint-config-prettier@^10.1.8, "eslint-config-prettier@>= 7.0.0 <10.0.0 || >=10.1.0":
+eslint-config-prettier@^10.1.8:
   version "10.1.8"
   resolved "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz"
   integrity sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==
@@ -3539,7 +3926,7 @@ eslint-module-utils@^2.12.1:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-import@*, eslint-plugin-import@^2.31.0:
+eslint-plugin-import@^2.31.0:
   version "2.32.0"
   resolved "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz"
   integrity sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==
@@ -3640,7 +4027,7 @@ eslint-visitor-keys@^4.2.1:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz"
   integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
 
-eslint@*, "eslint@^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7", "eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^7.23.0 || ^8.0.0 || ^9.0.0", "eslint@^8.57.0 || ^9.0.0", eslint@^9.35.0, eslint@>=7.0.0, eslint@>=8.0.0:
+eslint@^9.35.0:
   version "9.35.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz"
   integrity sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==
@@ -3786,7 +4173,7 @@ express-rate-limit@^8.2.1:
   dependencies:
     ip-address "^10.2.0"
 
-express@^5.2.1, "express@>= 4.11":
+express@^5.2.1:
   version "5.2.1"
   resolved "https://registry.npmjs.org/express/-/express-5.2.1.tgz"
   integrity sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==
@@ -3835,28 +4222,6 @@ fast-equals@^5.3.3:
   resolved "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz"
   integrity sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==
 
-fast-glob@^3.3.2:
-  version "3.3.3"
-  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz"
-  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.8"
-
-fast-glob@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz"
-  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.8"
-
 fast-glob@3.3.1:
   version "3.3.1"
   resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz"
@@ -3867,6 +4232,17 @@ fast-glob@3.3.1:
     glob-parent "^5.1.2"
     merge2 "^1.3.0"
     micromatch "^4.0.4"
+
+fast-glob@^3.3.2, fast-glob@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz"
+  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.8"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
@@ -3897,12 +4273,7 @@ faye-websocket@0.11.4:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fdir@^6.2.0:
-  version "6.5.0"
-  resolved "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz"
-  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
-
-fdir@^6.4.4:
+fdir@^6.2.0, fdir@^6.4.4:
   version "6.5.0"
   resolved "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
@@ -4281,7 +4652,7 @@ headers-polyfill@^4.0.2:
   resolved "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz"
   integrity sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==
 
-hono@^4, hono@^4.11.4:
+hono@^4.11.4:
   version "4.12.23"
   resolved "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz"
   integrity sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==
@@ -4714,7 +5085,7 @@ iterator.prototype@^1.1.4:
     has-symbols "^1.1.0"
     set-function-name "^2.0.2"
 
-jiti@*, jiti@^2.6.1:
+jiti@^2.6.1:
   version "2.6.1"
   resolved "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz"
   integrity sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==
@@ -4788,12 +5159,7 @@ json5@^1.0.2:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.2.2:
-  version "2.2.3"
-  resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz"
-  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
-
-json5@^2.2.3:
+json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -4854,10 +5220,60 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+lightningcss-android-arm64@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.31.1.tgz#609ff48332adff452a8157a7c2842fd692a8eac4"
+  integrity sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==
+
 lightningcss-darwin-arm64@1.31.1:
   version "1.31.1"
   resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.31.1.tgz"
   integrity sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==
+
+lightningcss-darwin-x64@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.31.1.tgz#f7482c311273571ec0c2bd8277c1f5f6e90e03a4"
+  integrity sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==
+
+lightningcss-freebsd-x64@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.31.1.tgz#91df1bb290f1cb7bb2af832d7d0d8809225e0124"
+  integrity sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==
+
+lightningcss-linux-arm-gnueabihf@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.31.1.tgz#c3cad5ae8b70045f21600dc95295ab6166acf57e"
+  integrity sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==
+
+lightningcss-linux-arm64-gnu@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.31.1.tgz#a5c4f6a5ac77447093f61b209c0bd7fef1f0a3e3"
+  integrity sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==
+
+lightningcss-linux-arm64-musl@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.31.1.tgz#af26ab8f829b727ada0a200938a6c8796ff36900"
+  integrity sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==
+
+lightningcss-linux-x64-gnu@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.31.1.tgz#a891d44e84b71c0d88959feb9a7522bbf61450ee"
+  integrity sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==
+
+lightningcss-linux-x64-musl@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.31.1.tgz#8c8b21def851f4d477fa897b80cb3db2b650bc6e"
+  integrity sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==
+
+lightningcss-win32-arm64-msvc@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.31.1.tgz#79000fb8c57e94a91b8fc643e74d5a54407d7080"
+  integrity sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==
+
+lightningcss-win32-x64-msvc@1.31.1:
+  version "1.31.1"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.31.1.tgz#7f025274c81c7d659829731e09c8b6f442209837"
+  integrity sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==
 
 lightningcss@1.31.1:
   version "1.31.1"
@@ -4928,7 +5344,7 @@ listr2@^9.0.3:
     rfdc "^1.4.1"
     wrap-ansi "^9.0.0"
 
-livekit-client@^2.17.2, livekit-client@^2.18.2, livekit-client@^2.9.9:
+livekit-client@^2.9.9:
   version "2.19.2"
   resolved "https://registry.npmjs.org/livekit-client/-/livekit-client-2.19.2.tgz"
   integrity sha512-Kvk07QYDWRAbmYNLRll04ZIuxMQobW/oLPYnmR1kCy8GGHpU0gqyHf704Rz+29zfy8IJZRjKqeVbzGSKn9sumw==
@@ -4989,15 +5405,15 @@ log-update@^6.1.0:
     strip-ansi "^7.1.0"
     wrap-ansi "^9.0.0"
 
-loglevel@^1.9.2:
-  version "1.9.2"
-  resolved "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz"
-  integrity sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==
-
 loglevel@1.9.1:
   version "1.9.1"
   resolved "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz"
   integrity sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==
+
+loglevel@^1.9.2:
+  version "1.9.2"
+  resolved "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz"
+  integrity sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==
 
 long@^5.0.0, long@^5.3.2:
   version "5.3.2"
@@ -5030,7 +5446,7 @@ magic-string@^0.30.21:
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.5"
 
-map-obj@^5.0.2, map-obj@5.0.2:
+map-obj@5.0.2, map-obj@^5.0.2:
   version "5.0.2"
   resolved "https://registry.npmjs.org/map-obj/-/map-obj-5.0.2.tgz"
   integrity sha512-K6K2NgKnTXimT3779/4KxSvobxOtMmx1LBZ3NwRxT/MDIR3Br/fQ4Q+WCX5QxjyUR8zg5+RV9Tbf2c5pAWTD2A==
@@ -5085,15 +5501,15 @@ micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.8:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
-mime-db@^1.54.0:
-  version "1.54.0"
-  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz"
-  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
-
 mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-db@^1.54.0:
+  version "1.54.0"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz"
+  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
 
 mime-types@^2.1.12:
   version "2.1.35"
@@ -5102,14 +5518,7 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "1.52.0"
 
-mime-types@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz"
-  integrity sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==
-  dependencies:
-    mime-db "^1.54.0"
-
-mime-types@^3.0.2:
+mime-types@^3.0.0, mime-types@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz"
   integrity sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==
@@ -5228,7 +5637,7 @@ next-themes@^0.4.6:
   resolved "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz"
   integrity sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==
 
-next@^15.5.12, next@>=13.2.0, next@>=15.0.0:
+next@^15.5.12:
   version "15.5.19"
   resolved "https://registry.npmjs.org/next/-/next-15.5.19.tgz"
   integrity sha512-xNOW6tYshGX1/Oi3F8uuk4gpDeWsSUE/1Z0G5uUMekIxaQ0xc03UXd9II0VQHYMWviMeA0OHpJFAKsHf8bTYVg==
@@ -5541,7 +5950,7 @@ picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz"
   integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
-"picomatch@^3 || ^4", picomatch@^4.0.2:
+picomatch@^4.0.2:
   version "4.0.4"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
@@ -5588,15 +5997,6 @@ postcss-value-parser@^4.2.0:
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.1.0, postcss@^8.5.6:
-  version "8.5.12"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz"
-  integrity sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==
-  dependencies:
-    nanoid "^3.3.11"
-    picocolors "^1.1.1"
-    source-map-js "^1.2.1"
-
 postcss@8.4.31:
   version "8.4.31"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz"
@@ -5605,6 +6005,15 @@ postcss@8.4.31:
     nanoid "^3.3.6"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
+
+postcss@^8.5.6:
+  version "8.5.12"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz"
+  integrity sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==
+  dependencies:
+    nanoid "^3.3.11"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
 
 powershell-utils@^0.1.0:
   version "0.1.0"
@@ -5623,7 +6032,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^3.6.2, prettier@>=3.0.0:
+prettier@^3.6.2:
   version "3.6.2"
   resolved "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz"
   integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==
@@ -5739,7 +6148,7 @@ prosemirror-menu@^1.2.4:
     prosemirror-history "^1.0.0"
     prosemirror-state "^1.0.0"
 
-prosemirror-model@^1.0.0, prosemirror-model@^1.20.0, prosemirror-model@^1.21.0, prosemirror-model@^1.22.1, prosemirror-model@^1.24.1, prosemirror-model@^1.25.0, prosemirror-model@^1.25.4:
+prosemirror-model@^1.0.0, prosemirror-model@^1.20.0, prosemirror-model@^1.21.0, prosemirror-model@^1.24.1, prosemirror-model@^1.25.0, prosemirror-model@^1.25.4:
   version "1.25.4"
   resolved "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz"
   integrity sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==
@@ -5762,7 +6171,7 @@ prosemirror-schema-list@^1.5.0:
     prosemirror-state "^1.0.0"
     prosemirror-transform "^1.7.3"
 
-prosemirror-state@^1.0.0, prosemirror-state@^1.2.2, prosemirror-state@^1.4.2, prosemirror-state@^1.4.3, prosemirror-state@^1.4.4:
+prosemirror-state@^1.0.0, prosemirror-state@^1.2.2, prosemirror-state@^1.4.3, prosemirror-state@^1.4.4:
   version "1.4.4"
   resolved "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz"
   integrity sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==
@@ -5797,7 +6206,7 @@ prosemirror-transform@^1.0.0, prosemirror-transform@^1.1.0, prosemirror-transfor
   dependencies:
     prosemirror-model "^1.21.0"
 
-prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.27.0, prosemirror-view@^1.31.0, prosemirror-view@^1.33.8, prosemirror-view@^1.38.1, prosemirror-view@^1.41.4:
+prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.27.0, prosemirror-view@^1.31.0, prosemirror-view@^1.38.1, prosemirror-view@^1.41.4:
   version "1.41.6"
   resolved "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.6.tgz"
   integrity sha512-mxpcDG4hNQa/CPtzxjdlir5bJFDlm0/x5nGBbStB2BWX+XOQ9M8ekEG+ojqB5BcVu2Rc80/jssCMZzSstJuSYg==
@@ -5950,14 +6359,14 @@ react-day-picker@^9:
     date-fns "^4.1.0"
     date-fns-jalali "4.1.0-0"
 
-"react-dom@^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom@^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^18.0.0 || ^19.0.0", "react-dom@^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react-dom@>=16.8, react-dom@>=16.8.0, react-dom@>=17, react-dom@>=18, react-dom@19.1.0:
+react-dom@19.1.0:
   version "19.1.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz"
   integrity sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==
   dependencies:
     scheduler "^0.26.0"
 
-react-hook-form@^7.55.0, react-hook-form@^7.71.2:
+react-hook-form@^7.71.2:
   version "7.71.2"
   resolved "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.2.tgz"
   integrity sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==
@@ -5994,7 +6403,7 @@ react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
     get-nonce "^1.0.0"
     tslib "^2.0.0"
 
-"react@^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react@^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc", "react@^16.8.0 || ^17 || ^18 || ^19", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^17.0.0 || ^18.0.0 || ^19.0.0", "react@^18 || ^19", "react@^18.0.0 || ^19.0.0", "react@^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", react@^19.1.0, "react@>= 16.8.0", "react@>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0", react@>=16.8, react@>=16.8.0, react@>=17, react@>=17.0.0, react@>=18, react@>=18.0.0, react@19.1.0:
+react@19.1.0:
   version "19.1.0"
   resolved "https://registry.npmjs.org/react/-/react-19.1.0.tgz"
   integrity sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==
@@ -6175,7 +6584,7 @@ safe-regex-test@^1.0.3, safe-regex-test@^1.1.0:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass@^1.3.0, sass@^1.91.0:
+sass@^1.91.0:
   version "1.92.1"
   resolved "https://registry.npmjs.org/sass/-/sass-1.92.1.tgz"
   integrity sha512-ffmsdbwqb3XeyR8jJR6KelIXARM9bFQe8A6Q3W4Klmwy5Ckd5gz7jgUNHo4UOqutU5Sk1DtKLbpDP0nLCg1xqQ==
@@ -6443,7 +6852,7 @@ sonner@^2.0.7:
   resolved "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz"
   integrity sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==
 
-source-map-js@^1.0.2, source-map-js@^1.2.1, "source-map-js@>=0.6.2 <2.0.0":
+"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -6495,16 +6904,7 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^7.0.0:
-  version "7.2.0"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz"
-  integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
-  dependencies:
-    emoji-regex "^10.3.0"
-    get-east-asian-width "^1.0.0"
-    strip-ansi "^7.1.0"
-
-string-width@^7.2.0:
+string-width@^7.0.0, string-width@^7.2.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz"
   integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
@@ -6668,7 +7068,7 @@ tailwind-merge@^3.0.1, tailwind-merge@^3.5.0:
   resolved "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz"
   integrity sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==
 
-tailwindcss@^4.2.1, tailwindcss@4.2.1:
+tailwindcss@4.2.1, tailwindcss@^4.2.1:
   version "4.2.1"
   resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz"
   integrity sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==
@@ -6759,7 +7159,7 @@ tsconfig-paths@^4.2.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.8.0, tslib@2.8.1:
+tslib@2.8.1, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.8.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -6842,9 +7242,9 @@ typed-emitter@^2.1.0:
   resolved "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz"
   integrity sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==
   optionalDependencies:
-    rxjs "*"
+    rxjs "^7.5.2"
 
-typescript@^5, "typescript@>= 4.8.x", typescript@>=3.3.1, typescript@>=4.8.4, "typescript@>=4.8.4 <6.0.0", typescript@>=4.9.5:
+typescript@^5:
   version "5.9.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz"
   integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
@@ -6946,7 +7346,7 @@ use-sidecar@^1.1.3:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
 
-use-sync-external-store@^1.2.2, use-sync-external-store@^1.4.0, use-sync-external-store@^1.5.0, use-sync-external-store@>=1.2.0:
+use-sync-external-store@^1.2.2, use-sync-external-store@^1.4.0, use-sync-external-store@^1.5.0:
   version "1.6.0"
   resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz"
   integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
@@ -7179,7 +7579,7 @@ zod@^3.24.1:
   resolved "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
 
-"zod@^3.25 || ^4", "zod@^3.25 || ^4.0", zod@^4.3.6:
+"zod@^3.25 || ^4.0", zod@^4.3.6:
   version "4.3.6"
   resolved "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz"
   integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==


### PR DESCRIPTION
* docs: add agent workflows/pathways implementation plan

Vapi-style node-based conversation builder: standalone org-level workflows with drafts/publish, per-agent assignment via AgentConfig.mode+workflow_id, React-Flow-native canonical graph (Vapi fields in node.data), layered prompts, and a call-time WorkflowEngine runtime.



* Agent config versioning changes (#503) (#504)

* Added changes in UI

* Added changes for agent config versioning

* Added UI changes

* Added changes for versioning in agents



* Trigger Deployment (#505)

* Agent config versioning changes (#503)

* Added changes in UI

* Added changes for agent config versioning

* Added UI changes

* Added changes for versioning in agents

* Update ui.md

Trigger deployment

---------



* feat(workflows): node-based visual workflow builder (Bland/Vapi-style)

Standalone org-level workflows with drafts/publish, assignable to agents via AgentConfig.mode + workflow_id. Canonical React-Flow-native graph (Vapi fields in node.data) with AI/Logic condition edges and a decision node.

Backend:
- models Workflow/WorkflowVersion + agent_configs.mode/workflow_id + enums
- alembic migration d4f7a1c9e2b8 (additive; defaults keep prompt-mode unchanged)
- core/services/workflow: schema (+validate_graph), service (CRUD/draft/publish/ validate/versions/delete/import_vapi/export_vapi), vapi_adapter
- /workflow API router registered (core + EE); assignment via existing agent path
- pure call-time engine core (graph/context/conditions/engine) — unit-tested; Pipecat runner wiring is a documented seam (prompt-mode unaffected)

Frontend:
- standalone Workflows page + full React Flow canvas editor (palette, per-type nodes, condition edges, config drawer, toolbar, validation), routes, sidebar nav
- data layer (types/service/atoms/utils + Vapi import) and modern design system
- @xyflow/react added; yarn build passes; new code type- and lint-clean



* docs: move workflow implementation-status into root plan doc



* feat(workflows): polish Workflows UI — empty state, node drawer, remove minimap

- Premium empty state (WorkflowEmptyState) with pathway illustration + value hints
- List page: graceful error state with retry (no scary toast on first load), keyboard-accessible cards, status/agents/issues badges
- Redesign node/edge settings drawer to use shared components (TextInput, TextAreaField, CheckboxField, SelectInput, SearchableSelect) with a clean card-grouped layout; Tool node now picks from a SearchableSelect of tools
- Remove the canvas MiniMap

yarn build passes; new code type- and lint-clean.



* fix(workflows): remove red destructive ring around nodes with issues

Keep the small error-count badge (with tooltip) for discoverability; the heavy red border was visually noisy. Issues remain surfaced via the badge + toolbar validation popover.



* fix(workflows): draggable nodes + node UI polish + centered empty state

- Nodes are now draggable: single-click selects (drag freely), double-click opens the settings drawer — so the modal drawer never blocks the canvas. Add canvas hint "Drag to move · double-click to edit · drag a handle to connect".
- Keep CustomDrawer for node/edge settings (per request).
- Refine node card: rounded-2xl, cleaner selected state (no detached offset ring), larger clearer connection handles, grab cursor, softer amber issue badge.
- Empty/error views centered in a comfortable max-w-3xl column (generous left/right whitespace on wide screens); populated grid stays wide.

yarn build passes (clean run); type- and lint-clean.



* fix(workflows): return 409 on duplicate workflow name instead of 500

Creating a workflow whose name already exists in the org hit the uq_workflows_org_name unique constraint and surfaced a raw 500. Add a friendly pre-check + an IntegrityError backstop (covers races and soft-deleted names) that raises a 409 with a clear message; the create modal shows it via handleApiError and stays open for a rename.



* feat(workflows): polish the workflow editor chrome (toolbar, palette, canvas)

- Toolbar: cleaner layout — back + divider + title with status pill + saved-state line; validation as a rounded chip popover; a "More" menu (CustomPopover) that absorbs Global prompt + Export Vapi, removing the floating buttons that overlapped the zoom controls.
- Canvas: drop the cramped bottom-left utility bar; move the interaction hint to a subtle bottom-center pill so it no longer clashes with the toolbar.
- Add-node panel: refined header with search icon + helper, card-style draggable items with hover lift and a drag grip affordance.
- Global prompt now uses the shared TextAreaField.

yarn build passes (clean run); type- and lint-clean.



* refactor(ui): use CustomButton for all feature-code buttons (cursor + consistency)

Replace native <button> with the shared CustomButton across feature components so every clickable button shows a pointer cursor and follows the project convention (CLAUDE.md). Covers the workflow editor (toolbar, palette items, node-config remove) plus organizations, service-providers, mcp, tools, integrations, knowledge-base. The shared/ and ui/ library layer keep native buttons by design (Radix Select/combobox triggers, search-clear, theme toggle, etc.).

yarn build passes (clean run); type-clean; lint-clean (only pre-existing warnings).



* fix(workflows): sensible default canvas view (100% zoom, top-centered)

Replace the blanket fitView (which over-zoomed a single small node to fill the screen) with an onInit that centers content horizontally at 100% zoom pinned near the top — falling back to a maxZoom:1 fitView only when the graph is too large to fit at 1x. minZoom lowered to 0.2.

yarn build passes; type- and lint-clean.



* feat(workflows): editable condition edges + richer nodes (Vapi-style)

Edges (logic/AI conditions for decision & conversation branching):
- Clickable condition pill on each edge — single-click an edge to set its condition; shows AI (sparkles) vs Logic (braces, mono) clearly.
- Empty edges show a dashed "+ Add condition" affordance.
- Selected edge shows an inline × to delete the connection.
- Wired via EdgeActionsContext (edit/delete) from the builder.

Nodes:
- Conversation nodes now show extracted-variable chips ({{var}}) and lead with the first message, matching the reference.

All on CustomButton; yarn build passes; type- and lint-clean.



* fix(ui): pointer cursor on the drawer (Sheet) close button

The Sheet close (×) button was missing cursor-pointer (the Dialog one already had it). Affects every CustomDrawer, including the workflow Node settings panel.



* fix(workflows): no outer border highlight on selected node

Selecting a node showed a heavy indigo border + ring. Drop the colored border/ring on select (keep a subtle shadow only) and suppress React Flow's default node selection outline. Editing still opens via double-click.



* fix(workflows): make creating connections reliable

Connections were hard to create because the handles were small/precise. Enlarge handles, add connectionRadius=48 so a drop near a handle snaps to it, and block only self-connections via isValidConnection. New edges start with an empty condition ("+ Add condition") and can be left blank (= always follow).

yarn build passes; lint-clean.



* feat(workflows): hover delete button on nodes

Hovering a node now reveals a trash button at its top-right corner to delete the node (and its connected edges) directly — no need to open the settings drawer. Wired via NodeActionsContext; the button is nodrag so it doesn't start a drag, and handles moved to a non-clipped wrapper so they render fully.

yarn build passes; type- and lint-clean.



* chore(sidebar): keep commented Workflows nav reference alongside active entry



* feat(workflow): workflow-under-agent-details updates + raise FD limit on startup

Workflow builder/engine, schema, conditions, graph and frontend node/config updates for the Workflows-under-agent-details feature, plus a new prompt_serializer and example workflows.

Also raise the process RLIMIT_NOFILE at startup (main.py): a live call holds many concurrent FDs and the macOS default soft limit (256) was exhausted mid-call, causing STT reconnects to fail with getaddrinfo "[Errno 8]".



* revert(main): drop startup RLIMIT_NOFILE raise

The open-file-limit raise did not resolve the mid-call STT getaddrinfo "[Errno 8]" errors (the soft limit was already high and the failures persisted), so remove it. main.py now matches origin/dev.



* feat(workflow): workflow-under-agent-details review fixes

- Align UI copy with backend v4 behavior: workflow mode drives the call from the workflow playbook alone (agent system prompt is dropped)
- PromptStep: correct the assigned-workflow note
- WorkflowBuilder: drop the inaccurate "Agent persona" layer in the global-prompt explainer
- sidebar: remove leftover commented-out Workflows nav entry



* fix(workflow): org-scope workflow lookup in call resolution

_load_workflow_prompt read the assigned workflow + version by id without an organization filter. Scope both queries to the agent's org so a workflow from another org can never drive a call, matching the org scoping already enforced on every list/get/assignment path via BaseService.query.



* feat(workflow): surface unpublished-changes state in the builder

A published workflow's draft is edited independently of the live snapshot; "Save draft" updates the draft only and never changes what assigned agents run until the user re-publishes. The toolbar gave no signal that saved edits weren't live.

- detail() now returns has_unpublished_changes (draft checksum != published)
- Toolbar shows an "Unpublished changes" badge and a "Saved · not published yet" status when the draft is ahead of the live version
- Publish button reads "Publish changes" when there's something to publish, and is disabled (with tooltip) when the live version is already up to date, avoiding duplicate identical snapshots



* chore(workflow): drop explanatory comments from recent changes



* fix(workflow): address review feedback on workflow-under-agent changes

- Replace the in-place edit of the already-applied add_workflows migration with a new migration (b7c3f1a9d2e4) that swaps the plain org+name UNIQUE constraint for a partial unique index scoped to live (non-deleted) rows.
- Remove the now-unused workflowEditorStatusAtom; saving/dirty stay as local state in WorkflowBuilder and per-node badges read workflowIssuesAtom.



* fix(migrations): re-point workflow partial-unique migration onto dev head

After merging origin/dev, the workflow partial-unique-index migration (b7c3f1a9d2e4) and dev's app-integrations head (a4c8e1f7b2d6) were two separate alembic heads. Re-point b7c3f1a9d2e4.down_revision to a4c8e1f7b2d6 so the history is linear and `alembic upgrade head` applies cleanly on the current DB revision.



* fix(workflow): preserve API Request secrets on re-save; harden SSRF guard

- _encrypt_graph_secrets: treat a row as already-ciphertext only when it has a value, so masked rows (empty value, _encrypted=true) fall through to the previous-secret carry-over instead of wiping stored ciphertext on re-save.
- _assert_safe_url: also normalize integer/octal/hex-encoded IPv4 literals via socket.inet_aton so forms like https://2130706433/ are caught by the private/loopback check.
- Strip explanatory inline comments from the uncommitted workflow API Request changes (kept docstrings/JSDoc and the noqa directive).



---------