### PR TITLE
Staging => Staging-gcp

### DIFF
--- a/.github/workflows/staging-aws.yaml
+++ b/.github/workflows/staging-aws.yaml
@@ -1,0 +1,96 @@
+name: Staging AWS EKS CI/CD
+
+on:
+  push:
+    branches: ["staging-aws"]
+  workflow_dispatch:
+
+env:
+  AWS_REGION: us-east-1
+  EKS_CLUSTER: tone-staging
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            developer390/tone:staging-aws-latest
+            developer390/tone:${{ github.sha }}
+          cache-from: type=registry,ref=developer390/tone:staging-buildcache
+          cache-to: type=registry,ref=developer390/tone:staging-buildcache,mode=max
+          secrets: |
+            pip_extra_index=${{ secrets.PIP_EXTRA_INDEX_URL }}
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Update kubeconfig
+        run: aws eks update-kubeconfig --name ${{ env.EKS_CLUSTER }} --region ${{ env.AWS_REGION }}
+
+      - name: Create namespace
+        run: kubectl create namespace staging --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Create monitoring namespace
+        run: kubectl apply -f build/kubernetes/staging-aws/monitoring/namespace.yaml
+
+      - name: Create Grafana Cloud credentials secret
+        run: |
+          kubectl create secret generic grafana-cloud-credentials \
+            --namespace=monitoring \
+            --from-literal=loki-url="${{ secrets.GRAFANA_LOKI_URL }}" \
+            --from-literal=loki-user="${{ secrets.GRAFANA_LOKI_USER }}" \
+            --from-literal=prom-url="${{ secrets.GRAFANA_PROM_URL }}" \
+            --from-literal=prom-user="${{ secrets.GRAFANA_PROM_USER }}" \
+            --from-literal=api-key="${{ secrets.GRAFANA_CLOUD_API_KEY }}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Substitute IMAGE_TAG in deployment manifests
+        run: |
+          sed -i "s|\${IMAGE_TAG}|${{ github.sha }}|g" build/kubernetes/staging-aws/api/deployment.yaml
+          sed -i "s|\${IMAGE_TAG}|${{ github.sha }}|g" build/kubernetes/staging-aws/call/deployment.yaml
+          sed -i "s|\${IMAGE_TAG}|${{ github.sha }}|g" build/kubernetes/staging-aws/worker/deployment.yaml
+
+      - name: Apply manifests
+        run: |
+          kubectl apply -f build/kubernetes/staging-aws/api/service.yaml
+          kubectl apply -f build/kubernetes/staging-aws/api/deployment.yaml
+          kubectl apply -f build/kubernetes/staging-aws/api/ingress.yaml
+          kubectl apply -f build/kubernetes/staging-aws/call/pdb.yaml
+          kubectl apply -f build/kubernetes/staging-aws/call/service.yaml
+          kubectl apply -f build/kubernetes/staging-aws/call/deployment.yaml
+          kubectl apply -f build/kubernetes/staging-aws/call/pod-routing.yaml
+          kubectl apply -f build/kubernetes/staging-aws/call/ingress.yaml
+          kubectl apply -f build/kubernetes/staging-aws/worker/rbac.yaml
+          kubectl apply -f build/kubernetes/staging-aws/worker/deployment.yaml
+          kubectl apply -f build/kubernetes/staging-aws/monitoring/rbac.yaml
+          kubectl apply -f build/kubernetes/staging-aws/monitoring/configmap.yaml
+          kubectl apply -f build/kubernetes/staging-aws/monitoring/daemonset.yaml
+
+      - name: Rollout restart deployments
+        run: |
+          kubectl rollout restart deployment/staging-tone-api-deployment -n staging
+          kubectl rollout restart statefulset/staging-tone-call-worker -n staging
+          kubectl rollout restart deployment/staging-tone-worker -n staging
+
+      - name: Wait for rollouts
+        run: |
+          kubectl rollout status deployment/staging-tone-api-deployment -n staging --timeout=180s
+          kubectl rollout status statefulset/staging-tone-call-worker -n staging --timeout=180s
+          kubectl rollout status deployment/staging-tone-worker -n staging --timeout=180s

--- a/build/kubernetes/staging-aws/api/deployment.yaml
+++ b/build/kubernetes/staging-aws/api/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: staging-tone-api-deployment
+  namespace: staging
+  labels:
+    app: staging-tone-api
+    environment: staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: staging-tone-api
+  template:
+    metadata:
+      labels:
+        app: staging-tone-api
+        environment: staging
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: staging-tone-api
+          image: developer390/tone:${IMAGE_TAG}
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+          command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "512Mi"
+            limits:
+              cpu: "256m"
+              memory: "1Gi"
+          env:
+            - name: ENV
+              value: "staging"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DEPLOYMENT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.labels['app']"
+            - name: INFISICAL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-credentials
+                  key: token
+            - name: INFISICAL_PROJECT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-credentials
+                  key: project_id
+            - name: INFISICAL_HOST
+              value: "https://secrets.trytone.ai"
+      imagePullSecrets:
+        - name: dockerhub-auth

--- a/build/kubernetes/staging-aws/api/ingress.yaml
+++ b/build/kubernetes/staging-aws/api/ingress.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: staging-tone-api-aws-ingress
+  namespace: staging
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, PUT, DELETE, OPTIONS, PATCH"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Range, Authorization, X-Auth-Token, X-Org-Id, X-Tenant-Id, tenant_id, Accept, Origin, Referer"
+    nginx.ingress.kubernetes.io/cors-expose-headers: "Content-Length, Content-Range, Content-Type, X-Request-Id"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    nginx.ingress.kubernetes.io/cors-max-age: "3600"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: staging-api-aws.trytone.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: staging-tone-api-service
+                port:
+                  number: 80

--- a/build/kubernetes/staging-aws/api/service.yaml
+++ b/build/kubernetes/staging-aws/api/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: staging-tone-api-service
+  namespace: staging
+  labels:
+    app: staging-tone-api
+    environment: staging
+spec:
+  selector:
+    app: staging-tone-api
+  ports:
+    - port: 80
+      targetPort: 8000
+      protocol: TCP
+  type: ClusterIP

--- a/build/kubernetes/staging-aws/call/deployment.yaml
+++ b/build/kubernetes/staging-aws/call/deployment.yaml
@@ -1,0 +1,120 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: staging-tone-call-worker
+  namespace: staging
+  labels:
+    app: staging-tone-call-worker
+    environment: staging
+    component: call
+spec:
+  serviceName: staging-tone-call-headless
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      app: staging-tone-call-worker
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: staging-tone-call-worker
+        environment: staging
+        component: call
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      terminationGracePeriodSeconds: 20
+      containers:
+        - name: staging-tone-call-worker
+          image: developer390/tone:${IMAGE_TAG}
+          imagePullPolicy: Always
+          command:
+            - uvicorn
+            - "main:app"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "8080"
+            - "--workers"
+            - "1"
+            - "--timeout-keep-alive"
+            - "3600"
+            - "--log-level"
+            - "info"
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: "1"
+              memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
+          env:
+            - name: ENV
+              value: "staging"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DEPLOYMENT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.labels['app']"
+            - name: WORKER_MODE
+              value: "voice"
+            - name: MAX_CONCURRENT_CALLS
+              value: "5"
+            - name: INFISICAL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-credentials
+                  key: token
+            - name: INFISICAL_PROJECT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-credentials
+                  key: project_id
+            - name: INFISICAL_HOST
+              value: "https://secrets.trytone.ai"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            periodSeconds: 2
+            timeoutSeconds: 3
+            failureThreshold: 2
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - "curl -sf http://localhost:8080/drain || true && sleep 280"
+      imagePullSecrets:
+        - name: dockerhub-auth

