### PR TITLE
refactor(loki-sync): store per-call logs as one JSON-array row

### DIFF
--- a/alembic/versions/d4b2f8a1c6e3_call_pipeline_logs_json_array.py
+++ b/alembic/versions/d4b2f8a1c6e3_call_pipeline_logs_json_array.py
@@ -1,0 +1,94 @@
+"""replace per-line pipeline_logs with per-call call_pipeline_logs (JSON array)
+
+Drops the per-line ``pipeline_logs`` table (its rows are discarded — they
+re-populate on the next sync) and creates ``call_pipeline_logs``, which stores
+ALL of a call's log lines as a single ``logs`` JSONB array on ONE row keyed by
+``call_id`` (UNIQUE). The per-call viewer now reads one row; a re-sync replaces
+the array wholesale. Idempotency comes from the bounded per-call fetch window,
+so no per-line ``fingerprint`` unique key is needed anymore.
+
+See ``core/models/log_entry.py`` (``CallPipelineLog``) and
+``PipelineLogSyncService``.
+
+Revision ID: d4b2f8a1c6e3
+Revises: a1c9f4e7b2d5
+Create Date: 2026-07-17
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "d4b2f8a1c6e3"
+down_revision = "a1c9f4e7b2d5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Discard the per-line table entirely (existing rows are not migrated —
+    # they re-populate from Loki on the next per-call sync).
+    op.drop_index("ix_pipeline_logs_call_ts", table_name="pipeline_logs")
+    op.drop_table("pipeline_logs")
+
+    op.create_table(
+        "call_pipeline_logs",
+        # OrgScopedModel columns.
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False, index=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        # Identity — stamped from the Call. One row per call.
+        sa.Column(
+            "call_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("calls.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=True, index=True),
+        sa.Column("trace_id", sa.String(128), nullable=True, index=True),
+        # All of the call's lines as one time-ordered JSON array.
+        sa.Column(
+            "logs",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("synced_at", sa.DateTime(timezone=True), nullable=True),
+        # One row per call → the upsert conflict target and the viewer lookup key.
+        # The UNIQUE constraint's index also serves call_id lookups (no separate index).
+        sa.UniqueConstraint("call_id", name="uq_call_pipeline_logs_call_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("call_pipeline_logs")
+
+    # Recreate the per-line table exactly as a1c9f4e7b2d5 created it.
+    op.create_table(
+        "pipeline_logs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False, index=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column(
+            "call_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("calls.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=True, index=True),
+        sa.Column("trace_id", sa.String(128), nullable=True, index=True),
+        sa.Column("ts", sa.DateTime(timezone=True), nullable=False, index=True),
+        sa.Column("ts_ns", sa.BigInteger(), nullable=False),
+        sa.Column("level", sa.String(16), nullable=True),
+        sa.Column("logger_name", sa.String(255), nullable=True),
+        sa.Column("message", sa.Text(), nullable=True),
+        sa.Column("raw_line", sa.Text(), nullable=False),
+        sa.Column("labels", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("fingerprint", sa.String(64), nullable=False),
+        sa.UniqueConstraint("fingerprint", name="uq_pipeline_logs_fingerprint"),
+    )
+    op.create_index("ix_pipeline_logs_call_ts", "pipeline_logs", ["call_id", "ts"])

--- a/core/api/v1/call_logs.py
+++ b/core/api/v1/call_logs.py
@@ -175,11 +175,11 @@ def sync_call_logs(
     claims: JWTClaims = Depends(require_org_member),
     db: Session = Depends(get_db),
 ):
-    """Read this call's log lines back from Loki into ``pipeline_logs`` (inline).
+    """Read this call's log lines back from Loki into ``call_pipeline_logs`` (inline).
 
     The on-demand trigger for the per-call log store — same service the
-    ``sync_loki_logs`` post-call action runs. Idempotent: a re-run inserts 0 and
-    reports all skipped (fingerprint dedup)."""
+    ``sync_loki_logs`` post-call action runs. Idempotent: a re-run re-reads the
+    same window and replaces the call's stored log array wholesale."""
     svc = PipelineLogSyncService(db, org_id=_org_id(claims))
     try:
         result = svc.sync_call_by_id(_parse_call_id(call_id))

