### PR TITLE
fix(call-history): derive Call Configurations tab from immutable call…

### DIFF
--- a/core/services/pipeline/runner/pipecat.py
+++ b/core/services/pipeline/runner/pipecat.py
@@ -101,11 +101,30 @@ class PipecatPipelineRunner(PipelineRunner):
                     return None
                 md = spec.get("metadata") or {}
                 model_id = md.get("model_id")
-                return {
+                # `provider_name` stays the slug — call filters/grouping key off it
+                # via JSONB paths (see CallService.get_filter_values). The friendly
+                # name goes in a separate `provider_display_name` field for the UI.
+                snap = {
                     "provider_name": spec.get("provider_name"),
+                    "provider_display_name": spec.get("provider_display_name"),
                     "model_name": spec.get("model_name"),
                     "model_id": str(model_id) if model_id is not None else None,
                 }
+                # The TTS spec carries the resolved voice + language on its metadata
+                # (see service_resolver._build_service_specs). Store both the raw ids
+                # and their human-readable display values so the call-history snapshot
+                # is self-sufficient — the UI shows friendly names without reading the
+                # mutable live agent config, and never renders a raw voice-id or a
+                # bare language code.
+                if md.get("voice_id") is not None:
+                    snap["voice_id"] = md.get("voice_id")
+                if md.get("voice_name") is not None:
+                    snap["voice_name"] = md.get("voice_name")
+                if md.get("language") is not None:
+                    snap["language"] = md.get("language")
+                if md.get("language_display") is not None:
+                    snap["language_display"] = md.get("language_display")
+                return snap
 
             # `custom_tools` mirrors the resolver's tool cache filtered to non-MCP tools
             # (mcp_server_id IS NULL) to match the original snapshot semantics. MCP servers

--- a/core/services/pipeline/service_resolver.py
+++ b/core/services/pipeline/service_resolver.py
@@ -124,6 +124,9 @@ def _make_service_spec(provider, model_name, api_key, metadata) -> Optional[dict
         return None
     return {
         "provider_name": (provider.slug or "").strip().lower(),
+        # Human-readable provider name for the call-history snapshot. `provider_name`
+        # stays the slug (the factory keys off it); this is display-only.
+        "provider_display_name": provider.display_name or provider.slug,
         "api_key": api_key,
         "model_name": model_name,
         "metadata": metadata,
@@ -272,11 +275,18 @@ def _build_service_specs(
     )
     tts_metadata = _build_metadata(voice_settings, tts_mid)
     tts_metadata["voice_id"] = resolved_voice
+    # Human-readable voice name for the call-history snapshot (falls back to the
+    # resolved id). Filtered out of the factory's InputParams by build_input_params.
+    tts_metadata["voice_name"] = (voice_row.name if voice_row else None) or resolved_voice
     # The factory reads metadata["language"]; prefer the language *code* (e.g. "en")
     # over the display name (e.g. "English"), which Pipecat's Language enum rejects.
     tts_language = voice_settings.get("language_code") or voice_settings.get("language")
     if tts_language:
         tts_metadata["language"] = tts_language
+    # Display name (e.g. "English") for the snapshot — the factory never reads this.
+    tts_language_display = voice_settings.get("language") or tts_language
+    if tts_language_display:
+        tts_metadata["language_display"] = tts_language_display
     tts_spec = _make_service_spec(
         provider_by_id.get(tts_pid),
         _mname(tts_mid),

--- a/frontend/src/components/call-history/sections/CallConfigurationsSection.tsx
+++ b/frontend/src/components/call-history/sections/CallConfigurationsSection.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { AppLoader } from '@/components/shared';
 import type { CallLogRow } from '@/types/callLog';
 import { BrainCircuit, Mic, Volume2 } from 'lucide-react';
 import React from 'react';
@@ -55,27 +54,19 @@ const PipelineCard: React.FC<PipelineCardProps> = ({ icon: Icon, title, rows }) 
 // ─── section ──────────────────────────────────────────────────────────────────
 
 const CallConfigurationsSection: React.FC<CallConfigurationsSectionProps> = ({ callLog }) => {
-  const { data: pipeline, loading: pipelineLoading } = useCallConfiguration({
-    agentId: callLog.agent_id,
+  // Derived synchronously from the call's immutable pipeline snapshot — no
+  // fetch, so there's no loading state to hold the tab on.
+  const { data: pipeline } = useCallConfiguration({
+    pipelineConfig: callLog.pipeline_config,
     metrics: callLog.metrics,
   });
-
-  // Hold the entire tab on the project's shared loader until the pipeline is
-  // ready, so the page doesn't paint a partial state and then shift.
-  // `min-h-0` overrides AppLoader's default `min-h-screen` (via tailwind-merge),
-  // letting it size to its parent so it centers within the tab body — not at
-  // 50vh, which would sit below the visible area now that the sticky summary
-  // card consumes space above.
-  if (pipelineLoading && !pipeline) {
-    return <AppLoader className="min-h-0 h-full" />;
-  }
 
   return (
     <div className="flex flex-col">
       <h3 className="mb-1 text-sm font-medium text-foreground">Pipeline</h3>
       <p className="mb-3 text-xs text-muted-foreground">
-        Reflects the agent&apos;s current configuration. Model names come from this call&apos;s
-        metrics when available.
+        Reflects the configuration used for this call. Model names come from this call&apos;s
+        configuration, falling back to its metrics.
       </p>
 
       {!pipeline ? (

--- a/frontend/src/components/call-history/sections/useCallConfiguration.ts
+++ b/frontend/src/components/call-history/sections/useCallConfiguration.ts
@@ -1,13 +1,7 @@
 'use client';
 
-import { getAgent } from '@/services/agentsService';
-import { listProviderCatalog } from '@/services/servicesService';
-import { listTtsVoices } from '@/services/ttsService';
-import type { AgentDetail } from '@/types/agent';
-import type { CallMetrics } from '@/types/callLog';
-import type { ProviderCatalogItem } from '@/types/service';
-import { handleApiError } from '@/utils/helpers';
-import { useEffect, useMemo, useState } from 'react';
+import type { CallMetrics, PipelineConfigSnapshot, PipelineSpecSnapshot } from '@/types/callLog';
+import { useMemo } from 'react';
 
 // One row in a pipeline card (LLM / STT / TTS).
 export interface PipelineStage {
@@ -24,34 +18,13 @@ export interface CallConfigurationPipeline {
 }
 
 interface UseCallConfigurationArgs {
-  agentId: string | null | undefined;
+  pipelineConfig: PipelineConfigSnapshot | null | undefined;
   metrics: CallMetrics | null | undefined;
 }
 
 interface UseCallConfigurationResult {
   data: CallConfigurationPipeline | null;
   loading: boolean;
-}
-
-interface FetchedSources {
-  agent: AgentDetail;
-  catalog: ProviderCatalogItem[];
-  voiceName: string | null;
-}
-
-// ─── session-scoped provider catalog cache ───────────────────────────────────
-// The catalog rarely changes during a session, but the Pipeline tab can be
-// opened many times across calls. A single in-flight promise dedupes
-// concurrent loads and caches the result for the rest of the session.
-let providerCatalogPromise: Promise<ProviderCatalogItem[]> | null = null;
-function getProviderCatalog(): Promise<ProviderCatalogItem[]> {
-  if (!providerCatalogPromise) {
-    providerCatalogPromise = listProviderCatalog().catch((err) => {
-      providerCatalogPromise = null; // allow retry on next mount
-      throw err;
-    });
-  }
-  return providerCatalogPromise;
 }
 
 // ─── pure helpers (no I/O, no React) ─────────────────────────────────────────
@@ -75,126 +48,63 @@ function firstModel<T extends { model: string | null }>(
   return rows.find((r) => r.model)?.model ?? null;
 }
 
-/** Map a provider id → display name, falling back to the id itself. */
-function providerName(
-  catalog: ProviderCatalogItem[],
-  providerId: string | null | undefined,
-): string | null {
-  if (!providerId) return null;
-  return catalog.find((p) => p.id === providerId)?.display_name ?? providerId;
+/**
+ * Resolve one pipeline stage from its call-time snapshot. Provider prefers the
+ * resolved display name, falling back to the raw slug for older snapshots. Model
+ * prefers the snapshot's resolved name, then the call's metrics, then a non-UUID
+ * model id.
+ */
+function stageFrom(
+  spec: PipelineSpecSnapshot | null | undefined,
+  metricsModel: string | null,
+): PipelineStage {
+  return {
+    provider: displayable(spec?.provider_display_name) ?? displayable(spec?.provider_name),
+    model: displayable(spec?.model_name) ?? metricsModel ?? displayable(spec?.model_id),
+  };
 }
 
 /**
- * Pure resolver. Joins fetched agent + catalog with the call's runtime
- * metrics to produce a render-ready pipeline. Kept separate from the
- * data-fetching hook so it stays trivially testable.
+ * Pure resolver. Turns the call's immutable pipeline snapshot (plus its runtime
+ * metrics, used only as a model-name fallback) into a render-ready pipeline.
+ * Kept separate from the hook so it stays trivially testable.
  */
-function resolvePipeline(
-  sources: FetchedSources,
+export function resolvePipeline(
+  snapshot: PipelineConfigSnapshot,
   metrics: CallMetrics | null | undefined,
 ): CallConfigurationPipeline {
-  const cfg = sources.agent.config ?? {};
-  const llm = (cfg.llm_settings ?? {}) as Record<string, unknown>;
-  const stt = (cfg.stt_settings ?? {}) as Record<string, unknown>;
-  const voice = cfg.voice_settings ?? {};
-
-  // Metrics carry the actual model name used during the call; prefer it over
-  // the stored id which would otherwise show as a bare UUID. If neither is
-  // human-readable, fall back to null so the UI renders an em-dash.
-  const llmModel = firstModel(metrics?.llm_usage) ?? displayable(llm.model_id as string | null);
-  const ttsModel = firstModel(metrics?.tts_usage) ?? displayable(voice.model_id as string | null);
-  const sttModel = firstModel(metrics?.stt_usage) ?? displayable(stt.model as string | null);
-
   return {
-    llm: {
-      provider: providerName(sources.catalog, llm.provider_id as string | null),
-      model: llmModel,
-    },
-    stt: {
-      provider: providerName(sources.catalog, stt.provider_id as string | null),
-      model: sttModel,
-    },
-    tts: {
-      provider: providerName(sources.catalog, voice.provider_id),
-      model: ttsModel,
-    },
-    language: voice.language ?? null,
-    voice: sources.voiceName ?? displayable(voice.voice_id),
+    llm: stageFrom(snapshot.llm, firstModel(metrics?.llm_usage)),
+    stt: stageFrom(snapshot.stt, firstModel(metrics?.stt_usage)),
+    tts: stageFrom(snapshot.tts, firstModel(metrics?.tts_usage)),
+    // Voice + language live on the TTS spec. Prefer the display forms captured at
+    // call time (friendly voice name, display language), falling back to the raw
+    // id / code for older snapshots, then null (renders an em-dash) — never the
+    // live agent config.
+    language: snapshot.tts?.language_display ?? snapshot.tts?.language ?? null,
+    voice: displayable(snapshot.tts?.voice_name) ?? displayable(snapshot.tts?.voice_id),
   };
 }
 
 // ─── hook ────────────────────────────────────────────────────────────────────
 
 /**
- * Loads everything the Call Configurations tab needs:
- *   1. Agent detail — for the configured providers, models, voice, language
- *   2. Provider catalog — to resolve provider ids → display names
- *   3. TTS voices (conditional) — to resolve the configured voice id → name
+ * Derives the Call Configurations tab from the call's immutable
+ * `pipeline_config` snapshot — the config that was actually used for THIS call.
+ * No network I/O: everything needed was captured at call time, so editing the
+ * agent afterwards can never rewrite a past call's displayed configuration.
  *
- * Fetches 1 + 2 in parallel; voice list runs only when provider + language
- * are present (avoids a redundant request on legacy/incomplete configs).
- *
- * Re-fetching keys off `agentId` only — metrics flow through the pure
- * `resolvePipeline` derive step, so a new metrics reference re-derives but
- * never re-hits the network.
+ * Returns `data: null` when the call has no snapshot (very old calls), which the
+ * section renders as an "unavailable" empty state.
  */
 export function useCallConfiguration({
-  agentId,
+  pipelineConfig,
   metrics,
 }: UseCallConfigurationArgs): UseCallConfigurationResult {
-  const [sources, setSources] = useState<FetchedSources | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    if (!agentId) {
-      setSources(null);
-      setLoading(false);
-      return;
-    }
-
-    let cancelled = false;
-    setLoading(true);
-
-    (async () => {
-      try {
-        const [agent, catalog] = await Promise.all([getAgent(agentId), getProviderCatalog()]);
-        if (cancelled) return;
-
-        const voice = agent.config?.voice_settings ?? {};
-        let voiceName: string | null = null;
-        if (voice.provider_id && voice.language && voice.voice_id) {
-          try {
-            const voices = await listTtsVoices(
-              voice.provider_id,
-              voice.language,
-              (voice.model_id as string | null | undefined) ?? null,
-            );
-            if (!cancelled) {
-              voiceName = voices.find((v) => v.id === voice.voice_id)?.name ?? null;
-            }
-          } catch {
-            // Non-fatal — fall back to showing the voice id in the resolver.
-          }
-        }
-        if (cancelled) return;
-
-        setSources({ agent, catalog, voiceName });
-      } catch (err) {
-        if (!cancelled) handleApiError(err);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [agentId]);
-
   const data = useMemo<CallConfigurationPipeline | null>(
-    () => (sources ? resolvePipeline(sources, metrics) : null),
-    [sources, metrics],
+    () => (pipelineConfig ? resolvePipeline(pipelineConfig, metrics) : null),
+    [pipelineConfig, metrics],
   );
 
-  return { data, loading };
+  return { data, loading: false };
 }

--- a/frontend/src/types/callLog.ts
+++ b/frontend/src/types/callLog.ts
@@ -103,6 +103,41 @@ export interface ServedBy {
   environment?: string;
 }
 
+/**
+ * One service (LLM / STT / TTS) inside the call's pipeline snapshot. Each field
+ * that has a raw id and a human-readable form carries both: `provider_name` is
+ * the provider slug (call filters key off it) with `provider_display_name` for
+ * the UI; the TTS spec adds `voice_id` + `voice_name` and `language` (code) +
+ * `language_display`. The display fields are present only for calls placed after
+ * the snapshot started capturing them, so the UI falls back to the raw value.
+ */
+export interface PipelineSpecSnapshot {
+  provider_name: string | null;
+  provider_display_name?: string | null;
+  model_name: string | null;
+  model_id: string | null;
+  voice_id?: string | null;
+  voice_name?: string | null;
+  language?: string | null;
+  language_display?: string | null;
+}
+
+/**
+ * Immutable snapshot of the pipeline used for a single call, captured at call
+ * start and stored on the call row. This — NOT the live agent config — is the
+ * source of truth for the Call Configurations tab, so editing the agent later
+ * never rewrites what a past call shows.
+ */
+export interface PipelineConfigSnapshot {
+  llm: PipelineSpecSnapshot | null;
+  stt: PipelineSpecSnapshot | null;
+  tts: PipelineSpecSnapshot | null;
+  is_s2s?: boolean;
+  custom_tools?: Array<{ id: string | null; name: string | null }>;
+  mcp_servers?: unknown[];
+  knowledge_bases?: unknown[];
+}
+
 export interface CallLogRow {
   id: string;
   agent_id: string;
@@ -136,6 +171,13 @@ export interface CallLogRow {
    * the full payload without a second round-trip.
    */
   metrics: (CallMetrics & { id: string }) | null;
+  /**
+   * Immutable snapshot of the pipeline used for THIS call (provider/model, plus
+   * voice/language on newer calls), captured at call start. Null for very old
+   * calls persisted before snapshots existed. Drives the Configurations tab so
+   * it reflects what the call actually used — not the agent's current config.
+   */
+  pipeline_config: PipelineConfigSnapshot | null;
 }
 
 export type ToolExecutionStatus = 'success' | 'error';


### PR DESCRIPTION
… snapshot

Read the call's pipeline_config snapshot instead of re-fetching live agent config, and capture provider/voice/language display names at call time so a past call's displayed configuration never changes when the agent is edited.