--- a/build/kubernetes/staging-aws/call/ingress.yaml
+++ b/build/kubernetes/staging-aws/call/ingress.yaml
@@ -1,0 +1,74 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: staging-tone-call-aws-ingress
+  namespace: staging
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "10"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, PUT, DELETE, OPTIONS, PATCH"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Range, Authorization, X-Auth-Token, X-Org-Id, X-Tenant-Id, tenant_id, Accept, Origin, Referer, Sec-WebSocket-Extensions, Sec-WebSocket-Key, Sec-WebSocket-Protocol, Sec-WebSocket-Version"
+    nginx.ingress.kubernetes.io/cors-expose-headers: "Content-Length, Content-Range, Content-Type, X-Request-Id"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    nginx.ingress.kubernetes.io/cors-max-age: "3600"
+    nginx.ingress.kubernetes.io/websocket-services: "staging-tone-call-service"
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: staging-call-aws.trytone.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: staging-tone-call-service
+                port:
+                  number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: staging-tone-call-pod-aws-ingress
+  namespace: staging
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "10"
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: staging-call-aws.trytone.ai
+      http:
+        paths:
+          - path: /pod/0(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: staging-tone-call-pod-0
+                port:
+                  number: 80
+          - path: /pod/1(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: staging-tone-call-pod-1
+                port:
+                  number: 80
+          - path: /pod/2(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: staging-tone-call-pod-2
+                port:
+                  number: 80

--- a/build/kubernetes/staging-aws/call/pdb.yaml
+++ b/build/kubernetes/staging-aws/call/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: staging-tone-call-worker-pdb
+  namespace: staging
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: staging-tone-call-worker

--- a/build/kubernetes/staging-aws/call/pod-routing.yaml
+++ b/build/kubernetes/staging-aws/call/pod-routing.yaml
@@ -1,0 +1,169 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: staging-tone-call-pod-0
+  namespace: staging
+  labels:
+    app: staging-tone-call-worker
+    environment: staging
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: staging-tone-call-worker-0
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: staging-tone-call-pod-1
+  namespace: staging
+  labels:
+    app: staging-tone-call-worker
+    environment: staging
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: staging-tone-call-worker-1
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: staging-tone-call-pod-2
+  namespace: staging
+  labels:
+    app: staging-tone-call-worker
+    environment: staging
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: staging-tone-call-worker-2
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: staging-tone-call-pod-3
+  namespace: staging
+  labels:
+    app: staging-tone-call-worker
+    environment: staging
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: staging-tone-call-worker-3
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: staging-tone-call-pod-4
+  namespace: staging
+  labels:
+    app: staging-tone-call-worker
+    environment: staging
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: staging-tone-call-worker-4
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: staging-tone-call-pod-5
+  namespace: staging
+  labels:
+    app: staging-tone-call-worker
+    environment: staging
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: staging-tone-call-worker-5
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: staging-tone-call-pod-6
+  namespace: staging
+  labels:
+    app: staging-tone-call-worker
+    environment: staging
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: staging-tone-call-worker-6
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: staging-tone-call-pod-7
+  namespace: staging
+  labels:
+    app: staging-tone-call-worker
+    environment: staging
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: staging-tone-call-worker-7
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: staging-tone-call-pod-8
+  namespace: staging
+  labels:
+    app: staging-tone-call-worker
+    environment: staging
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: staging-tone-call-worker-8
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: staging-tone-call-pod-9
+  namespace: staging
+  labels:
+    app: staging-tone-call-worker
+    environment: staging
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: staging-tone-call-worker-9
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP

--- a/build/kubernetes/staging-aws/call/service.yaml
+++ b/build/kubernetes/staging-aws/call/service.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: staging-tone-call-service
+  namespace: staging
+  labels:
+    app: staging-tone-call-worker
+    environment: staging
+    component: call
+spec:
+  selector:
+    app: staging-tone-call-worker
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: staging-tone-call-headless
+  namespace: staging
+  labels:
+    app: staging-tone-call-worker
+    environment: staging
+    component: call
+spec:
+  clusterIP: None
+  selector:
+    app: staging-tone-call-worker
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP

--- a/build/kubernetes/staging-aws/gpu/device-plugin.yaml
+++ b/build/kubernetes/staging-aws/gpu/device-plugin.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nvidia-device-plugin-config
+  namespace: kube-system
+data:
+  config.yaml: |-
+    version: v1
+    flags:
+      migStrategy: none
+    sharing:
+      timeSlicing:
+        resources:
+          - name: nvidia.com/gpu
+            replicas: 4
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin-daemonset
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: nvidia-device-plugin-ds
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: nvidia-device-plugin-ds
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: gpu
+                    operator: Exists
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      priorityClassName: system-node-critical
+      containers:
+        - name: nvidia-device-plugin-ctr
+          image: nvcr.io/nvidia/k8s-device-plugin:v0.16.2
+          env:
+            - name: CONFIG_FILE
+              value: /config/config.yaml
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: config
+              mountPath: /config
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: config
+          configMap:
+            name: nvidia-device-plugin-config

--- a/build/kubernetes/staging-aws/models/llm-mistral.yaml
+++ b/build/kubernetes/staging-aws/models/llm-mistral.yaml
@@ -1,0 +1,113 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: staging-llm-mistral-deployment
+  namespace: staging
+  labels:
+    app: staging-llm-mistral
+spec:
+  replicas: 1
+  progressDeadlineSeconds: 1800
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: staging-llm-mistral
+  template:
+    metadata:
+      labels:
+        app: staging-llm-mistral
+    spec:
+      nodeSelector:
+        gpu: llm
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:v0.13.0
+          args:
+            - --model
+            - mistralai/Mistral-Nemo-Instruct-2407
+            - --served-model-name
+            - mistral-nemo-12b
+            - --quantization
+            - fp8
+            - --tokenizer-mode
+            - mistral
+            - --config-format
+            - mistral
+            - --load-format
+            - mistral
+            - --max-model-len
+            - "32768"
+            - --gpu-memory-utilization
+            - "0.90"
+            - --enable-auto-tool-choice
+            - --tool-call-parser
+            - mistral
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8000"
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+            - name: HF_HOME
+              value: /cache/hf
+          ports:
+            - name: http
+              containerPort: 8000
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+          volumeMounts:
+            - name: cache
+              mountPath: /cache
+            - name: dshm
+              mountPath: /dev/shm
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 15
+            failureThreshold: 120
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 20
+            failureThreshold: 3
+      volumes:
+        - name: cache
+          emptyDir: {}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 4Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: staging-llm-mistral-service
+  namespace: staging
+  labels:
+    app: staging-llm-mistral
+spec:
+  selector:
+    app: staging-llm-mistral
+  ports:
+    - port: 80
+      targetPort: 8000
+      protocol: TCP
+  type: ClusterIP

--- a/build/kubernetes/staging-aws/models/stt-nemotron.yaml
+++ b/build/kubernetes/staging-aws/models/stt-nemotron.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: staging-stt-nemotron-deployment
+  namespace: staging
+  labels:
+    app: staging-stt-nemotron
+spec:
+  replicas: 1
+  progressDeadlineSeconds: 2400
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: staging-stt-nemotron
+  template:
+    metadata:
+      labels:
+        app: staging-stt-nemotron
+    spec:
+      nodeSelector:
+        gpu: speech
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      imagePullSecrets:
+        - name: ngc-secret
+      containers:
+        - name: nemotron-asr
+          image: nvcr.io/nim/nvidia/nemotron-asr-streaming:latest
+          env:
+            - name: NGC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ngc-api-key
+                  key: NGC_API_KEY
+            - name: NIM_TAGS_SELECTOR
+              value: type=multi
+            - name: NIM_HTTP_API_PORT
+              value: "9000"
+            - name: NIM_GRPC_API_PORT
+              value: "50051"
+            - name: NIM_CACHE_PATH
+              value: /opt/nim/.cache
+          ports:
+            - name: http
+              containerPort: 9000
+            - name: grpc
+              containerPort: 50051
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+          volumeMounts:
+            - name: nim-cache
+              mountPath: /opt/nim/.cache
+            - name: dshm
+              mountPath: /dev/shm
+          startupProbe:
+            httpGet:
+              path: /v1/health/ready
+              port: http
+            periodSeconds: 15
+            failureThreshold: 160
+          readinessProbe:
+            httpGet:
+              path: /v1/health/ready
+              port: http
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /v1/health/live
+              port: http
+            periodSeconds: 20
+            failureThreshold: 3
+      volumes:
+        - name: nim-cache
+          emptyDir: {}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 2Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: staging-stt-nemotron-service
+  namespace: staging
+  labels:
+    app: staging-stt-nemotron
+spec:
+  selector:
+    app: staging-stt-nemotron
+  ports:
+    - name: http
+      port: 9000
+      targetPort: 9000
+      protocol: TCP
+    - name: grpc
+      port: 50051
+      targetPort: 50051
+      protocol: TCP
+  type: ClusterIP

--- a/build/kubernetes/staging-aws/models/tts-cosyvoice.yaml
+++ b/build/kubernetes/staging-aws/models/tts-cosyvoice.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: staging-tts-cosyvoice-deployment
+  namespace: staging
+  labels:
+    app: staging-tts-cosyvoice
+spec:
+  replicas: 1
+  progressDeadlineSeconds: 1800
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: staging-tts-cosyvoice
+  template:
+    metadata:
+      labels:
+        app: staging-tts-cosyvoice
+    spec:
+      nodeSelector:
+        gpu: speech
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: cosyvoice
+          image: podwide/cosyvoice:v1.0
+          command: ["bash", "-lc"]
+          args:
+            - |
+              set -e
+              cd /opt/CosyVoice/CosyVoice/runtime/python/fastapi
+              exec python3 server.py --port 8000 --model_dir iic/CosyVoice2-0.5B
+          env:
+            - name: MODELSCOPE_CACHE
+              value: /cache/modelscope
+            - name: PYTHONPATH
+              value: /opt/CosyVoice/CosyVoice:/opt/CosyVoice/CosyVoice/third_party/Matcha-TTS
+          ports:
+            - name: http
+              containerPort: 8000
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+          volumeMounts:
+            - name: cache
+              mountPath: /cache
+            - name: dshm
+              mountPath: /dev/shm
+          startupProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 15
+            failureThreshold: 80
+          readinessProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: http
+            periodSeconds: 20
+            failureThreshold: 3
+      volumes:
+        - name: cache
+          emptyDir: {}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 2Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: staging-tts-cosyvoice-service
+  namespace: staging
+  labels:
+    app: staging-tts-cosyvoice
+spec:
+  selector:
+    app: staging-tts-cosyvoice
+  ports:
+    - port: 80
+      targetPort: 8000
+      protocol: TCP
+  type: ClusterIP

--- a/build/kubernetes/staging-aws/models/tts-qwen.yaml
+++ b/build/kubernetes/staging-aws/models/tts-qwen.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: staging-tts-qwen-deployment
+  namespace: staging
+  labels:
+    app: staging-tts-qwen
+spec:
+  replicas: 1
+  progressDeadlineSeconds: 1800
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: staging-tts-qwen
+  template:
+    metadata:
+      labels:
+        app: staging-tts-qwen
+    spec:
+      nodeSelector:
+        gpu: speech
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: vllm-omni
+          image: vllm/vllm-omni:latest
+          command: ["vllm", "serve"]
+          args:
+            - Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice
+            - --omni
+            - --served-model-name
+            - qwen3-tts
+            - --trust-remote-code
+            - --gpu-memory-utilization
+            - "0.35"
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8000"
+          env:
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: HF_TOKEN
+            - name: HF_HOME
+              value: /cache/hf
+          ports:
+            - name: http
+              containerPort: 8000
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+          volumeMounts:
+            - name: cache
+              mountPath: /cache
+            - name: dshm
+              mountPath: /dev/shm
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 15
+            failureThreshold: 80
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 20
+            failureThreshold: 3
+      volumes:
+        - name: cache
+          emptyDir: {}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 2Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: staging-tts-qwen-service
+  namespace: staging
+  labels:
+    app: staging-tts-qwen
+spec:
+  selector:
+    app: staging-tts-qwen
+  ports:
+    - port: 80
+      targetPort: 8000
+      protocol: TCP
+  type: ClusterIP

--- a/build/kubernetes/staging-aws/monitoring/configmap.yaml
+++ b/build/kubernetes/staging-aws/monitoring/configmap.yaml
@@ -1,0 +1,124 @@
+# Grafana Alloy pipeline configuration (Alloy syntax / "River").
+#
+# Collects pod logs + node metrics from the EKS cluster and pushes them to
+# Grafana Cloud (Loki for logs, Prometheus for metrics). This is a raw-manifest
+# port of the Vultr Helm values at
+#   .claude/skills/provisioning-cluster/provisioning-vultr/templates/alloy-values.yaml
+#
+# Grafana Cloud credentials and the cluster label are injected from the
+# `grafana-cloud-credentials` Secret via environment variables, read here with
+# sys.env(...). Nothing sensitive lives in this ConfigMap.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alloy-config
+  namespace: monitoring
+data:
+  config.alloy: |
+    // ──── Kubernetes Discovery ────
+    discovery.kubernetes "pods" {
+      role = "pod"
+    }
+
+    // ──── Relabel: extract K8s metadata as labels ────
+    discovery.relabel "pod_labels" {
+      targets = discovery.kubernetes.pods.targets
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app"]
+        target_label  = "app"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_environment"]
+        target_label  = "environment"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_component"]
+        target_label  = "component"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label  = "node"
+      }
+    }
+
+    // ──── Log Collection from the Kubernetes API ────
+    loki.source.kubernetes "pod_logs" {
+      targets    = discovery.relabel.pod_labels.output
+      forward_to = [loki.process.filter.receiver]
+    }
+
+    // ──── Log Processing: add cluster label + drop health-check noise ────
+    loki.process "filter" {
+      stage.static_labels {
+        values = {
+          cluster = sys.env("CLUSTER_NAME"),
+        }
+      }
+
+      stage.drop {
+        expression          = "GET /health"
+        drop_counter_reason = "health_check"
+      }
+      stage.drop {
+        expression          = "GET /ready"
+        drop_counter_reason = "readiness_check"
+      }
+
+      forward_to = [loki.write.grafana_cloud.receiver]
+    }
+
+    // ──── Push logs to Grafana Cloud Loki ────
+    loki.write "grafana_cloud" {
+      endpoint {
+        url = sys.env("LOKI_URL")
+
+        basic_auth {
+          username = sys.env("LOKI_USER")
+          password = sys.env("GRAFANA_API_KEY")
+        }
+      }
+      external_labels = {
+        cluster = sys.env("CLUSTER_NAME"),
+      }
+    }
+
+    // ──── Node Metrics: embedded node_exporter ────
+    prometheus.exporter.unix "node" {
+      rootfs_path = "/host/root"
+      procfs_path = "/host/proc"
+      sysfs_path  = "/host/sys"
+    }
+
+    prometheus.scrape "node_metrics" {
+      targets         = prometheus.exporter.unix.node.targets
+      forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
+      scrape_interval = "60s"
+    }
+
+    // ──── Push metrics to Grafana Cloud Prometheus ────
+    prometheus.remote_write "grafana_cloud" {
+      endpoint {
+        url = sys.env("PROM_URL")
+
+        basic_auth {
+          username = sys.env("PROM_USER")
+          password = sys.env("GRAFANA_API_KEY")
+        }
+      }
+      external_labels = {
+        cluster = sys.env("CLUSTER_NAME"),
+      }
+    }

--- a/build/kubernetes/staging-aws/monitoring/daemonset.yaml
+++ b/build/kubernetes/staging-aws/monitoring/daemonset.yaml
@@ -1,0 +1,104 @@
+# Grafana Alloy DaemonSet — runs one collector pod on every node (including
+# GPU / tainted nodes) to gather logs and node metrics for Grafana Cloud.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: alloy
+  namespace: monitoring
+  labels:
+    app: alloy
+    component: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: alloy
+  template:
+    metadata:
+      labels:
+        app: alloy
+        component: monitoring
+    spec:
+      serviceAccountName: alloy
+      # Run on every node, tolerating all taints (GPU/system nodes included).
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: alloy
+          image: grafana/alloy:v1.5.1
+          args:
+            - run
+            - /etc/alloy/config.alloy
+            - --storage.path=/var/lib/alloy/data
+            - --server.http.listen-addr=0.0.0.0:12345
+          securityContext:
+            runAsUser: 0
+            privileged: false
+          ports:
+            - name: http
+              containerPort: 12345
+          env:
+            - name: CLUSTER_NAME
+              value: "tone-staging-aws"
+            - name: LOKI_URL
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-cloud-credentials
+                  key: loki-url
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-cloud-credentials
+                  key: loki-user
+            - name: PROM_URL
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-cloud-credentials
+                  key: prom-url
+            - name: PROM_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-cloud-credentials
+                  key: prom-user
+            - name: GRAFANA_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-cloud-credentials
+                  key: api-key
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+            - name: data
+              mountPath: /var/lib/alloy/data
+            # Host filesystem for node_exporter metrics (always present on EKS).
+            - name: rootfs
+              mountPath: /host/root
+              readOnly: true
+              mountPropagation: HostToContainer
+            - name: procfs
+              mountPath: /host/proc
+              readOnly: true
+            - name: sysfs
+              mountPath: /host/sys
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: alloy-config
+        - name: data
+          emptyDir: {}
+        - name: rootfs
+          hostPath:
+            path: /
+        - name: procfs
+          hostPath:
+            path: /proc
+        - name: sysfs
+          hostPath:
+            path: /sys

--- a/build/kubernetes/staging-aws/monitoring/namespace.yaml
+++ b/build/kubernetes/staging-aws/monitoring/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+  labels:
+    name: monitoring

--- a/build/kubernetes/staging-aws/monitoring/rbac.yaml
+++ b/build/kubernetes/staging-aws/monitoring/rbac.yaml
@@ -1,0 +1,44 @@
+# RBAC for Grafana Alloy.
+# Alloy uses the Kubernetes API to discover pods and stream their logs
+# (loki.source.kubernetes) and to read node metadata, so it needs cluster-wide
+# read access to pods, pods/log and nodes.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alloy
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: alloy
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+      - pods/log
+      - events
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: alloy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alloy
+subjects:
+  - kind: ServiceAccount
+    name: alloy
+    namespace: monitoring

--- a/build/kubernetes/staging-aws/worker/deployment.yaml
+++ b/build/kubernetes/staging-aws/worker/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: staging-tone-worker
+  namespace: staging
+  labels:
+    app: staging-tone-worker
+    environment: staging
+    component: worker
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: staging-tone-worker
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: staging-tone-worker
+        environment: staging
+        component: worker
+    spec:
+      serviceAccountName: tone-worker
+      nodeSelector:
+        kubernetes.io/os: linux
+      terminationGracePeriodSeconds: 120
+      containers:
+        - name: staging-tone-worker
+          image: developer390/tone:${IMAGE_TAG}
+          imagePullPolicy: Always
+          command:
+            - python
+            - "-m"
+            - procrastinate
+            - "--app=core.services.ingestion_queue.app"
+            - worker
+            - "--name=$(POD_NAME)"
+            - "--queues=ingestion,pod_sync"
+            - "--concurrency=1"
+            - "--no-listen-notify"
+            - "--fetch-job-polling-interval=5"
+          resources:
+            requests:
+              cpu: "1"
+              memory: "3Gi"
+            limits:
+              cpu: "2"
+              memory: "5Gi"
+          env:
+            - name: ENV
+              value: "staging"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DEPLOYMENT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.labels['app']"
+            - name: DOCLING_NUM_THREADS
+              value: "2"
+            - name: OMP_NUM_THREADS
+              value: "2"
+            - name: OPENBLAS_NUM_THREADS
+              value: "2"
+            - name: MKL_NUM_THREADS
+              value: "2"
+            - name: INFISICAL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-credentials
+                  key: token
+            - name: INFISICAL_PROJECT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-credentials
+                  key: project_id
+            - name: INFISICAL_HOST
+              value: "https://secrets.trytone.ai"
+      imagePullSecrets:
+        - name: dockerhub-auth

--- a/build/kubernetes/staging-aws/worker/rbac.yaml
+++ b/build/kubernetes/staging-aws/worker/rbac.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tone-worker
+  namespace: staging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tone-worker-pods
+  namespace: staging
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tone-worker-pods
+  namespace: staging
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tone-worker-pods
+subjects:
+  - kind: ServiceAccount
+    name: tone-worker
+    namespace: staging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tone-worker-nodes
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tone-worker-nodes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tone-worker-nodes
+subjects:
+  - kind: ServiceAccount
+    name: tone-worker
+    namespace: staging

--- a/core/services/pipeline/builder/pipecat.py
+++ b/core/services/pipeline/builder/pipecat.py
@@ -62,6 +62,39 @@ def _sanitize_tool_schemas(tool_schemas):
     return cleaned
 
 
+def _spec_summary(spec: Any) -> str:
+    """Render a `{provider_name, model_name, ...}` spec as "provider/model" for logs."""
+    if not spec:
+        return "none"
+    return f"{spec.get('provider_name') or '?'}/{spec.get('model_name') or '?'}"
+
+
+def _build_service(kind: str, factory, spec: Any) -> Any:
+    """Build one pipeline service, logging which provider/model failed on error.
+
+    Without this, a bad provider name or missing API key surfaces as a bare
+    traceback from deep inside service_factory with no indication of which of the
+    three services (or which provider) actually blew up.
+    """
+    if not spec:
+        logger.debug("Pipeline service {} not configured — skipping", kind)
+        return None
+    started = _time.monotonic()
+    try:
+        service = factory(spec)
+    except Exception as e:
+        logger.exception(
+            "Pipeline service {} FAILED to build: spec={} err={}",
+            kind, _spec_summary(spec), e,
+        )
+        raise
+    logger.info(
+        "Pipeline service {} built: {} (+{:.3f}s)",
+        kind, _spec_summary(spec), _time.monotonic() - started,
+    )
+    return service
+
+
 def _build_service_categories(*, stt: Any, llm: Any, tts: Any) -> dict:
     """Map each built service instance's ``.name`` to its role category.
 
@@ -136,10 +169,17 @@ class PipecatPipelineBuilder(PipelineBuilder):
         from core.processors.duplicate_transcription_filter import DuplicateTranscriptionFilter
         from core.processors.transcription_timeout_turn_stop import TranscriptionTimeoutUserTurnStopStrategy
 
+        _t_build_start = _time.monotonic()
+        logger.info(
+            "Pipeline build START: agent={} s2s={} llm={} stt={} tts={}",
+            getattr(agent, "id", None), is_s2s,
+            _spec_summary(params.llm), _spec_summary(params.stt), _spec_summary(params.tts),
+        )
+
         # --- Build services from the resolved specs (plain dicts, no DB) ---
-        llm = build_llm(params.llm) if params.llm else None
-        stt = build_stt(params.stt) if (not is_s2s and params.stt) else None
-        tts = build_tts(params.tts) if (not is_s2s and params.tts) else None
+        llm = _build_service("llm", build_llm, params.llm)
+        stt = _build_service("stt", build_stt, None if is_s2s else params.stt)
+        tts = _build_service("tts", build_tts, None if is_s2s else params.tts)
 
         _t = _time.monotonic()
         rtvi = RTVIProcessor()
@@ -149,10 +189,20 @@ class PipecatPipelineBuilder(PipelineBuilder):
         doc_tools = None
         if agent:
             from core.services.document_tool_service import build_document_tool
-            doc_tools = build_document_tool(
-                llm, agent.id, agent.organization_id, params.kb,
-                tool_call_entries=tool_call_entries, current_turn=current_turn,
-            )
+            try:
+                doc_tools = build_document_tool(
+                    llm, agent.id, agent.organization_id, params.kb,
+                    tool_call_entries=tool_call_entries, current_turn=current_turn,
+                )
+                logger.info(
+                    "Document tool built for agent {}: {} tool(s), kb_configured={}",
+                    agent.id,
+                    len(doc_tools.standard_tools) if doc_tools else 0,
+                    bool(params.kb),
+                )
+            except Exception as e:
+                logger.exception("Document tool build FAILED for agent {}: {}", agent.id, e)
+                raise
 
         # Custom + built-in tools, rebuilt from the cached tool dicts (no DB query).
         custom_tools_schema = None
@@ -165,33 +215,41 @@ class PipecatPipelineBuilder(PipelineBuilder):
                 logger.info("Building {} cached tools for agent {}", len(custom_tools), agent.id)
                 custom_tools_schema = build_custom_tool_schemas(custom_tools)
                 for tool in custom_tools:
-                    # Only "custom" tools are customer webhooks; everything else
-                    # (google_calendar, send_sms, …) is a built-in whose tool_type IS
-                    # the specific type. google_calendar needs org_id for its OAuth
-                    # lookup. (The old code routed identically: tool_type != "custom".)
-                    if tool.tool_type != "custom":
-                        handler = create_built_in_tool_handler(
-                            tool, from_number, org_id=agent.organization_id,
-                            tool_call_entries=tool_call_entries,
-                            current_turn=current_turn,
-                            tool_dedup=tool_dedup,
+                    try:
+                        # Only "custom" tools are customer webhooks; everything else
+                        # (google_calendar, send_sms, …) is a built-in whose tool_type IS
+                        # the specific type. google_calendar needs org_id for its OAuth
+                        # lookup. (The old code routed identically: tool_type != "custom".)
+                        if tool.tool_type != "custom":
+                            handler = create_built_in_tool_handler(
+                                tool, from_number, org_id=agent.organization_id,
+                                tool_call_entries=tool_call_entries,
+                                current_turn=current_turn,
+                                tool_dedup=tool_dedup,
+                            )
+                        else:
+                            handler = create_custom_tool_handler(
+                                tool,
+                                tool_call_entries=tool_call_entries,
+                                current_turn=current_turn,
+                            )
+                        # Register under the SAME sanitized name used in the schema so the
+                        # model's tool call (e.g. "calender_tool") maps back to this handler.
+                        fn_name = sanitize_tool_name(tool.name)
+                        llm.register_function(fn_name, handler)
+                        logger.info("Registered {} tool handler: {} (fn name: {})", tool.tool_type, tool.name, fn_name)
+                    except Exception as e:
+                        logger.exception(
+                            "Tool handler registration FAILED: name={} type={} agent={} err={}",
+                            getattr(tool, "name", "?"), getattr(tool, "tool_type", "?"), agent.id, e,
                         )
-                    else:
-                        handler = create_custom_tool_handler(
-                            tool,
-                            tool_call_entries=tool_call_entries,
-                            current_turn=current_turn,
-                        )
-                    # Register under the SAME sanitized name used in the schema so the
-                    # model's tool call (e.g. "calender_tool") maps back to this handler.
-                    fn_name = sanitize_tool_name(tool.name)
-                    llm.register_function(fn_name, handler)
-                    logger.info("Registered {} tool handler: {} (fn name: {})", tool.tool_type, tool.name, fn_name)
+                        raise
 
         # MCP tools: connect to the agent's linked MCP servers and register their tools.
         # register_mcp_tools is async (network I/O), which is why build() is async.
         mcp_tools_schema = None
         if agent:
+            _t_mcp = _time.monotonic()
             try:
                 from core.services.mcp_tool_service import register_mcp_tools
                 mcp_tools_schema = await register_mcp_tools(
@@ -200,8 +258,18 @@ class PipecatPipelineBuilder(PipelineBuilder):
                     current_turn=current_turn,
                     tool_dedup=tool_dedup,
                 )
+                logger.info(
+                    "MCP tools registered for agent {}: {} tool(s) (+{:.3f}s)",
+                    agent.id,
+                    len(mcp_tools_schema.standard_tools) if mcp_tools_schema else 0,
+                    _time.monotonic() - _t_mcp,
+                )
             except Exception as e:
-                logger.warning("MCP tools unavailable, disabled: {}", e)
+                logger.warning(
+                    "MCP tools unavailable for agent {}, DISABLED after {:.3f}s: {}",
+                    agent.id, _time.monotonic() - _t_mcp, e,
+                )
+                logger.opt(exception=True).debug("MCP registration traceback for agent {}", agent.id)
 
         # Built-in end_call tool — always-on for every agent. The single,
         # canonical path for ending a call (mandatory two-step confirmation
@@ -222,6 +290,7 @@ class PipecatPipelineBuilder(PipelineBuilder):
                 ),
             )
             end_call_registered = True
+            logger.info("Registered built-in end_call tool for agent {}", agent.id)
 
         # Combine doc tools, custom tools, MCP tools, and built-in tools into one ToolsSchema
         all_tool_schemas = []
@@ -282,7 +351,7 @@ class PipecatPipelineBuilder(PipelineBuilder):
                 transport.output(),
                 assistant_aggregator,
             ]
-            logger.info("[TIMING] S2S pipeline processors created (+%.3fs)", _time.monotonic() - _t)
+            logger.info("[TIMING] S2S pipeline processors created (+{:.3f}s)", _time.monotonic() - _t)
         else:
             # Standard pipeline: STT -> LLM -> TTS
             context = LLMContext(messages, combined_tools)
@@ -320,7 +389,7 @@ class PipecatPipelineBuilder(PipelineBuilder):
             # tool with a mandatory two-step confirmation (see END_CALL_SYSTEM_PROMPT).
             # The agent_config.end_call_message column is preserved for
             # backwards compatibility but no longer takes effect.
-            logger.info("[TIMING] context + aggregators + processors created (+%.3fs)", _time.monotonic() - _t)
+            logger.info("[TIMING] context + aggregators + processors created (+{:.3f}s)", _time.monotonic() - _t)
 
             # VADSpeakingTimeout caps a stuck VAD "speaking" segment (8s) so
             # segmented STTs flush and turn-stop strategies can fire; the
@@ -389,6 +458,12 @@ class PipecatPipelineBuilder(PipelineBuilder):
         if audio_buffer:
             pipeline_processors.append(audio_buffer)
 
+        logger.info(
+            "Pipeline processor chain ({}): {}",
+            len(pipeline_processors),
+            " -> ".join(getattr(p, "name", None) or type(p).__name__ for p in pipeline_processors),
+        )
+
         _t = _time.monotonic()
         pipeline = Pipeline(pipeline_processors)
 
@@ -424,7 +499,12 @@ class PipecatPipelineBuilder(PipelineBuilder):
                 turn_observer,
             ],
         )
-        logger.info("[TIMING] Pipeline + PipelineTask created (+%.3fs)", _time.monotonic() - _t)
+        logger.info("[TIMING] Pipeline + PipelineTask created (+{:.3f}s)", _time.monotonic() - _t)
+        logger.info(
+            "Pipeline build COMPLETE: agent={} s2s={} processors={} tts_sample_rate={} total={:.3f}s",
+            getattr(agent, "id", None), is_s2s, len(pipeline_processors),
+            tts_sample_rate, _time.monotonic() - _t_build_start,
+        )
 
         return BuildResult(
             pipeline=pipeline,

--- a/core/services/pipeline/qwen_omni_tts_service.py
+++ b/core/services/pipeline/qwen_omni_tts_service.py
@@ -1,0 +1,207 @@
+import base64
+import json
+from typing import AsyncGenerator, Optional
+
+import httpx
+from loguru import logger
+
+from pipecat.frames.frames import (
+    ErrorFrame,
+    Frame,
+    TTSAudioRawFrame,
+    TTSStartedFrame,
+    TTSStoppedFrame,
+)
+from pipecat.services.tts_service import TTSService
+
+try:  # pipecat >= 1.4.0 — settings object + run_tts(text, context_id)
+    from pipecat.services.tts_service import TTSSettings
+except ImportError:  # older pipecat — set_model_name() + run_tts(text)
+    TTSSettings = None
+
+_LANG_LABELS = {
+    "en": "English", "zh": "Chinese", "ja": "Japanese", "ko": "Korean",
+    "de": "German", "fr": "French", "ru": "Russian", "pt": "Portuguese",
+    "es": "Spanish", "it": "Italian",
+}
+
+_SPEAKERS = ["vivian", "serena", "uncle_fu", "dylan", "eric", "ryan", "aiden", "ono_anna", "sohee"]
+
+_DEFAULT_SPEAKER = "vivian"
+
+
+def _qwen_language(value: str) -> str:
+    if not value:
+        return "English"
+    v = value.strip()
+    if v.title() in set(_LANG_LABELS.values()):
+        return v.title()
+    return _LANG_LABELS.get(v.lower().split("-")[0], "English")
+
+
+def _qwen_voice(value: Optional[str]) -> str:
+    if not value:
+        return _DEFAULT_SPEAKER
+    v = value.strip().lower()
+    return v if v in _SPEAKERS else _DEFAULT_SPEAKER
+
+
+class QwenOmniTTSService(TTSService):
+    """Self-hosted Qwen3-TTS served by vLLM-Omni (`vllm serve <model> --omni`).
+
+    Speaks the OpenAI-compatible `/v1/audio/speech` API, which streams
+    `speech.audio.delta` SSE events carrying base64-encoded PCM (24kHz mono
+    s16le) rather than raw audio bytes.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        voice_id: str = _DEFAULT_SPEAKER,
+        language: str = "English",
+        model: str = "qwen3-tts",
+        sample_rate: Optional[int] = 24000,
+        trace_id: Optional[str] = None,
+        **kwargs,
+    ):
+        voice = _qwen_voice(voice_id)
+        if TTSSettings is not None:
+            super().__init__(
+                sample_rate=sample_rate,
+                push_start_frame=True,
+                push_stop_frames=True,
+                settings=TTSSettings(
+                    model=model,
+                    voice=voice,
+                    language=_qwen_language(language),
+                ),
+                **kwargs,
+            )
+        else:
+            super().__init__(sample_rate=sample_rate, **kwargs)
+
+        self._base_url = (base_url or "").rstrip("/")
+        self._voice_id = voice
+        self._language = _qwen_language(language)
+        self._model = model
+        self._trace_id = trace_id
+        self._apply_model_name(model)
+
+    def _apply_model_name(self, model: str):
+        # pipecat < 0.0.104 had set_model_name(); newer versions store the
+        # model on _settings and sync it to metrics separately.
+        if hasattr(self, "set_model_name"):
+            self.set_model_name(model)
+        else:
+            self._settings.model = model
+            self._sync_model_name_to_metrics()
+
+    def __str__(self):
+        return f"{self.name}"
+
+    def can_generate_metrics(self) -> bool:
+        return True
+
+    async def set_model(self, model: str):
+        self._model = model
+        self._apply_model_name(model)
+
+    async def set_voice(self, voice: str):
+        self._voice_id = _qwen_voice(voice)
+
+    async def run_tts(self, text: str, context_id: str = "") -> AsyncGenerator[Frame, None]:
+        # New pipecat calls run_tts(text, context_id) and pushes
+        # TTSStarted/StoppedFrames itself (push_start_frame/push_stop_frames);
+        # old pipecat calls run_tts(text) and expects us to yield them.
+        new_api = TTSSettings is not None
+        audio_kwargs = {"context_id": context_id} if new_api else {}
+        logger.debug(f"{self}: Generating TTS [{text}]")
+
+        payload = {
+            "model": self._model,
+            "input": text,
+            "voice": self._voice_id,
+            "language": self._language,
+            "response_format": "pcm",
+            "stream": True,
+        }
+        params = {"trace_id": self._trace_id} if self._trace_id else None
+        started = False
+
+        try:
+            await self.start_ttfb_metrics()
+            async with httpx.AsyncClient(timeout=httpx.Timeout(60.0, connect=10.0)) as client:
+                async with client.stream(
+                    "POST",
+                    f"{self._base_url}/audio/speech",
+                    json=payload,
+                    params=params,
+                    headers={"Accept": "text/event-stream"},
+                ) as resp:
+                    if resp.status_code != 200:
+                        detail = (await resp.aread()).decode(errors="replace")[:400]
+                        logger.error(f"{self} TTS request failed ({resp.status_code}): {detail}")
+                        yield ErrorFrame(error=f"Qwen TTS error {resp.status_code}: {detail}")
+                        return
+
+                    await self.start_tts_usage_metrics(text)
+
+                    async for line in resp.aiter_lines():
+                        if not line or not line.startswith("data:"):
+                            continue
+                        data = line[len("data:"):].strip()
+                        if not data or data == "[DONE]":
+                            continue
+                        try:
+                            event = json.loads(data)
+                        except json.JSONDecodeError:
+                            logger.warning(f"{self} received non-JSON SSE data: {data[:120]}")
+                            continue
+
+                        event_type = event.get("type")
+                        if event_type == "speech.audio.delta":
+                            audio_b64 = event.get("audio")
+                            if not audio_b64:
+                                continue
+                            try:
+                                chunk = base64.b64decode(audio_b64)
+                            except (ValueError, TypeError) as e:
+                                logger.warning(f"{self} failed to decode audio delta: {e}")
+                                continue
+                            if not chunk:
+                                continue
+                            if not started:
+                                if not new_api:
+                                    yield TTSStartedFrame()
+                                started = True
+                            await self.stop_ttfb_metrics()
+                            yield TTSAudioRawFrame(chunk, self.sample_rate, 1, **audio_kwargs)
+                        elif event_type == "speech.audio.done":
+                            break
+                        elif event_type == "error":
+                            detail = event.get("error") or event.get("detail")
+                            logger.error(f"{self} TTS stream error: {detail}")
+                            yield ErrorFrame(error=f"Qwen TTS error: {detail}")
+                            break
+
+            if not new_api:
+                yield TTSStoppedFrame()
+        except Exception as e:  # noqa: BLE001
+            logger.exception(f"{self} TTS generation failed")
+            yield ErrorFrame(error=f"Qwen TTS generation failed: {e}")
+
+    @classmethod
+    def get_voices(cls, api_key: str = ""):
+        return [
+            {
+                "name": s.replace("_", " ").title(),
+                "voice_id": s,
+                "description": None,
+                "gender": None,
+                "language": None,
+                "sample_url": None,
+                "accent": None,
+            }
+            for s in _SPEAKERS
+        ]

--- a/core/services/pipeline/runner/pipecat.py
+++ b/core/services/pipeline/runner/pipecat.py
@@ -165,7 +165,7 @@ class PipecatPipelineRunner(PipelineRunner):
                         if call_log:
                             call_log_state["id"] = call_log.id
                             call_id_holder["id"] = str(call_log.id)
-                            logger.info("[TIMING] create_call_log thread (+%.3fs)", _time.monotonic() - _t)
+                            logger.info("[TIMING] create_call_log thread (+{:.3f}s)", _time.monotonic() - _t)
                         else:
                             logger.warning("create_call_log returned None (no channel resolved) — no call record created")
                 except Exception as e:
@@ -446,7 +446,7 @@ class PipecatPipelineRunner(PipelineRunner):
             async def on_participant_disconnected(transport, participant_id):
                 await _end_session(participant_id)
 
-        logger.info("[TIMING] runner setup complete, total: %.3fs — starting runner.run()", _time.monotonic() - _t_comp_start)
+        logger.info("[TIMING] runner setup complete, total: {:.3f}s — starting runner.run()", _time.monotonic() - _t_comp_start)
         runner = PipecatRunner(handle_sigint=getattr(runner_args, "handle_sigint", False))
         await runner.run(task)
 

--- a/core/services/pipeline/service_factory.py
+++ b/core/services/pipeline/service_factory.py
@@ -69,6 +69,13 @@ def build_llm(spec: dict) -> Optional[Any]:
     metadata = spec["metadata"]
     model_meta = spec["model_meta_data"]
 
+    logger.info(
+        "[LLM] building provider='{}' model='{}' base_url='{}'",
+        provider_name,
+        model,
+        (model_meta or {}).get("base_url") or (metadata or {}).get("base_url"),
+    )
+
     try:
         if provider_name == "openai":  # done
             from pipecat.services.openai.llm import OpenAILLMService
@@ -96,7 +103,7 @@ def build_llm(spec: dict) -> Optional[Any]:
             from pipecat.services.ollama.llm import OLLamaLLMService
             base_url = api_key if api_key else "http://localhost:11434/v1"
             return OLLamaLLMService(model=model or "llama2", base_url=base_url, params=build_input_params(OLLamaLLMService, metadata))
-        if provider_name in ["azure", "cerebras", "nvidia_nim", "fireworks", "together", "perplexity", "qwen", "deepseek", "mistral", "sambanova", "grok", "cohere", "gemma"]:
+        if provider_name in ["azure", "cerebras", "nvidia_nim", "fireworks", "together", "perplexity", "qwen", "deepseek", "mistral", "sambanova", "grok", "cohere", "gemma", "mistral-self-hosted"]:
             from pipecat.services.openai.llm import BaseOpenAILLMService
             base_url = model_meta.get("base_url") or metadata.get("base_url")
             default_models = {
@@ -113,6 +120,7 @@ def build_llm(spec: dict) -> Optional[Any]:
                 "grok": "grok-3",
                 "cohere": "command-a-03-2025",
                 "gemma": "gemma-2-2b-it",
+                "mistral-self-hosted": "mistral-nemo-12b",
             }
             default_base_urls = {
                 "cerebras": "https://api.cerebras.ai/v1",
@@ -127,6 +135,7 @@ def build_llm(spec: dict) -> Optional[Any]:
                 "grok": "https://api.x.ai/v1",
                 "cohere": "https://api.cohere.ai/compatibility/v1",
                 "gemma": "http://staging-llm-gemma-service.staging.svc.cluster.local/v1",
+                "mistral-self-hosted": "http://staging-llm-mistral-service.staging.svc.cluster.local/v1",
             }
             if not base_url:
                 base_url = default_base_urls.get(provider_name)
@@ -164,13 +173,13 @@ def build_llm(spec: dict) -> Optional[Any]:
                 voice_id=voice_id,
                 system_instruction=metadata.get("system_instruction"),
             )
