### PR TITLE
fix(stt-deploy): raise nemotron rollout progressDeadlineSeconds (fixes failed deploy)

### DIFF
--- a/build/kubernetes/stt/nemotron/deployment.yaml
+++ b/build/kubernetes/stt/nemotron/deployment.yaml
@@ -10,6 +10,12 @@ metadata:
     app: staging-stt-nemotron
 spec:
   replicas: 1
+  # Startup is slow: the container pip-installs deps then downloads/loads the
+  # NeMo model (the startupProbe allows up to 25 min). The default rollout
+  # progress deadline is only 600s (10 min), so a healthy-but-slow start was
+  # marked "exceeded its progress deadline" and failed the deploy. Give the
+  # rollout longer than the startupProbe budget so a normal cold start passes.
+  progressDeadlineSeconds: 1800
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
## Summary
Fixes the failed **Staging Model Services Deploy** run (nemotron job): `error: deployment "staging-stt-nemotron-deployment" exceeded its progress deadline` at exactly 10 min.

**Root cause:** the nemotron container pip-installs deps + downloads/loads the NeMo model on startup (the `startupProbe` budgets up to 25 min), but the deployment's rollout `progressDeadlineSeconds` was the default **600s (10 min)**. A healthy-but-slow cold start tripped the deadline and failed the deploy — even though ConfigMap + manifest apply + rollout restart all succeeded.

**Fix:** `build/kubernetes/stt/nemotron/deployment.yaml` → `progressDeadlineSeconds: 1800` (30 min, > the 25-min startupProbe budget).

## After merge → staging
Re-run **Staging Model Services Deploy** (`model=nemotron`). The rollout will now wait for the slow model load instead of failing at 10 min. If it still fails after ~25–30 min, the new pod is genuinely stuck (no GPU / crash) — needs `kubectl describe/logs`, not a manifest change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)