--- a/core/jobs/sync_loki.py
+++ b/core/jobs/sync_loki.py
@@ -10,11 +10,12 @@ from core.services.pipeline_log_sync_service import PipelineLogSyncService
 
 
 def sync_call_logs(call_id: str) -> None:
-    """Read a finished call's log lines from Loki into ``pipeline_logs``.
+    """Read a finished call's log lines from Loki into ``call_pipeline_logs``.
 
     Runs inside the ``sync_loki_logs`` procrastinate task, deferred with a delay
     after the call ends so Loki has ingested the call's teardown lines. Idempotent
-    (fingerprint dedup), so task-level retries are safe. A missing call is a no-op
+    (the array is rebuilt from the same window and replaced), so task-level
+    retries are safe. A missing call is a no-op
     (it may have been deleted between defer and run)."""
     with get_db_context() as db:
         call = db.query(Call).filter(Call.id == UUID(call_id)).first()
@@ -23,6 +24,6 @@ def sync_call_logs(call_id: str) -> None:
             return
         result = PipelineLogSyncService(db, org_id=call.organization_id).sync_call(call)
     logger.info(
-        "[loki_sync] job done call={} inserted={} skipped_dup={} fetched={}",
-        call_id, result.inserted, result.skipped, result.fetched,
+        "[loki_sync] job done call={} fetched={} stored={}",
+        call_id, result.fetched, result.stored,
     )

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -49,7 +49,7 @@ from core.models.pod import Pod
 # Calls & Metrics
 from core.models.call import Call
 from core.models.call_metrics import CallMetrics
-from core.models.log_entry import PipelineLog
+from core.models.log_entry import CallPipelineLog
 from core.models.scheduled_call import ScheduledCall
 from core.models.tool_execution import ToolExecution
 from core.models.webhook import Webhook

--- a/core/models/log_entry.py
+++ b/core/models/log_entry.py
@@ -1,66 +1,51 @@
 from sqlalchemy import (
-    BigInteger,
     Column,
     DateTime,
     ForeignKey,
-    Index,
     String,
-    Text,
-    UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 from core.models.base import OrgScopedModel
 
 
-class PipelineLog(OrgScopedModel):
-    """One log line of a single finished call, read back from Grafana Loki.
+class CallPipelineLog(OrgScopedModel):
+    """All of one finished call's log lines, read back from Grafana Loki and
+    stored as a single JSON array — ONE row per call.
 
-    Populated by ``PipelineLogSyncService`` after a call ends (via the
-    ``sync_loki_logs`` post-call action or the manual sync endpoint) to power an
-    in-product per-call log viewer. Identity columns (``call_id``,
-    ``organization_id``, ``agent_id``, ``trace_id``) are STAMPED from the ``Call``
-    row — never parsed from the line text — so viewer queries stay tenant-scoped
-    and reliable. Only ``level``/``logger_name``/``message`` are parsed from the
-    raw line, defensively (``raw_line`` always preserves the original).
+    Replaces the earlier per-line ``pipeline_logs`` table: a call's lines now
+    live in the ``logs`` JSONB array on a single row keyed by ``call_id``
+    (UNIQUE), so the per-call viewer reads one row and a re-sync replaces the
+    array wholesale. Populated by ``PipelineLogSyncService`` after a call ends
+    (via the ``sync_loki_logs`` post-call action or the manual sync endpoint).
+    Identity columns (``call_id``/``organization_id``/``agent_id``/``trace_id``)
+    are STAMPED from the ``Call`` row — never parsed from the line text — so
+    viewer queries stay tenant-scoped and reliable.
 
-    ``fingerprint`` (sha256 of ts + labels + line) is UNIQUE so re-runs of the
-    same call — the post-call action and a manual re-sync, task retries,
-    concurrent runs — are idempotent via ``on_conflict_do_nothing``.
+    Idempotency comes from the bounded per-call fetch window, not a per-line
+    unique key: every sync re-reads the same window, rebuilds the same
+    de-duplicated, time-ordered array, and upserts it
+    (``on_conflict(call_id) do update``). So the post-call action, a manual
+    re-sync, task retries and concurrent runs all converge on one row with the
+    same contents. Each ``logs`` element is
+    ``{ts, ts_ns, level, logger_name, message, raw_line}``; identity is not
+    repeated per element (it lives on the row).
     """
 
