### PR TITLE
fix(cors): allow credentialed CORS on staging-aws api ingress

### DIFF
--- a/build/kubernetes/staging-aws/api/ingress.yaml
+++ b/build/kubernetes/staging-aws/api/ingress.yaml
@@ -6,7 +6,11 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"
     nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+    # Credentialed (cookie) auth forbids `Allow-Origin: *`. This wildcard-
+    # subdomain form matches any https://<sub>.trytone.ai and makes nginx echo
+    # back the CONCRETE request origin (e.g. https://staging.trytone.ai), which
+    # is valid with credentials. Requires ingress-nginx controller v1.4.0+.
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://*.trytone.ai"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, PUT, DELETE, OPTIONS, PATCH"
     nginx.ingress.kubernetes.io/cors-allow-headers: "DNT, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Range, Authorization, X-Auth-Token, X-Org-Id, X-Tenant-Id, tenant_id, Accept, Origin, Referer"
     nginx.ingress.kubernetes.io/cors-expose-headers: "Content-Length, Content-Range, Content-Type, X-Request-Id"


### PR DESCRIPTION
## What
Change the nginx ingress `cors-allow-origin` for `staging-api-aws.trytone.ai` from `"*"` to `"https://*.trytone.ai"`.

## Why
The auth migration moved access/refresh JWTs into **httpOnly cookies**, so browser requests are now **credentialed** (`withCredentials: true`). Browsers reject `Access-Control-Allow-Origin: *` together with `Access-Control-Allow-Credentials: true`, so login from `https://staging.trytone.ai` was blocked at the preflight. The nginx ingress terminates the OPTIONS preflight itself and was emitting the wildcard — overriding the app-level CORS config — so this must be fixed at the ingress.

The wildcard-subdomain form makes nginx **reflect the concrete request origin** (e.g. `https://staging.trytone.ai`), which is valid with credentials.

## Verification
Applied to the live cluster and re-ran the preflight:
```
$ curl -s -D - -o /dev/null -X OPTIONS \
    'https://staging-api-aws.trytone.ai/api/v1/auth/login' \
    -H 'Origin: https://staging.trytone.ai' -H 'Access-Control-Request-Method: POST'
access-control-allow-origin: https://staging.trytone.ai   ✅
```

## Notes
- Requires ingress-nginx controller **v1.4.0+** for wildcard-origin matching (staging-aws confirmed working).
- The same `cors-allow-origin: "*"` still exists in the other env ingresses (`staging`, `dev`, `staging-aws/call`, `staging-gcp-kube`, …); each will need the same change **when/if** it adopts cookie auth — intentionally **not** touched here to keep this PR single-purpose.
- Scope: **this one manifest only.** The auth-cookie application code landed separately in #759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)