### PR TITLE
Feature/staging/cerebras model provider (#714)

### DIFF
--- a/core/services/custom_tool_service.py
+++ b/core/services/custom_tool_service.py
@@ -13,10 +13,14 @@ from pipecat.adapters.schemas.function_schema import FunctionSchema
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.services.llm_service import FunctionCallParams
 
+from core.config import settings
 from core.models.tool import Tool
 from core.models.agent_tool import AgentTool
 from core.utils.logging import truncate_for_log
 from core.utils.oauth_resolution import effective_of, stamp_effective
+
+# Placeholder caller number used by test/preview calls; Twilio rejects it.
+_PLACEHOLDER_CALLER_NUMBER = "+10000000000"
 
 
 def _resolve_connection_header(tool: Tool) -> Optional[Tuple[str, str]]:
@@ -379,10 +383,18 @@ def _create_send_sms_handler(tool: Tool, caller_number: str, tool_call_entries: 
 
         arguments = params.arguments
         message = arguments.get("message", "")
-        logger.info("Built-in tool 'send_sms' called. Sending SMS to {}", caller_number)
+        logger.info("Built-in tool 'send_sms' called (caller_number={})", caller_number)
         _t_start = _time.monotonic()
         meta = tool.meta_data or {}
-        recipient = meta.get("to_number") or caller_number
+        recipient = (meta.get("to_number") or caller_number or "").strip()
+        if recipient in ("", _PLACEHOLDER_CALLER_NUMBER):
+            default_to = (settings.SEND_SMS_DEFAULT_TO_NUMBER or "").strip()
+            if default_to:
+                logger.info(
+                    "send_sms: recipient '{}' is empty/placeholder — using SEND_SMS_DEFAULT_TO_NUMBER '{}'",
+                    recipient or "(empty)", default_to,
+                )
+                recipient = default_to
         tool_call_entry = {
             "tool": "send_sms",
             "tool_type": "send_sms",

--- a/shared/config.py
+++ b/shared/config.py
@@ -107,4 +107,6 @@ class Settings:
         self.WEBRTC_CLIENT_BASE_URL: str = get_secret("WEBRTC_CLIENT_BASE_URL", "")
         self.CALL_WORKER_INTERNAL_URL: str = get_secret("CALL_WORKER_INTERNAL_URL", "")
 
+        self.SEND_SMS_DEFAULT_TO_NUMBER: str = get_secret("SEND_SMS_DEFAULT_TO_NUMBER", "")
+
 settings = Settings()


### PR DESCRIPTION
* fix(stt-deploy): raise nemotron rollout progressDeadlineSeconds to 1800s

The Staging Model Services Deploy run failed on the nemotron job with "exceeded its progress deadline" at exactly 10 min, even though ConfigMap + manifest apply + rollout restart all succeeded. The container pip-installs deps then downloads/loads the NeMo model on startup — the startupProbe already budgets up to 25 min for this — but the deployment's rollout progress deadline was the default 600s (10 min). A healthy-but-slow cold start therefore tripped the deadline and failed the deploy. Set progressDeadlineSeconds=1800 so the rollout waits past the startupProbe budget.



* fix(metrics): discard silence-gap STT TTFB samples (phantom 60s p99)

STTLatencyTap measures STT TTFB as (next-transcript-time − user-stopped-time). When a caller stopped speaking and then went silent for a long time (thinking, end of call, or a late/spurious transcript arrived), that whole real-world SILENCE was recorded as "STT latency" — producing phantom 60s+ p99 spikes on the dashboard while the STT was actually ~300-800ms. The armed anchor survived the gap because nothing disarmed it.

- Discard samples above MAX_SANE_STT_TTFB_S (default 5s, env-tunable via STT_MAX_SANE_TTFB_S): a streaming STT final never legitimately takes seconds.
- Disarm the anchor on BotStartedSpeaking / End / Cancel frames — once the bot responds or the call ends, any still-armed stop is stale and must not be matched to a later transcript.

Result: STT p99 reflects real latency (~500-900ms) instead of silence gaps. No effect on real STT samples; fully reversible via env.



* feat(providers): add Cerebras LLM provider (gpt-oss-120b) to catalog seed

Add Cerebras as an OpenAI-compatible LLM provider in dev-data.json with the gpt-oss-120b model (131k context). Runtime support already exists in service_factory.py (base_url https://api.cerebras.ai/v1). Includes dev/seed_cerebras.py, an idempotent standalone upsert that seeds only the Cerebras provider + models without creating a user/org, safe to re-run against any already-populated environment.



* chore(stt): drop explanatory comment blocks from STT latency changes



* feat(send_sms): fall back to SEND_SMS_DEFAULT_TO_NUMBER for empty/placeholder recipients

Preview/test calls carry no real caller number, so send_sms had no recipient. Add a configurable SEND_SMS_DEFAULT_TO_NUMBER setting and use it when the resolved recipient is empty or the test placeholder.



---------