-    __tablename__ = "pipeline_logs"
+    __tablename__ = "call_pipeline_logs"
 
     call_id = Column(
         UUID(as_uuid=True),
         ForeignKey("calls.id", ondelete="CASCADE"),
         nullable=False,
-        index=True,
+        # UNIQUE — one row per call; its index also serves the viewer lookup.
+        unique=True,
     )
     agent_id = Column(UUID(as_uuid=True), nullable=True, index=True)
     trace_id = Column(String(128), nullable=True, index=True)
 
-    # Loki line timestamp. ``ts`` is tz-aware for range queries; ``ts_ns`` keeps
-    # the original nanosecond precision Loki reports (and drives pagination).
-    ts = Column(DateTime(timezone=True), nullable=False, index=True)
-    ts_ns = Column(BigInteger, nullable=False)
-
-    # Parsed defensively from the line — any may be NULL on a non-matching or
-    # multiline line, in which case ``message`` falls back to the whole line.
-    level = Column(String(16), nullable=True)
-    logger_name = Column(String(255), nullable=True)
-    message = Column(Text, nullable=True)
-
-    # The original Loki line, always stored verbatim (never dropped).
-    raw_line = Column(Text, nullable=False)
-    # Loki stream labels for the line (app, namespace, pod, …).
-    labels = Column(JSONB, nullable=True)
-
-    # sha256(ts_ns + sorted labels + raw line). Deterministic → dedup key.
-    fingerprint = Column(String(64), nullable=False)
-
-    __table_args__ = (
-        UniqueConstraint("fingerprint", name="uq_pipeline_logs_fingerprint"),
-        # Primary viewer access path: a call's lines in time order.
-        Index("ix_pipeline_logs_call_ts", "call_id", "ts"),
-    )
+    # Time-ordered (oldest first) array of the call's log lines. Each element is
+    # {ts, ts_ns, level, logger_name, message, raw_line}.
+    logs = Column(JSONB, nullable=False, default=list)
+    # When ``logs`` was last (re)synced from Loki.
+    synced_at = Column(DateTime(timezone=True), nullable=True)

--- a/core/services/pipeline_log_sync_service.py
+++ b/core/services/pipeline_log_sync_service.py
@@ -1,10 +1,13 @@
-"""Read one finished call's log lines back from Loki into ``pipeline_logs``.
+"""Read one finished call's log lines back from Loki into ``call_pipeline_logs``.
 
 The service behind both the ``sync_loki_logs`` post-call action and the manual
 ``POST /call-log/{call_id}/sync-logs`` endpoint. Scoped to a single call, so the
-time window is bounded and known up front; a deterministic ``fingerprint`` unique
-index makes every re-run idempotent (post-call action + manual re-sync + task
-retry + concurrent runs all converge on the same rows).
+time window is bounded and known up front. All of the call's lines are stored as
+a single ``logs`` JSON array on ONE row keyed by ``call_id``; every re-run
+re-reads the same bounded window, rebuilds the same de-duplicated, time-ordered
+array and upserts it (``on_conflict(call_id) do update``), so the post-call
+action, a manual re-sync, task retries and concurrent runs all converge on one
+row with the same contents.
 """
 from __future__ import annotations
 
@@ -17,7 +20,7 @@ from loguru import logger
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from core.models.call import Call
-from core.models.log_entry import PipelineLog
+from core.models.log_entry import CallPipelineLog
 from core.services.base import BaseService
 from core.services.loki_client import LokiClient
 from core.services.log_parser import extract_trace_id, fingerprint, parse_line
@@ -29,8 +32,7 @@ class SyncResult:
     """Outcome of a per-call sync — returned by the endpoint and logged by the job."""
 
     fetched: int = 0          # total lines returned by Loki (incl. page overlap)
-    inserted: int = 0         # rows newly written this run
-    skipped: int = 0          # unique rows already present (fingerprint dedup)
+    stored: int = 0           # unique lines in the stored array after this run
     pages: int = 0
     truncated: bool = False   # hit MAX_PAGES with more lines likely remaining
     window_start: Optional[datetime] = None
@@ -58,28 +60,28 @@ class PipelineLogSyncService(BaseService):
     ) -> dict:
         """Return stored log lines for a call, oldest first, for the viewer.
 
