### PR TITLE
fix(worker): consume log_sync queue so per-call Loki→Postgres sync runs

### DIFF
--- a/build/kubernetes/staging-aws/worker/deployment.yaml
+++ b/build/kubernetes/staging-aws/worker/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             - "--app=core.services.ingestion_queue.app"
             - worker
             - "--name=$(POD_NAME)"
-            - "--queues=ingestion,pod_sync,outbound_calls,call_overlaps,call_transcripts,call_metrics"
+            - "--queues=ingestion,pod_sync,outbound_calls,call_overlaps,call_transcripts,call_metrics,log_sync"
             - "--concurrency=1"
             - "--no-listen-notify"
             - "--fetch-job-polling-interval=5"

--- a/build/kubernetes/staging/worker/deployment.yaml
+++ b/build/kubernetes/staging/worker/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             - "--app=core.services.ingestion_queue.app"
             - worker
             - "--name=$(POD_NAME)"
-            - "--queues=ingestion,pod_sync,outbound_calls,call_overlaps,call_transcripts,call_metrics"
+            - "--queues=ingestion,pod_sync,outbound_calls,call_overlaps,call_transcripts,call_metrics,log_sync"
             - "--concurrency=1"
             - "--no-listen-notify"
             - "--fetch-job-polling-interval=5"


### PR DESCRIPTION
## Problem
The per-call **Grafana Loki → Postgres** log sync stores nothing in `pipeline_logs`.

Root cause: the post-call `SyncLokiLogsAction` defers its job to the Procrastinate queue **`log_sync`**, but the worker's `--queues` allowlist omitted it:

```
--queues=ingestion,pod_sync,outbound_calls,call_overlaps,call_transcripts,call_metrics
```

So `sync_loki_logs` jobs were enqueued to a queue **no worker consumes** and sat in `procrastinate_jobs` as `todo` forever. Sibling post-call actions worked because their queues (`call_transcripts`, `call_metrics`) *were* in the list — which is why the Consolidated/Metrics tabs populate but call logs never do.

## Fix
Add `log_sync` to `--queues` in both worker deployments:
- `build/kubernetes/staging-aws/worker/deployment.yaml`
- `build/kubernetes/staging/worker/deployment.yaml`

## Deploy
Requires a worker rollout to pick up the new args:
```bash
kubectl apply -f build/kubernetes/staging-aws/worker/deployment.yaml
kubectl rollout restart deploy/staging-tone-worker -n staging
kubectl get deploy staging-tone-worker -n staging   # confirm replicas >= 1
```

## Still required for rows to appear (runtime deps, not in this PR)
1. Loki read creds reachable by the **call** and **worker** pods via Infisical: `LOKI_URL` (+`GRAFANA_API_KEY`) so `settings.loki_read_configured()` is true — else `SyncLokiLogsAction` safe-no-ops.
2. `GRAFANA_API_KEY` must have `logs:read` scope.
3. `pipeline_logs` migration applied on the target DB.

The inline endpoint `POST /api/v1/call-log/{call_id}/sync-logs` bypasses the queue and can validate deps #1–#3 independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)