### PR TITLE
fix(loki-sync): correct LogQL selector so per-call logs actually store

### DIFF
--- a/core/services/pipeline_log_sync_service.py
+++ b/core/services/pipeline_log_sync_service.py
@@ -107,7 +107,7 @@ class PipelineLogSyncService(BaseService):
         # the fully-rendered trace_id before storing, so foreign lines aren't
         # misattributed to this call.
         call_uuid = call.trace_id.split("-", 1)[0]
-        query = f'{{app="{settings.LOKI_SYNC_APP_LABEL}"}} |= "trace_id={call_uuid}"'
+        query = f'{settings.LOKI_SYNC_STREAM_SELECTOR} |= "trace_id={call_uuid}"'
 
         client = LokiClient()
         result = SyncResult(window_start=start_dt, window_end=end_dt)

--- a/shared/config.py
+++ b/shared/config.py
@@ -147,7 +147,21 @@ class Settings:
 
         # Per-call sync tuning. No enable/disable flag — the post-call action is
         # always wired; loki_read_configured() alone gates it.
-        self.LOKI_SYNC_APP_LABEL: str = get_secret("LOKI_SYNC_APP_LABEL", "tone")
+        # Loki stream selector for the per-call log fetch. The trace_id line
+        # filter does the real per-call scoping; this selector just narrows the
+        # streams. Default is env-agnostic — Alloy labels tone pods with
+        # component={call,api,worker}, so {component=~"call|api"} matches the
+        # call + api pods in every environment. Override with a full LogQL
+        # selector via LOKI_SYNC_STREAM_SELECTOR, or a single workload via
+        # LOKI_SYNC_APP_LABEL (builds {app="<value>"}). NOTE: there is no
+        # app="tone" label — app values are the workload names
+        # (e.g. staging-tone-call-worker), which is why the old default matched
+        # nothing.
+        _loki_app_label = get_secret("LOKI_SYNC_APP_LABEL", "").strip()
+        self.LOKI_SYNC_STREAM_SELECTOR: str = (
+            get_secret("LOKI_SYNC_STREAM_SELECTOR", "").strip()
+            or (f'{{app="{_loki_app_label}"}}' if _loki_app_label else '{component=~"call|api"}')
+        )
         self.LOKI_SYNC_DELAY_SECONDS: int = int(get_secret("LOKI_SYNC_DELAY_SECONDS", "120"))
         self.LOKI_SYNC_PRE_BUFFER_SECONDS: int = int(get_secret("LOKI_SYNC_PRE_BUFFER_SECONDS", "30"))
         self.LOKI_SYNC_POST_BUFFER_SECONDS: int = int(get_secret("LOKI_SYNC_POST_BUFFER_SECONDS", "60"))


### PR DESCRIPTION
## Problem
`sync_loki_logs` jobs ran and **succeeded** but `pipeline_logs` stayed empty (0 rows inserted for every call).

Root cause: the query used `{app="tone"} |= "trace_id=..."`, but **there is no `app="tone"` stream in Loki**. Grafana Alloy labels pods by workload name — the real `app` values are `staging-tone-call-worker`, `staging-tone-api`, `staging-tone-worker`. So the selector matched **0 streams** → 0 fetched → 0 inserted, and the job still reported success.

Verified live against a real call (`trace_id=bfb23365…`):
- `{app="tone"}` → **0** streams
- `{app="staging-tone-call-worker"}` / `{component=~"call|api"}` / `{namespace="staging"}` → **1216** lines
- Running the real service with a corrected selector inserted **1216/1216** rows.

This matches Grafana's own "View logs" link, which filters on `app = staging-tone-call-worker, staging-tone-api`.

## Fix
Replace `LOKI_SYNC_APP_LABEL` (default `tone`) with `LOKI_SYNC_STREAM_SELECTOR`, defaulting to the **environment-agnostic** `{component=~"call|api"}` (Alloy sets `component={call,api,worker}` in every env). Backward-compatible:
- `LOKI_SYNC_APP_LABEL=<x>` still works → builds `{app="<x>"}`
- `LOKI_SYNC_STREAM_SELECTOR=<full LogQL>` for full control

The `trace_id` line filter continues to do the real per-call scoping.

## Immediate unblock (no redeploy)
The currently-deployed image reads `LOKI_SYNC_APP_LABEL`, so set in staging Infisical:
```
LOKI_SYNC_APP_LABEL = staging-tone-call-worker
```
then restart the api/call/worker pods and scale the worker to ≥1. After this PR deploys, the env var is optional (default works).

## Note
`core/services/pipeline/call_end_events.py:58` has a docstring example that also shows the stale `{app="tone"}` — cosmetic, left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)