### PR TITLE
fix(loki-sync): correct LogQL selector so per-call logs actually store

### DIFF
--- a/core/services/pipeline_log_sync_service.py
+++ b/core/services/pipeline_log_sync_service.py
@@ -107,7 +107,12 @@ class PipelineLogSyncService(BaseService):
         # the fully-rendered trace_id before storing, so foreign lines aren't
         # misattributed to this call.
         call_uuid = call.trace_id.split("-", 1)[0]
-        query = f'{{app="{settings.LOKI_SYNC_APP_LABEL}"}} |= "trace_id={call_uuid}"'
+        selector = (
+            f'{{app="{settings.LOKI_SYNC_APP_LABEL}"}}'
+            if settings.LOKI_SYNC_APP_LABEL
+            else '{component=~"call|api"}'
+        )
+        query = f'{selector} |= "trace_id={call_uuid}"'
 
         client = LokiClient()
         result = SyncResult(window_start=start_dt, window_end=end_dt)

--- a/shared/config.py
+++ b/shared/config.py
@@ -178,7 +178,15 @@ class Settings:
 
         # Per-call sync tuning. No enable/disable flag — the post-call action is
         # always wired; loki_read_configured() alone gates it.
-        self.LOKI_SYNC_APP_LABEL: str = get_secret("LOKI_SYNC_APP_LABEL", "tone")
+        # Loki stream selector for the per-call log fetch — the trace_id line
+        # filter does the real per-call scoping; this just narrows the streams.
+        # Set LOKI_SYNC_APP_LABEL to a single workload (builds {app="<value>"}),
+        # e.g. staging-tone-call-worker. Left blank, the query falls back to the
+        # env-agnostic {component=~"call|api"} (Alloy labels tone pods with
+        # component={call,api,worker}). NOTE: there is no app="tone" label — app
+        # values are the workload names, which is why the old default matched
+        # nothing.
+        self.LOKI_SYNC_APP_LABEL: str = get_secret("LOKI_SYNC_APP_LABEL", "").strip()
         self.LOKI_SYNC_DELAY_SECONDS: int = int(get_secret("LOKI_SYNC_DELAY_SECONDS", "120"))
         self.LOKI_SYNC_PRE_BUFFER_SECONDS: int = int(get_secret("LOKI_SYNC_PRE_BUFFER_SECONDS", "30"))
         self.LOKI_SYNC_POST_BUFFER_SECONDS: int = int(get_secret("LOKI_SYNC_POST_BUFFER_SECONDS", "60"))


### PR DESCRIPTION
## Problem
`sync_loki_logs` jobs ran and **succeeded** but `pipeline_logs` stayed empty (0 rows inserted per call).

Root cause: the query used `{app="tone"} |= "trace_id=..."`, but there is **no `app="tone"` stream** in Loki — Grafana Alloy labels pods by workload name (`staging-tone-call-worker`, `staging-tone-api`, `staging-tone-worker`). The selector matched **0 streams** → 0 fetched → 0 inserted, and the job still reported success.

Verified live against a real call (`trace_id=bfb23365…`):
- `{app="tone"}` → **0** streams
- corrected selector → **1216** lines; running the real service inserted **1216/1216** rows.

## Fix
Build the selector from `LOKI_SYNC_APP_LABEL` (→ `{app="<value>"}`); when unset, fall back to the **environment-agnostic** `{component=~"call|api"}` (Alloy sets `component={call,api,worker}` in every env). The `trace_id` line filter still does the real per-call scoping. One config key, no `app="tone"` default.

Set in staging Infisical for the current deployed image: `LOKI_SYNC_APP_LABEL=staging-tone-call-worker`.

## Note
Same fix also flows through the feature PR #758; this is the focused standalone version for `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)