+        Reads the single ``call_pipeline_logs`` row and slices its ``logs`` array.
         Org-scoped via ``BaseService.query`` so a cross-org ``call_id`` returns an
         empty page rather than leaking another tenant's logs."""
-        base = self.query(PipelineLog).filter(PipelineLog.call_id == call_id)
+        row = self.query(CallPipelineLog).filter(CallPipelineLog.call_id == call_id).first()
+        entries: List[dict] = list(row.logs) if row and row.logs else []
         if level:
-            base = base.filter(PipelineLog.level == level.upper())
-        total = base.count()
-        rows = (
-            base.order_by(PipelineLog.ts.asc(), PipelineLog.ts_ns.asc())
-            .offset(max(offset, 0))
-            .limit(max(min(limit, 5000), 1))
-            .all()
-        )
+            lvl = level.upper()
+            entries = [e for e in entries if (e.get("level") or "").upper() == lvl]
+        total = len(entries)
+        lo = max(offset, 0)
+        hi = lo + max(min(limit, 5000), 1)
         return {
             "call_id": str(call_id),
             "total": total,
             "limit": limit,
             "offset": offset,
-            "items": [_row_payload(r) for r in rows],
+            "items": [_entry_payload(e) for e in entries[lo:hi]],
         }
 
     def sync_call(self, call: Call) -> SyncResult:
-        """Fetch ``call``'s Loki lines within its (buffered) time window and store them.
+        """Fetch ``call``'s Loki lines within its (buffered) time window and store them
+        as a single time-ordered array on one row.
 
         Safe no-op (returns zeros, never raises) when Loki read creds are absent
         or the call never got a ``trace_id``. Loki transport errors DO propagate
@@ -103,8 +105,8 @@ class PipelineLogSyncService(BaseService):
         # present on EVERY line (including early ones logged before the agent/call
         # id are known), so it's the fetch key — filtering on the full trace_id
         # would drop those setup lines. The prefix is only 8 hex chars, so a