-        logger.warning("No matching LLM provider for '%s'", provider_name)
+        logger.warning("No matching LLM provider for '{}'", provider_name)
         return None
     except ImportError:
-        logger.exception("LLM provider %s not available (ImportError)", provider_name)
+        logger.exception("LLM provider {} not available (ImportError)", provider_name)
         return None
     except Exception as e:
-        logger.exception("LLM provider %s failed to initialize: %s", provider_name, e)
+        logger.exception("LLM provider {} failed to initialize: {}", provider_name, e)
         return None
 
 
@@ -181,6 +190,14 @@ def build_stt(spec: dict) -> Optional[Any]:
     model = spec["model_name"]
     metadata = spec["metadata"]
     model_meta = spec["model_meta_data"]
+
+    logger.info(
+        "[STT] building provider='{}' model='{}' base_url='{}' sample_rate={}",
+        provider_name,
+        model,
+        (model_meta or {}).get("base_url") or (metadata or {}).get("base_url"),
+        (metadata or {}).get("sample_rate"),
+    )
 
     try:
         if provider_name == "deepgram":
@@ -225,6 +242,35 @@ def build_stt(spec: dict) -> Optional[Any]:
             if metadata.get("sample_rate") is not None:
                 ws_kwargs["sample_rate"] = metadata["sample_rate"]
             return NvidiaWebSocketService(url=ws_url, trace_id=get_trace_id(), **ws_kwargs)
