### PR TITLE
fix(worker): complete truncated enqueue_compute_call_metrics_aggregates_sync (crash-loop hotfix)

### DIFF
--- a/core/services/ingestion_queue.py
+++ b/core/services/ingestion_queue.py
@@ -164,3 +164,4 @@ def enqueue_compute_call_metrics_aggregates_sync(call_id) -> int:
     called from ``PostCallHandler`` which runs inside the sync completion
     path."""
     with app.open():
+        return compute_call_metrics_aggregates_task.defer(call_id=str(call_id))


### PR DESCRIPTION
## What
Completes the truncated `enqueue_compute_call_metrics_aggregates_sync` helper in `core/services/ingestion_queue.py`, which was committed with an empty `with app.open():` block.

## Why (crash loop)
The empty block raises at **module import time**:
```
IndentationError: expected an indented block after 'with' statement on line 166
  File "/app/core/services/ingestion_queue.py", line 166
```
Both the API (`uvicorn main:app`) and the Procrastinate worker import `core.services.ingestion_queue`, so the staging-aws `staging-tone-api-deployment` and `staging-tone-worker` pods **crash-loop on startup**.

## Fix
One line — add the missing `defer` call, mirroring the async sibling `enqueue_compute_call_metrics_aggregates`:
```python
def enqueue_compute_call_metrics_aggregates_sync(call_id) -> int:
    with app.open():
        return compute_call_metrics_aggregates_task.defer(call_id=str(call_id))
```
`python -m py_compile core/services/ingestion_queue.py` passes.

## Target branch
Based off `staging-aws` (the only branch containing the broken function; `dev` is clean). Merging here triggers the `staging-aws` CI rebuild that resolves the crash loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)