-        # different call can share it; _rows_for_page disambiguates client-side by
-        # the fully-rendered trace_id before storing, so foreign lines aren't
+        # different call can share it; _entries_for_page disambiguates client-side
+        # by the fully-rendered trace_id before storing, so foreign lines aren't
         # misattributed to this call.
         call_uuid = call.trace_id.split("-", 1)[0]
         selector = (
@@ -117,6 +119,7 @@ class PipelineLogSyncService(BaseService):
         client = LokiClient()
         result = SyncResult(window_start=start_dt, window_end=end_dt)
         seen_fingerprints: set[str] = set()
+        entries: List[dict] = []
         cursor = start_ns
 
         for page in range(settings.LOKI_SYNC_MAX_PAGES):
@@ -128,11 +131,8 @@ class PipelineLogSyncService(BaseService):
                 break
             result.fetched += len(lines)
 
-            rows, max_ts = self._rows_for_page(call, lines, seen_fingerprints)
-            if rows:
-                inserted = self._insert(rows)
-                result.inserted += inserted
-                result.skipped += len(rows) - inserted
+            page_entries, max_ts = self._entries_for_page(call, lines, seen_fingerprints)
+            entries.extend(page_entries)
 
             # Last (partial) page → done.
             if len(lines) < settings.LOKI_SYNC_PAGE_LIMIT:
@@ -148,10 +148,15 @@ class PipelineLogSyncService(BaseService):
             # Exhausted MAX_PAGES with full pages throughout — more may remain.
             result.truncated = True
 
+        # Oldest first — pages come forward-ordered but sort defensively so a
+        # boundary overlap or out-of-order stream can't scramble the viewer.
+        entries.sort(key=lambda e: e["ts_ns"])
+        result.stored = self._upsert_call(call, entries)
+
         logger.info(
-            "[loki_sync] call={} window=[{} → {}] pages={} fetched={} inserted={} skipped_dup={} truncated={}",
+            "[loki_sync] call={} window=[{} → {}] pages={} fetched={} stored={} truncated={}",
             call.id, start_dt.isoformat(), end_dt.isoformat(),
-            result.pages, result.fetched, result.inserted, result.skipped, result.truncated,
+            result.pages, result.fetched, result.stored, result.truncated,
         )
         return result
 
@@ -174,11 +179,13 @@ class PipelineLogSyncService(BaseService):
             end_dt = start_dt + timedelta(seconds=settings.LOKI_SYNC_POST_BUFFER_SECONDS)
         return start_dt, end_dt
 
-    def _rows_for_page(self, call: Call, lines, seen: set) -> tuple[List[dict], int]:
-        """Build stamped row dicts for a page, deduping within-run by fingerprint.
+    def _entries_for_page(self, call: Call, lines, seen: set) -> tuple[List[dict], int]:
+        """Build JSON-safe log entries for a page, deduping within-run by fingerprint.
 
-        Returns the rows plus the max ts_ns seen (the pagination cursor)."""
-        rows: List[dict] = []
+        Returns the entries plus the max ts_ns seen (the pagination cursor). Each
+        entry is ``{ts, ts_ns, level, logger_name, message, raw_line}`` — identity
+        (call/org/agent/trace) is not repeated per line; it lives on the row."""
+        entries: List[dict] = []
         max_ts = 0
         for ln in lines:
             # max_ts advances over every fetched line (incl. dropped foreign ones)
@@ -186,8 +193,8 @@ class PipelineLogSyncService(BaseService):
             if ln.ts_ns > max_ts:
                 max_ts = ln.ts_ns
             # The prefix filter can match a different call that shares our 8-char
-            # short-uuid prefix; drop those instead of stamping them with this
-            # call's id. Lines with no parseable token are kept (never dropped).
+            # short-uuid prefix; drop those instead of attributing them to this
+            # call. Lines with no parseable token are kept (never dropped).
             if not _trace_belongs(extract_trace_id(ln.line), call.trace_id):
                 continue
             fp = fingerprint(ln.ts_ns, ln.labels, ln.line)
@@ -195,34 +202,48 @@ class PipelineLogSyncService(BaseService):
                 continue
             seen.add(fp)
             parsed = parse_line(ln.line)
-            rows.append(
+            entries.append(
                 {
-                    "id": uuid.uuid4(),
-                    # Stamped from the Call → reliable, tenant-scoped viewer queries.
-                    "organization_id": call.organization_id,
-                    "call_id": call.id,
-                    "agent_id": call.agent_id,
-                    "trace_id": call.trace_id,
-                    "ts": _from_ns(ln.ts_ns),
+                    "ts": _from_ns(ln.ts_ns).isoformat(),
                     "ts_ns": ln.ts_ns,
                     "level": parsed["level"],
                     "logger_name": parsed["logger_name"],
                     "message": parsed["message"],
                     "raw_line": ln.line,
-                    "labels": ln.labels or None,
-                    "fingerprint": fp,
                 }
             )
-        return rows, max_ts
+        return entries, max_ts
 
-    def _insert(self, rows: List[dict]) -> int:
-        """Idempotent bulk insert; returns the count of rows actually written."""
-        stmt = pg_insert(PipelineLog).values(rows).on_conflict_do_nothing(
-            index_elements=["fingerprint"]
+    def _upsert_call(self, call: Call, entries: List[dict]) -> int:
+        """Replace the call's stored log array in one idempotent upsert.
+
+        One row per call (``call_id`` UNIQUE): insert it or overwrite ``logs``
+        wholesale. Because ``entries`` is the full, deduped window every run, a
+        re-sync / retry / concurrent run converges on the same array — last write
+        wins with an equivalent value. Returns the stored line count."""
+        now = datetime.now(timezone.utc)
+        values = {
+            "id": uuid.uuid4(),
+            "organization_id": call.organization_id,
+            "call_id": call.id,
+            "agent_id": call.agent_id,
+            "trace_id": call.trace_id,
+            "logs": entries,
+            "synced_at": now,
+        }
+        stmt = pg_insert(CallPipelineLog).values(**values).on_conflict_do_update(
+            index_elements=["call_id"],
+            set_={
+                "logs": entries,
+                "agent_id": call.agent_id,
+                "trace_id": call.trace_id,
+                "synced_at": now,
+                "updated_at": now,
+            },
         )
-        result = self.db.execute(stmt)
+        self.db.execute(stmt)
         self.db.commit()
-        return result.rowcount or 0
+        return len(entries)
 
 
 def _trace_belongs(token: Optional[str], full_trace_id: str) -> bool:
@@ -253,8 +274,7 @@ def sync_result_payload(result: SyncResult) -> dict:
     """JSON-safe payload for the manual sync endpoint."""
     return {
         "fetched": result.fetched,
-        "inserted": result.inserted,
-        "skipped": result.skipped,
+        "stored": result.stored,
         "pages": result.pages,
         "truncated": result.truncated,
         "configured": result.configured,
@@ -264,12 +284,12 @@ def sync_result_payload(result: SyncResult) -> dict:
     }
 
 
-def _row_payload(row: PipelineLog) -> dict:
+def _entry_payload(entry: dict) -> dict:
+    """Viewer-facing shape for one stored log entry."""
     return {
-        "id": str(row.id),
-        "ts": row.ts.isoformat() if row.ts else None,
-        "level": row.level,
-        "logger_name": row.logger_name,
-        "message": row.message,
-        "raw_line": row.raw_line,
+        "ts": entry.get("ts"),
+        "level": entry.get("level"),
+        "logger_name": entry.get("logger_name"),
+        "message": entry.get("message"),
+        "raw_line": entry.get("raw_line"),
     }

--- a/core/services/post_call/actions/sync_loki_logs.py
+++ b/core/services/post_call/actions/sync_loki_logs.py
@@ -7,7 +7,7 @@ from shared.config import settings
 
 
 class SyncLokiLogsAction(PostCallAction):
-    """Read the just-ended call's log lines back from Loki into ``pipeline_logs``.
+    """Read the just-ended call's log lines back from Loki into ``call_pipeline_logs``.
 
     No enable/disable flag — always wired. Safe no-op when Loki read creds are
     absent (local dev) or the call never got a ``trace_id``, so nothing to fetch.

--- a/ee/api/v1/call_logs.py
+++ b/ee/api/v1/call_logs.py
@@ -131,7 +131,7 @@ def sync_call_logs(
     claims: EEJWTClaims = Depends(require_ee_org_member),
     db: Session = Depends(get_db),
 ):
-    """Read this call's log lines back from Loki into ``pipeline_logs`` (inline).
+    """Read this call's log lines back from Loki into ``call_pipeline_logs`` (inline).
     Idempotent — see the OSS twin in ``core/api/v1/call_logs.py``."""
     svc = PipelineLogSyncService(db, org_id=UUID(claims.org_id))
     try:

--- a/test-cases/test_loki_log_sync.py
+++ b/test-cases/test_loki_log_sync.py
@@ -1,10 +1,11 @@
 """Hermetic unit tests for the per-call Loki -> Postgres log sync.
 
 No live database, no network: the Loki HTTP layer is stubbed (fake httpx.Client)
-and the DB insert is simulated with a fingerprint set that mimics the real
-UNIQUE-constraint dedup. Covers the parser, fingerprint, LokiClient retry/backoff,
-the sync service (insert + idempotent re-run + short-circuits + pagination + clock
-skew), and the post-call action enqueue guard.
+and the DB upsert is simulated by capturing the wholesale ``logs`` array written
+per call (mimicking the real ``on_conflict(call_id) do update`` replace). Covers
+the parser, fingerprint, LokiClient retry/backoff, the sync service (array build
++ idempotent re-run + short-circuits + pagination + clock skew), and the
+post-call action enqueue guard.
 """
 from __future__ import annotations
 
@@ -161,16 +162,16 @@ def test_query_range_401_is_non_retryable(fake_httpx):
 # ── PipelineLogSyncService ───────────────────────────────────────────────────
 
 class _FakeDB:
-    """DB stand-in that mimics the fingerprint UNIQUE dedup across runs."""
+    """Captures the wholesale ``logs`` array written per call (upsert-replace)."""
 
     def __init__(self):
-        self.stored_fingerprints: set[str] = set()
-        self.inserted_rows: list[dict] = []
+        self.stored: dict = {}    # call_id -> list[entry] (the row's logs array)
+        self.upserts: list = []   # (call, entries) per _upsert_call
 
 
 def _stub_service(monkeypatch, db, pages):
     """Return a service whose LokiClient yields ``pages`` (list of line-lists) and
-    whose _insert simulates on_conflict_do_nothing against ``db``."""
+    whose _upsert_call replaces the call's stored array against ``db``."""
     monkeypatch.setattr(settings, "loki_read_configured", lambda: True)
     monkeypatch.setattr(settings, "LOKI_SYNC_PAGE_LIMIT", 2)
 
@@ -185,14 +186,13 @@ def _stub_service(monkeypatch, db, pages):
         "core.services.pipeline_log_sync_service.LokiClient", _StubClient
     )
 
-    def fake_insert(self, rows):
-        new = [r for r in rows if r["fingerprint"] not in db.stored_fingerprints]
-        for r in new:
-            db.stored_fingerprints.add(r["fingerprint"])
-            db.inserted_rows.append(r)
-        return len(new)
+    def fake_upsert(self, call, entries):
+        # Wholesale replace — exactly what on_conflict(call_id) do update does.
+        db.stored[call.id] = list(entries)
+        db.upserts.append((call, list(entries)))
+        return len(entries)
 
-    monkeypatch.setattr(PipelineLogSyncService, "_insert", fake_insert)
+    monkeypatch.setattr(PipelineLogSyncService, "_upsert_call", fake_upsert)
     return PipelineLogSyncService(SimpleNamespace(), org_id=uuid.uuid4())
 
 
@@ -222,7 +222,7 @@ def _window_ns(offset: int = 0) -> int:
     return int((datetime.now(timezone.utc) - timedelta(seconds=60)).timestamp() * 1_000_000_000) + offset
 
 
-def test_sync_inserts_and_stamps_from_call(monkeypatch):
+def test_sync_builds_array_and_stamps_from_call(monkeypatch):
     db = _FakeDB()
     call = _make_call()
     svc = _stub_service(
@@ -232,16 +232,22 @@ def test_sync_inserts_and_stamps_from_call(monkeypatch):
 
     result = svc.sync_call(call)
 
-    assert result.inserted == 3
-    assert result.skipped == 0
+    assert result.stored == 3
     assert result.pages == 2  # full first page forces a second fetch
-    # Identity columns are stamped from the Call, not parsed.
-    for row in db.inserted_rows:
-        assert row["call_id"] == call.id
-        assert row["organization_id"] == call.organization_id
-        assert row["agent_id"] == call.agent_id
-        assert row["trace_id"] == call.trace_id
-        assert row["fingerprint"]
+
+    entries = db.stored[call.id]
+    # One row per call: all lines land in a single time-ordered array.
+    assert [e["raw_line"] for e in entries] == ["a", "b", "c"]
+    assert [e["ts_ns"] for e in entries] == sorted(e["ts_ns"] for e in entries)
+    # Entry shape — identity is NOT repeated per line; it lives on the row.
+    for e in entries:
+        assert set(e) == {"ts", "ts_ns", "level", "logger_name", "message", "raw_line"}
+    # Identity stamped from the Call onto the row (via _upsert_call).
+    upsert_call, _ = db.upserts[-1]
+    assert upsert_call.id == call.id
+    assert upsert_call.organization_id == call.organization_id
+    assert upsert_call.agent_id == call.agent_id
+    assert upsert_call.trace_id == call.trace_id
 
 
 def test_sync_is_idempotent_on_rerun(monkeypatch):
@@ -249,13 +255,14 @@ def test_sync_is_idempotent_on_rerun(monkeypatch):
     call = _make_call()
     pages = [[_line(_window_ns(1), "a"), _line(_window_ns(2), "b")], [_line(_window_ns(3), "c")]]
     svc1 = _stub_service(monkeypatch, db, pages=[list(p) for p in pages])
-    assert svc1.sync_call(call).inserted == 3
+    assert svc1.sync_call(call).stored == 3
 
-    # Second run against the same fingerprint store: nothing new.
+    # Second run re-reads the same window and replaces the array wholesale:
+    # the stored row still has exactly the same 3 lines, never 6.
     svc2 = _stub_service(monkeypatch, db, pages=[list(p) for p in pages])
     second = svc2.sync_call(call)
-    assert second.inserted == 0
-    assert second.skipped == 3
+    assert second.stored == 3
+    assert [e["raw_line"] for e in db.stored[call.id]] == ["a", "b", "c"]
 
 
 def test_sync_short_circuits_when_not_configured(monkeypatch):
@@ -263,14 +270,14 @@ def test_sync_short_circuits_when_not_configured(monkeypatch):
     svc = PipelineLogSyncService(SimpleNamespace(), org_id=uuid.uuid4())
     result = svc.sync_call(_make_call())
     assert result.configured is False
-    assert result.inserted == 0
+    assert result.stored == 0
 
 
 def test_sync_short_circuits_without_trace_id(monkeypatch):
     monkeypatch.setattr(settings, "loki_read_configured", lambda: True)
     svc = PipelineLogSyncService(SimpleNamespace(), org_id=uuid.uuid4())
     result = svc.sync_call(_make_call(trace_id=None))
-    assert result.inserted == 0
+    assert result.stored == 0
     assert "trace_id" in result.message
 
 
@@ -294,8 +301,8 @@ def test_sync_drops_foreign_prefix_collision(monkeypatch):
 
     result = svc.sync_call(call)
 
-    assert result.inserted == 1
-    assert [r["raw_line"] for r in db.inserted_rows] == [ours]
+    assert result.stored == 1
+    assert [e["raw_line"] for e in db.stored[call.id]] == [ours]
 
 
 def test_sync_keeps_early_prefix_only_lines(monkeypatch):
@@ -311,8 +318,8 @@ def test_sync_keeps_early_prefix_only_lines(monkeypatch):
 
     result = svc.sync_call(call)
 
-    assert result.inserted == 1
-    assert db.inserted_rows[0]["raw_line"] == early
+    assert result.stored == 1
+    assert db.stored[call.id][0]["raw_line"] == early
 
 
 def test_sync_clamps_future_ended_at(monkeypatch):


### PR DESCRIPTION
## What
Replaces the per-line `pipeline_logs` table with a per-call `call_pipeline_logs` table that stores **all of a call's log lines as a single `logs` JSONB array on ONE row** (keyed by `call_id`, UNIQUE). Each element is `{ts, ts_ns, level, logger_name, message, raw_line}`.

## Why
A single call produced 150–1216 separate `pipeline_logs` rows, cluttering the table. The viewer reads a call at a time, so one row per call is a better fit.

## How idempotency is preserved
Each sync re-reads the same bounded call window, rebuilds the deduped, time-ordered array, and upserts it (`on_conflict(call_id) do update` — wholesale replace). Post-call action, manual re-sync, task retries and concurrent runs all converge on one row. No per-line `fingerprint` unique key needed.

## Migration `d4b2f8a1c6e3`
- **DROPs `pipeline_logs`** (existing rows discarded — they re-populate on next sync) and creates `call_pipeline_logs`.
- Migrations are run manually (`alembic upgrade head`) — not in CI. Run against each env **with/after** the new image deploys.

## Tests
- 21/21 hermetic unit tests pass (rewritten for the array shape).
- Real-Postgres upsert verified: JSONB round-trips, wholesale-replace idempotency (3→2), one row per call — run in a rolled-back txn.
- `list_for_call` slicing / case-insensitive level filter / cross-org empty-page validated.

## Notes
- `ts_ns` (1.7e18, exceeds JS safe int) is server-side only; the viewer payload never exposes it.
- Endpoints (core + ee) unchanged except docstrings — signatures preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)