+        if provider_name == "nemotron-asr-self-hosted":
+            # Self-hosted Nemotron ASR on a Riva NIM — pipecat's first-party Riva
+            # gRPC client. Local deployments take a bare host:port, no SSL, no key.
+            from pipecat.services.nvidia.stt import NvidiaSTTService
+            server = (
+                model_meta.get("base_url")
+                or metadata.get("base_url")
+                or "staging-stt-nemotron-service.staging.svc.cluster.local:50051"
+            )
+            for scheme in ("http://", "https://", "grpc://", "grpcs://"):
+                if server.startswith(scheme):
+                    server = server[len(scheme):]
+                    break
+            server = server.strip().rstrip("/")
+            nemotron_kwargs = {}
+            if metadata.get("sample_rate") is not None:
+                nemotron_kwargs["sample_rate"] = metadata["sample_rate"]
+            logger.debug("[STT {}] server: {} kwargs: {}", provider_name, server, nemotron_kwargs)
+            # Endpointing is left on pipecat's defaults (stop_history=320). Passing all
+            # params <= 0 makes riva.client send no EndpointingConfig at all, which
+            # disables Riva endpointing entirely — it then returns neither interims nor
+            # finals and the STT goes completely mute (verified on staging 2026-07-15).
+            return NvidiaSTTService(
+                api_key=None,
+                server=server,
+                use_ssl=False,
+                model_function_map={"model_name": model or "nemotron-asr-streaming"},
+                **nemotron_kwargs,
+            )
         if provider_name == "parakeet":
             from core.services.pipeline.parakeet_stt_service import ParakeetSTTService
             from core.logging import get_trace_id
@@ -402,6 +448,15 @@ def build_tts(spec: dict) -> Optional[Any]:
 
     tts_voice_id = metadata.get("voice_id")
     tts_language = metadata.get("language")
+
+    logger.info(
+        "[TTS] building provider='{}' model='{}' base_url='{}' voice_id='{}' language='{}'",
+        provider_name,
+        model,
+        (model_meta or {}).get("base_url") or (metadata or {}).get("base_url"),
+        tts_voice_id,
+        tts_language,
+    )
 
     # HTTP-based providers create their aiohttp session lazily, in their own branch
     # right before construction (so a failed import never leaks a session). `session`
@@ -706,6 +761,31 @@ def build_tts(spec: dict) -> Optional[Any]:
                 qwen_kwargs["sample_rate"] = metadata["sample_rate"]
             logger.debug("[TTS {}] qwen_kwargs: {}", provider_name, qwen_kwargs)
             return QwenWebSocketTTSService(url=ws_url, trace_id=get_trace_id(), **qwen_kwargs)
+
+        if provider_name == "qwen-tts-self-hosted":
+            # Self-hosted Qwen3-TTS on vLLM-Omni. Unlike the /ws/tts sidecars above,
+            # this speaks OpenAI's /v1/audio/speech and streams base64 PCM over SSE.
+            from core.services.pipeline.qwen_omni_tts_service import QwenOmniTTSService
+            from core.logging import get_trace_id
+            base_url = (
+                model_meta.get("base_url")
+                or metadata.get("base_url")
+                or "http://staging-tts-qwen-service.staging.svc.cluster.local/v1"
+            )
+            qwen_kwargs = {}
+            if tts_voice_id is not None:
+                qwen_kwargs["voice_id"] = tts_voice_id
+            if tts_language is not None:
+                qwen_kwargs["language"] = tts_language
+            if metadata.get("sample_rate") is not None:
+                qwen_kwargs["sample_rate"] = metadata["sample_rate"]
+            logger.debug("[TTS {}] qwen_kwargs: {}", provider_name, qwen_kwargs)
+            return QwenOmniTTSService(
+                base_url=base_url,
+                model=model or "qwen3-tts",
+                trace_id=get_trace_id(),
+                **qwen_kwargs,
+            )
 
         logger.warning("Unsupported TTS provider: {}", provider_name)
         return None


### PR DESCRIPTION
* ci: add AWS EKS staging deploy workflow

* Feature/staging/cerebras model provider (#714) (#715)

* fix(stt-deploy): raise nemotron rollout progressDeadlineSeconds to 1800s

The Staging Model Services Deploy run failed on the nemotron job with "exceeded its progress deadline" at exactly 10 min, even though ConfigMap + manifest apply + rollout restart all succeeded. The container pip-installs deps then downloads/loads the NeMo model on startup — the startupProbe already budgets up to 25 min for this — but the deployment's rollout progress deadline was the default 600s (10 min). A healthy-but-slow cold start therefore tripped the deadline and failed the deploy. Set progressDeadlineSeconds=1800 so the rollout waits past the startupProbe budget.



* fix(metrics): discard silence-gap STT TTFB samples (phantom 60s p99)

STTLatencyTap measures STT TTFB as (next-transcript-time − user-stopped-time). When a caller stopped speaking and then went silent for a long time (thinking, end of call, or a late/spurious transcript arrived), that whole real-world SILENCE was recorded as "STT latency" — producing phantom 60s+ p99 spikes on the dashboard while the STT was actually ~300-800ms. The armed anchor survived the gap because nothing disarmed it.

- Discard samples above MAX_SANE_STT_TTFB_S (default 5s, env-tunable via STT_MAX_SANE_TTFB_S): a streaming STT final never legitimately takes seconds.
- Disarm the anchor on BotStartedSpeaking / End / Cancel frames — once the bot responds or the call ends, any still-armed stop is stale and must not be matched to a later transcript.

Result: STT p99 reflects real latency (~500-900ms) instead of silence gaps. No effect on real STT samples; fully reversible via env.



* feat(providers): add Cerebras LLM provider (gpt-oss-120b) to catalog seed

Add Cerebras as an OpenAI-compatible LLM provider in dev-data.json with the gpt-oss-120b model (131k context). Runtime support already exists in service_factory.py (base_url https://api.cerebras.ai/v1). Includes dev/seed_cerebras.py, an idempotent standalone upsert that seeds only the Cerebras provider + models without creating a user/org, safe to re-run against any already-populated environment.



* chore(stt): drop explanatory comment blocks from STT latency changes



* feat(send_sms): fall back to SEND_SMS_DEFAULT_TO_NUMBER for empty/placeholder recipients

Preview/test calls carry no real caller number, so send_sms had no recipient. Add a configurable SEND_SMS_DEFAULT_TO_NUMBER setting and use it when the resolved recipient is empty or the test placeholder.



---------




* Staging => Staging-aws (#716)

* Added changes for adding model providers

* Added UI changes for creating model providers

* Feature/staging/cerebras model provider (#714) (#715)

* fix(stt-deploy): raise nemotron rollout progressDeadlineSeconds to 1800s

The Staging Model Services Deploy run failed on the nemotron job with "exceeded its progress deadline" at exactly 10 min, even though ConfigMap + manifest apply + rollout restart all succeeded. The container pip-installs deps then downloads/loads the NeMo model on startup — the startupProbe already budgets up to 25 min for this — but the deployment's rollout progress deadline was the default 600s (10 min). A healthy-but-slow cold start therefore tripped the deadline and failed the deploy. Set progressDeadlineSeconds=1800 so the rollout waits past the startupProbe budget.



* fix(metrics): discard silence-gap STT TTFB samples (phantom 60s p99)

STTLatencyTap measures STT TTFB as (next-transcript-time − user-stopped-time). When a caller stopped speaking and then went silent for a long time (thinking, end of call, or a late/spurious transcript arrived), that whole real-world SILENCE was recorded as "STT latency" — producing phantom 60s+ p99 spikes on the dashboard while the STT was actually ~300-800ms. The armed anchor survived the gap because nothing disarmed it.

- Discard samples above MAX_SANE_STT_TTFB_S (default 5s, env-tunable via STT_MAX_SANE_TTFB_S): a streaming STT final never legitimately takes seconds.
- Disarm the anchor on BotStartedSpeaking / End / Cancel frames — once the bot responds or the call ends, any still-armed stop is stale and must not be matched to a later transcript.

Result: STT p99 reflects real latency (~500-900ms) instead of silence gaps. No effect on real STT samples; fully reversible via env.



* feat(providers): add Cerebras LLM provider (gpt-oss-120b) to catalog seed

Add Cerebras as an OpenAI-compatible LLM provider in dev-data.json with the gpt-oss-120b model (131k context). Runtime support already exists in service_factory.py (base_url https://api.cerebras.ai/v1). Includes dev/seed_cerebras.py, an idempotent standalone upsert that seeds only the Cerebras provider + models without creating a user/org, safe to re-run against any already-populated environment.



* chore(stt): drop explanatory comment blocks from STT latency changes



* feat(send_sms): fall back to SEND_SMS_DEFAULT_TO_NUMBER for empty/placeholder recipients

Preview/test calls carry no real caller number, so send_sms had no recipient. Add a configurable SEND_SMS_DEFAULT_TO_NUMBER setting and use it when the resolved recipient is empty or the test placeholder.



---------




---------




* feat(aws): staging-aws manifests with GPU model deployments

* feat(pipeline): route self-hosted nemotron STT via riva grpc and qwen3-tts via vllm-omni sse

* added logger lines

* fix(stt): use riva nim default endpointing and add pipeline build logs

* revert(stt): restore pipecat default riva endpointing and bump vllm to v0.13.0

* feat(aws): ship staging logs to Grafana Cloud via Alloy on EKS

Add Grafana Alloy as a DaemonSet in the monitoring namespace on the staging-aws EKS cluster, collecting pod logs + node metrics and pushing them to the existing Grafana Cloud (Loki + Prometheus). This replaces the Vultr-side collector after the staging migration to AWS.

- monitoring/{namespace,rbac,configmap,daemonset}.yaml — raw manifests (matches this branch's kubectl-apply style; no Helm)
- Alloy reads Grafana Cloud creds from the grafana-cloud-credentials Secret via sys.env(); nothing sensitive committed
- Logs collected via the K8s API (loki.source.kubernetes), so no host /var/log or containerd log-path mounts needed — avoids EKS containerd pod-start failures
- CI: create monitoring ns + grafana-cloud-credentials secret (from repo Actions secrets) + apply the Alloy manifests



---------