### PR TITLE
Dev → Staging: per-call log JSON array + loki-sync fixes + auth cookies + agent readiness

### DIFF
--- a/alembic/versions/d4b2f8a1c6e3_call_pipeline_logs_json_array.py
+++ b/alembic/versions/d4b2f8a1c6e3_call_pipeline_logs_json_array.py
@@ -1,0 +1,94 @@
+"""replace per-line pipeline_logs with per-call call_pipeline_logs (JSON array)
+
+Drops the per-line ``pipeline_logs`` table (its rows are discarded — they
+re-populate on the next sync) and creates ``call_pipeline_logs``, which stores
+ALL of a call's log lines as a single ``logs`` JSONB array on ONE row keyed by
+``call_id`` (UNIQUE). The per-call viewer now reads one row; a re-sync replaces
+the array wholesale. Idempotency comes from the bounded per-call fetch window,
+so no per-line ``fingerprint`` unique key is needed anymore.
+
+See ``core/models/log_entry.py`` (``CallPipelineLog``) and
+``PipelineLogSyncService``.
+
+Revision ID: d4b2f8a1c6e3
+Revises: a1c9f4e7b2d5
+Create Date: 2026-07-17
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "d4b2f8a1c6e3"
+down_revision = "a1c9f4e7b2d5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Discard the per-line table entirely (existing rows are not migrated —
+    # they re-populate from Loki on the next per-call sync).
+    op.drop_index("ix_pipeline_logs_call_ts", table_name="pipeline_logs")
+    op.drop_table("pipeline_logs")
+
+    op.create_table(
+        "call_pipeline_logs",
+        # OrgScopedModel columns.
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False, index=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        # Identity — stamped from the Call. One row per call.
+        sa.Column(
+            "call_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("calls.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=True, index=True),
+        sa.Column("trace_id", sa.String(128), nullable=True, index=True),
+        # All of the call's lines as one time-ordered JSON array.
+        sa.Column(
+            "logs",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("synced_at", sa.DateTime(timezone=True), nullable=True),
+        # One row per call → the upsert conflict target and the viewer lookup key.
+        # The UNIQUE constraint's index also serves call_id lookups (no separate index).
+        sa.UniqueConstraint("call_id", name="uq_call_pipeline_logs_call_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("call_pipeline_logs")
+
+    # Recreate the per-line table exactly as a1c9f4e7b2d5 created it.
+    op.create_table(
+        "pipeline_logs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False, index=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column(
+            "call_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("calls.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=True, index=True),
+        sa.Column("trace_id", sa.String(128), nullable=True, index=True),
+        sa.Column("ts", sa.DateTime(timezone=True), nullable=False, index=True),
+        sa.Column("ts_ns", sa.BigInteger(), nullable=False),
+        sa.Column("level", sa.String(16), nullable=True),
+        sa.Column("logger_name", sa.String(255), nullable=True),
+        sa.Column("message", sa.Text(), nullable=True),
+        sa.Column("raw_line", sa.Text(), nullable=False),
+        sa.Column("labels", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("fingerprint", sa.String(64), nullable=False),
+        sa.UniqueConstraint("fingerprint", name="uq_pipeline_logs_fingerprint"),
+    )
+    op.create_index("ix_pipeline_logs_call_ts", "pipeline_logs", ["call_id", "ts"])

--- a/build/kubernetes/staging-aws/api/ingress.yaml
+++ b/build/kubernetes/staging-aws/api/ingress.yaml
@@ -6,7 +6,11 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"
     nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+    # Credentialed (cookie) auth forbids `Allow-Origin: *`. This wildcard-
+    # subdomain form matches any https://<sub>.trytone.ai and makes nginx echo
+    # back the CONCRETE request origin (e.g. https://staging.trytone.ai), which
+    # is valid with credentials. Requires ingress-nginx controller v1.4.0+.
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://*.trytone.ai"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, PUT, DELETE, OPTIONS, PATCH"
     nginx.ingress.kubernetes.io/cors-allow-headers: "DNT, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Range, Authorization, X-Auth-Token, X-Org-Id, X-Tenant-Id, tenant_id, Accept, Origin, Referer"
     nginx.ingress.kubernetes.io/cors-expose-headers: "Content-Length, Content-Range, Content-Type, X-Request-Id"

--- a/core/api/v1/auth.py
+++ b/core/api/v1/auth.py
@@ -1,13 +1,16 @@
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request, Response, status
 from sqlalchemy.orm import Session
 
 from core.database.session import get_db
 from core.middleware.auth import (
     JWTClaims,
+    REFRESH_COOKIE,
+    clear_auth_cookies,
     get_jwt_claims,
     get_optional_jwt_claims,
+    set_cookies_and_strip,
 )
 from core.services.auth_service import AuthService
 from core.utils.device import extract_device_context
@@ -21,6 +24,7 @@ router = APIRouter()
 @router.post("/signup", status_code=status.HTTP_201_CREATED)
 def signup(
     request: Request,
+    response: Response,
     user_data: Dict[str, Any] = Body(...),
     db: Session = Depends(get_db),
 ):
@@ -46,7 +50,7 @@ def signup(
             detail="first_name is required",
         )
 
-    return AuthService(db).signup_v2(
+    result = AuthService(db).signup_v2(
         email=email,
         password=password,
         first_name=first_name,
@@ -54,11 +58,13 @@ def signup(
         organization_name=organization_name,
         device=extract_device_context(request),
     )
+    return set_cookies_and_strip(response, result)
 
 
 @router.post("/login")
 def login(
     request: Request,
+    response: Response,
     login_data: Dict[str, str] = Body(...),
     db: Session = Depends(get_db),
 ):
@@ -69,7 +75,8 @@ def login(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Email and password are required",
         )
-    return AuthService(db).login_v2(email, password, device=extract_device_context(request))
+    result = AuthService(db).login_v2(email, password, device=extract_device_context(request))
+    return set_cookies_and_strip(response, result)
 
 
 @router.post("/signin-code/request")
@@ -85,6 +92,7 @@ def request_signin_code(body: Dict[str, str] = Body(...), db: Session = Depends(
 @router.post("/signin-code/verify")
 def verify_signin_code(
     request: Request,
+    response: Response,
     body: Dict[str, str] = Body(...),
     db: Session = Depends(get_db),
 ):
@@ -95,29 +103,42 @@ def verify_signin_code(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="email and code are required",
         )
-    return AuthService(db).verify_signin_code(
+    result = AuthService(db).verify_signin_code(
         email, code, device=extract_device_context(request),
     )
+    return set_cookies_and_strip(response, result)
 
 
 @router.post("/refresh")
 def refresh(
     request: Request,
-    body: Dict[str, str] = Body(...),
+    response: Response,
+    body: Dict[str, str] = Body(default={}),
     db: Session = Depends(get_db),
 ):
-    refresh_token = body.get("refresh_token")
+    # Prefer the httpOnly refresh cookie; fall back to a body token for
+    # non-browser clients and the pre-cookie migration window.
+    refresh_token = request.cookies.get(REFRESH_COOKIE) or (body or {}).get("refresh_token")
     if not refresh_token:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="refresh_token is required",
         )
-    return AuthService(db).refresh_tokens(refresh_token, device=extract_device_context(request))
+    result = AuthService(db).refresh_tokens(refresh_token, device=extract_device_context(request))
+    return set_cookies_and_strip(response, result)
 
 
 @router.post("/logout")
-def logout(body: Dict[str, Any] = Body(default={}), db: Session = Depends(get_db)):
-    return AuthService(db).logout(refresh_token=body.get("refresh_token"))
+def logout(
+    request: Request,
+    response: Response,
+    body: Dict[str, Any] = Body(default={}),
+    db: Session = Depends(get_db),
+):
+    refresh_token = request.cookies.get(REFRESH_COOKIE) or (body or {}).get("refresh_token")
+    result = AuthService(db).logout(refresh_token=refresh_token)
+    clear_auth_cookies(response)
+    return result
 
 
 @router.post("/verify-email")
@@ -193,6 +214,7 @@ def validate_invitation(token: str = Query(...), db: Session = Depends(get_db)):
 @router.post("/accept-invitation")
 def accept_invitation(
     request: Request,
+    response: Response,
     body: Dict[str, Any] = Body(...),
     db: Session = Depends(get_db),
     claims: Optional[JWTClaims] = Depends(get_optional_jwt_claims),
@@ -202,7 +224,7 @@ def accept_invitation(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="token is required"
         )
-    return AuthService(db).accept_invitation_by_token(
+    result = AuthService(db).accept_invitation_by_token(
         token=token,
         password=body.get("password"),
         first_name=body.get("first_name"),
@@ -210,6 +232,7 @@ def accept_invitation(
         current_user_id=claims.user_id if claims else None,
         device=extract_device_context(request),
     )
+    return set_cookies_and_strip(response, result)
 
 
 # ── Legacy aliases (kept for older clients) ────────────────────────────

--- a/core/api/v1/call_logs.py
+++ b/core/api/v1/call_logs.py
@@ -175,11 +175,11 @@ def sync_call_logs(
     claims: JWTClaims = Depends(require_org_member),
     db: Session = Depends(get_db),
 ):
-    """Read this call's log lines back from Loki into ``pipeline_logs`` (inline).
+    """Read this call's log lines back from Loki into ``call_pipeline_logs`` (inline).
 
     The on-demand trigger for the per-call log store — same service the
-    ``sync_loki_logs`` post-call action runs. Idempotent: a re-run inserts 0 and
-    reports all skipped (fingerprint dedup)."""
+    ``sync_loki_logs`` post-call action runs. Idempotent: a re-run re-reads the
+    same window and replaces the call's stored log array wholesale."""
     svc = PipelineLogSyncService(db, org_id=_org_id(claims))
     try:
         result = svc.sync_call_by_id(_parse_call_id(call_id))

--- a/core/jobs/sync_loki.py
+++ b/core/jobs/sync_loki.py
@@ -10,11 +10,12 @@ from core.services.pipeline_log_sync_service import PipelineLogSyncService
 
 
 def sync_call_logs(call_id: str) -> None:
-    """Read a finished call's log lines from Loki into ``pipeline_logs``.
+    """Read a finished call's log lines from Loki into ``call_pipeline_logs``.
 
     Runs inside the ``sync_loki_logs`` procrastinate task, deferred with a delay
     after the call ends so Loki has ingested the call's teardown lines. Idempotent
-    (fingerprint dedup), so task-level retries are safe. A missing call is a no-op
+    (the array is rebuilt from the same window and replaced), so task-level
+    retries are safe. A missing call is a no-op
     (it may have been deleted between defer and run)."""
     with get_db_context() as db:
         call = db.query(Call).filter(Call.id == UUID(call_id)).first()
@@ -23,6 +24,6 @@ def sync_call_logs(call_id: str) -> None:
             return
         result = PipelineLogSyncService(db, org_id=call.organization_id).sync_call(call)
     logger.info(
-        "[loki_sync] job done call={} inserted={} skipped_dup={} fetched={}",
-        call_id, result.inserted, result.skipped, result.fetched,
+        "[loki_sync] job done call={} fetched={} stored={}",
+        call_id, result.fetched, result.stored,
     )

--- a/core/middleware/auth.py
+++ b/core/middleware/auth.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from fastapi import HTTPException, status, Depends
+from fastapi import HTTPException, status, Depends, Request, Response
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from typing import Optional, Dict, Any, Union
 from uuid import UUID
@@ -14,6 +14,99 @@ from core.internal.capabilities import is_ee_enabled
 
 
 security = HTTPBearer()
+
+# ── httpOnly auth-cookie transport ──────────────────────────────────────
+# Access/refresh JWTs live in httpOnly cookies (unreadable by JS) instead of
+# localStorage. The access cookie is sent on every request (path=/); the
+# refresh cookie is scoped to the auth routes so it isn't attached to normal
+# API traffic. Attributes come from settings so dev (host-only, insecure) and
+# prod (.trytone.ai, secure) differ only by config.
+ACCESS_COOKIE = "access_token"
+REFRESH_COOKIE = "refresh_token"
+# Both cookies are set site-wide (Path=/). Scoping the refresh cookie to the
+# auth routes was a minor hardening, but a path-scoped Set-Cookie is fragile
+# behind the Next.js dev proxy (the site-wide access cookie survives while the
+# scoped refresh cookie gets dropped — e.g. on org-switch). Keeping them
+# symmetric makes set/rotate/clear behave identically. Still httpOnly + Secure.
+REFRESH_COOKIE_PATH = "/"
+
+
+def _cookie_attrs() -> Dict[str, Any]:
+    return {
+        "httponly": True,
+        "secure": settings.COOKIE_SECURE,
+        "samesite": settings.COOKIE_SAMESITE,
+        "domain": settings.COOKIE_DOMAIN or None,
+    }
+
+
+def set_auth_cookies(
+    response: Response,
+    access_token: str,
+    refresh_token: Optional[str] = None,
+) -> None:
+    """Attach the access (and optionally refresh) JWT as httpOnly cookies.
+
+    Both cookies are given the *session* (refresh-token) lifetime, not the
+    short access-token TTL. The access JWT inside still expires quickly and is
+    rotated by silent ``/auth/refresh``; keeping the cookie alive for the whole
+    session means the Next.js middleware's presence-check and the silent
+    refresh keep working after the JWT expires — otherwise the user would be
+    bounced to /login every time the access token lapsed.
+    """
+    attrs = _cookie_attrs()
+    session_max_age = settings.REFRESH_TOKEN_EXPIRE_DAYS * 86400
+    response.set_cookie(
+        key=ACCESS_COOKIE,
+        value=access_token,
+        max_age=session_max_age,
+        path="/",
+        **attrs,
+    )
+    if refresh_token is not None:
+        response.set_cookie(
+            key=REFRESH_COOKIE,
+            value=refresh_token,
+            max_age=session_max_age,
+            path=REFRESH_COOKIE_PATH,
+            **attrs,
+        )
+
+
+def clear_auth_cookies(response: Response) -> None:
+    """Expire both auth cookies (used on logout). Attributes must match the
+    ones used to set them or the browser keeps the cookie."""
+    domain = settings.COOKIE_DOMAIN or None
+    response.delete_cookie(
+        key=ACCESS_COOKIE, path="/", domain=domain,
+        secure=settings.COOKIE_SECURE, httponly=True, samesite=settings.COOKIE_SAMESITE,
+    )
+    response.delete_cookie(
+        key=REFRESH_COOKIE, path=REFRESH_COOKIE_PATH, domain=domain,
+        secure=settings.COOKIE_SECURE, httponly=True, samesite=settings.COOKIE_SAMESITE,
+    )
+
+
+def set_cookies_and_strip(response: Response, result: Dict[str, Any]) -> Dict[str, Any]:
+    """Move any tokens in an auth-service result dict into httpOnly cookies and
+    drop them from the JSON body. No-op when the result carries no access token
+    (e.g. signup pending email verification, invite-accept without auto-login)."""
+    if isinstance(result, dict) and result.get("access_token"):
+        set_auth_cookies(response, result["access_token"], result.get("refresh_token"))
+        return {k: v for k, v in result.items() if k not in ("access_token", "refresh_token")}
+    return result
+
+
+def get_bearer_or_cookie_token(request: Request) -> Optional[str]:
+    """Extract the access token from the ``Authorization: Bearer`` header if
+    present, else from the httpOnly access cookie. Header support is kept so
+    non-browser API clients (and the migration window) keep working."""
+    auth_header = request.headers.get("Authorization") or request.headers.get("authorization")
+    if auth_header:
+        scheme, _, credentials = auth_header.partition(" ")
+        if scheme.lower() == "bearer" and credentials:
+            return credentials.strip()
+    return request.cookies.get(ACCESS_COOKIE)
 
 class JWTClaims(BaseModel):
     user_id: str
@@ -197,10 +290,16 @@ def _enforce_active_session(claims: JWTClaims, db) -> None:
 
 
 def get_jwt_claims(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    request: Request,
     db=Depends(get_db),
 ) -> JWTClaims:
-    claims = jwt_manager.verify_token(credentials)
+    token = get_bearer_or_cookie_token(request)
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+        )
+    claims = jwt_manager.decode_token(token)
     if is_ee_enabled() and claims.org_id:
         org_id = claims.org_id
     else:
@@ -211,12 +310,13 @@ def get_jwt_claims(
 
 
 def get_optional_jwt_claims(
-    credentials: Optional[HTTPAuthorizationCredentials] = Depends(HTTPBearer(auto_error=False)),
+    request: Request,
     db=Depends(get_db),
 ) -> Optional[JWTClaims]:
-    if not credentials:
+    token = get_bearer_or_cookie_token(request)
+    if not token:
         return None
-    claims = jwt_manager.verify_token(credentials)
+    claims = jwt_manager.decode_token(token)
     _enforce_active_session(claims, db)
     return claims
 

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -49,7 +49,7 @@ from core.models.pod import Pod
 # Calls & Metrics
 from core.models.call import Call
 from core.models.call_metrics import CallMetrics
-from core.models.log_entry import PipelineLog
+from core.models.log_entry import CallPipelineLog
 from core.models.scheduled_call import ScheduledCall
 from core.models.tool_execution import ToolExecution
 from core.models.webhook import Webhook

--- a/core/models/log_entry.py
+++ b/core/models/log_entry.py
@@ -1,66 +1,51 @@
 from sqlalchemy import (
-    BigInteger,
     Column,
     DateTime,
     ForeignKey,
-    Index,
     String,
-    Text,
-    UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 from core.models.base import OrgScopedModel
 
 
-class PipelineLog(OrgScopedModel):
-    """One log line of a single finished call, read back from Grafana Loki.
+class CallPipelineLog(OrgScopedModel):
+    """All of one finished call's log lines, read back from Grafana Loki and
+    stored as a single JSON array — ONE row per call.
 
-    Populated by ``PipelineLogSyncService`` after a call ends (via the
-    ``sync_loki_logs`` post-call action or the manual sync endpoint) to power an
-    in-product per-call log viewer. Identity columns (``call_id``,
-    ``organization_id``, ``agent_id``, ``trace_id``) are STAMPED from the ``Call``
-    row — never parsed from the line text — so viewer queries stay tenant-scoped
-    and reliable. Only ``level``/``logger_name``/``message`` are parsed from the
-    raw line, defensively (``raw_line`` always preserves the original).
+    Replaces the earlier per-line ``pipeline_logs`` table: a call's lines now
+    live in the ``logs`` JSONB array on a single row keyed by ``call_id``
+    (UNIQUE), so the per-call viewer reads one row and a re-sync replaces the
+    array wholesale. Populated by ``PipelineLogSyncService`` after a call ends
+    (via the ``sync_loki_logs`` post-call action or the manual sync endpoint).
+    Identity columns (``call_id``/``organization_id``/``agent_id``/``trace_id``)
+    are STAMPED from the ``Call`` row — never parsed from the line text — so
+    viewer queries stay tenant-scoped and reliable.
 
-    ``fingerprint`` (sha256 of ts + labels + line) is UNIQUE so re-runs of the
-    same call — the post-call action and a manual re-sync, task retries,
-    concurrent runs — are idempotent via ``on_conflict_do_nothing``.
+    Idempotency comes from the bounded per-call fetch window, not a per-line
+    unique key: every sync re-reads the same window, rebuilds the same
+    de-duplicated, time-ordered array, and upserts it
+    (``on_conflict(call_id) do update``). So the post-call action, a manual
+    re-sync, task retries and concurrent runs all converge on one row with the
+    same contents. Each ``logs`` element is
+    ``{ts, ts_ns, level, logger_name, message, raw_line}``; identity is not
+    repeated per element (it lives on the row).
     """
 
-    __tablename__ = "pipeline_logs"
+    __tablename__ = "call_pipeline_logs"
 
     call_id = Column(
         UUID(as_uuid=True),
         ForeignKey("calls.id", ondelete="CASCADE"),
         nullable=False,
-        index=True,
+        # UNIQUE — one row per call; its index also serves the viewer lookup.
+        unique=True,
     )
     agent_id = Column(UUID(as_uuid=True), nullable=True, index=True)
     trace_id = Column(String(128), nullable=True, index=True)
 
-    # Loki line timestamp. ``ts`` is tz-aware for range queries; ``ts_ns`` keeps
-    # the original nanosecond precision Loki reports (and drives pagination).
-    ts = Column(DateTime(timezone=True), nullable=False, index=True)
-    ts_ns = Column(BigInteger, nullable=False)
-
-    # Parsed defensively from the line — any may be NULL on a non-matching or
-    # multiline line, in which case ``message`` falls back to the whole line.
-    level = Column(String(16), nullable=True)
-    logger_name = Column(String(255), nullable=True)
-    message = Column(Text, nullable=True)
-
-    # The original Loki line, always stored verbatim (never dropped).
-    raw_line = Column(Text, nullable=False)
-    # Loki stream labels for the line (app, namespace, pod, …).
-    labels = Column(JSONB, nullable=True)
-
-    # sha256(ts_ns + sorted labels + raw line). Deterministic → dedup key.
-    fingerprint = Column(String(64), nullable=False)
-
-    __table_args__ = (
-        UniqueConstraint("fingerprint", name="uq_pipeline_logs_fingerprint"),
-        # Primary viewer access path: a call's lines in time order.
-        Index("ix_pipeline_logs_call_ts", "call_id", "ts"),
-    )
+    # Time-ordered (oldest first) array of the call's log lines. Each element is
+    # {ts, ts_ns, level, logger_name, message, raw_line}.
+    logs = Column(JSONB, nullable=False, default=list)
+    # When ``logs`` was last (re)synced from Loki.
+    synced_at = Column(DateTime(timezone=True), nullable=True)

--- a/core/services/auth_service.py
+++ b/core/services/auth_service.py
@@ -108,6 +108,38 @@ class AuthService(BaseService):
         role = member.role if member else user.role
         return org_obj, org_id, role
 
+    def _resolve_refresh_org_role(
+        self,
+        user: User,
+        requested_org_id: Optional[str],
+    ) -> Tuple[Optional[Organization], Optional[str], Optional[str]]:
+        """Org/role for a token rotation.
+
+        Preserves the org the incoming refresh token was minted for (e.g. the
+        org the user switched into) as long as they are still a member of it —
+        so a silent ``/auth/refresh`` does not revert them to their default
+        org. Falls back to the default membership when the requested org is
+        absent or membership has since been revoked.
+        """
+        if requested_org_id:
+            oid = _user_uuid(requested_org_id)
+            member = (
+                self.db.query(Member)
+                .filter(Member.user_id == user.id, Member.organization_id == oid)
+                .first()
+                if oid
+                else None
+            )
+            if member:
+                org_obj = (
+                    self.db.query(Organization)
+                    .filter(Organization.id == oid)
+                    .first()
+                )
+                if org_obj:
+                    return org_obj, str(org_obj.id), member.role
+        return self._resolve_member_org_role(user)
+
     def _token_response(
         self,
         user: User,
@@ -527,7 +559,9 @@ class AuthService(BaseService):
                 detail="User not found or inactive",
             )
 
-        org_obj, org_id, role = self._resolve_member_org_role(user)
+        # Keep the org the token was minted for (e.g. after an org switch)
+        # instead of always reverting to the default membership.
+        org_obj, org_id, role = self._resolve_refresh_org_role(user, payload.get("org_id"))
 
         new_access_token = jwt_manager.create_access_token(
             user_id=str(user.id),

--- a/core/services/pipeline_log_sync_service.py
+++ b/core/services/pipeline_log_sync_service.py
@@ -107,7 +107,12 @@ class PipelineLogSyncService(BaseService):
         # the fully-rendered trace_id before storing, so foreign lines aren't
         # misattributed to this call.
         call_uuid = call.trace_id.split("-", 1)[0]
-        query = f'{{app="{settings.LOKI_SYNC_APP_LABEL}"}} |= "trace_id={call_uuid}"'
+        selector = (
+            f'{{app="{settings.LOKI_SYNC_APP_LABEL}"}}'
+            if settings.LOKI_SYNC_APP_LABEL
+            else '{component=~"call|api"}'
+        )
+        query = f'{selector} |= "trace_id={call_uuid}"'
 
         client = LokiClient()
         result = SyncResult(window_start=start_dt, window_end=end_dt)

--- a/core/services/pipeline_log_sync_service.py
+++ b/core/services/pipeline_log_sync_service.py
@@ -1,10 +1,13 @@
-"""Read one finished call's log lines back from Loki into ``pipeline_logs``.
+"""Read one finished call's log lines back from Loki into ``call_pipeline_logs``.
 
 The service behind both the ``sync_loki_logs`` post-call action and the manual
 ``POST /call-log/{call_id}/sync-logs`` endpoint. Scoped to a single call, so the
-time window is bounded and known up front; a deterministic ``fingerprint`` unique
-index makes every re-run idempotent (post-call action + manual re-sync + task
-retry + concurrent runs all converge on the same rows).
+time window is bounded and known up front. All of the call's lines are stored as
+a single ``logs`` JSON array on ONE row keyed by ``call_id``; every re-run
+re-reads the same bounded window, rebuilds the same de-duplicated, time-ordered
+array and upserts it (``on_conflict(call_id) do update``), so the post-call
+action, a manual re-sync, task retries and concurrent runs all converge on one
+row with the same contents.
 """
 from __future__ import annotations
 
@@ -17,7 +20,7 @@ from loguru import logger
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from core.models.call import Call
-from core.models.log_entry import PipelineLog
+from core.models.log_entry import CallPipelineLog
 from core.services.base import BaseService
 from core.services.loki_client import LokiClient
 from core.services.log_parser import extract_trace_id, fingerprint, parse_line
@@ -29,8 +32,7 @@ class SyncResult:
     """Outcome of a per-call sync — returned by the endpoint and logged by the job."""
 
     fetched: int = 0          # total lines returned by Loki (incl. page overlap)
-    inserted: int = 0         # rows newly written this run
-    skipped: int = 0          # unique rows already present (fingerprint dedup)
+    stored: int = 0           # unique lines in the stored array after this run
     pages: int = 0
     truncated: bool = False   # hit MAX_PAGES with more lines likely remaining
     window_start: Optional[datetime] = None
@@ -58,28 +60,28 @@ class PipelineLogSyncService(BaseService):
     ) -> dict:
         """Return stored log lines for a call, oldest first, for the viewer.
 
+        Reads the single ``call_pipeline_logs`` row and slices its ``logs`` array.
         Org-scoped via ``BaseService.query`` so a cross-org ``call_id`` returns an
         empty page rather than leaking another tenant's logs."""
-        base = self.query(PipelineLog).filter(PipelineLog.call_id == call_id)
+        row = self.query(CallPipelineLog).filter(CallPipelineLog.call_id == call_id).first()
+        entries: List[dict] = list(row.logs) if row and row.logs else []
         if level:
-            base = base.filter(PipelineLog.level == level.upper())
-        total = base.count()
-        rows = (
-            base.order_by(PipelineLog.ts.asc(), PipelineLog.ts_ns.asc())
-            .offset(max(offset, 0))
-            .limit(max(min(limit, 5000), 1))
-            .all()
-        )
+            lvl = level.upper()
+            entries = [e for e in entries if (e.get("level") or "").upper() == lvl]
+        total = len(entries)
+        lo = max(offset, 0)
+        hi = lo + max(min(limit, 5000), 1)
         return {
             "call_id": str(call_id),
             "total": total,
             "limit": limit,
             "offset": offset,
-            "items": [_row_payload(r) for r in rows],
+            "items": [_entry_payload(e) for e in entries[lo:hi]],
         }
 
     def sync_call(self, call: Call) -> SyncResult:
-        """Fetch ``call``'s Loki lines within its (buffered) time window and store them.
+        """Fetch ``call``'s Loki lines within its (buffered) time window and store them
+        as a single time-ordered array on one row.
 
         Safe no-op (returns zeros, never raises) when Loki read creds are absent
         or the call never got a ``trace_id``. Loki transport errors DO propagate
@@ -103,8 +105,8 @@ class PipelineLogSyncService(BaseService):
         # present on EVERY line (including early ones logged before the agent/call
         # id are known), so it's the fetch key — filtering on the full trace_id
         # would drop those setup lines. The prefix is only 8 hex chars, so a
-        # different call can share it; _rows_for_page disambiguates client-side by
-        # the fully-rendered trace_id before storing, so foreign lines aren't
+        # different call can share it; _entries_for_page disambiguates client-side
+        # by the fully-rendered trace_id before storing, so foreign lines aren't
         # misattributed to this call.
         call_uuid = call.trace_id.split("-", 1)[0]
         selector = (
@@ -117,6 +119,7 @@ class PipelineLogSyncService(BaseService):
         client = LokiClient()
         result = SyncResult(window_start=start_dt, window_end=end_dt)
         seen_fingerprints: set[str] = set()
+        entries: List[dict] = []
         cursor = start_ns
 
         for page in range(settings.LOKI_SYNC_MAX_PAGES):
@@ -128,11 +131,8 @@ class PipelineLogSyncService(BaseService):
                 break
             result.fetched += len(lines)
 
-            rows, max_ts = self._rows_for_page(call, lines, seen_fingerprints)
-            if rows:
-                inserted = self._insert(rows)
-                result.inserted += inserted
-                result.skipped += len(rows) - inserted
+            page_entries, max_ts = self._entries_for_page(call, lines, seen_fingerprints)
+            entries.extend(page_entries)
 
             # Last (partial) page → done.
             if len(lines) < settings.LOKI_SYNC_PAGE_LIMIT:
@@ -148,10 +148,15 @@ class PipelineLogSyncService(BaseService):
             # Exhausted MAX_PAGES with full pages throughout — more may remain.
             result.truncated = True
 
+        # Oldest first — pages come forward-ordered but sort defensively so a
+        # boundary overlap or out-of-order stream can't scramble the viewer.
+        entries.sort(key=lambda e: e["ts_ns"])
+        result.stored = self._upsert_call(call, entries)
+
         logger.info(
-            "[loki_sync] call={} window=[{} → {}] pages={} fetched={} inserted={} skipped_dup={} truncated={}",
+            "[loki_sync] call={} window=[{} → {}] pages={} fetched={} stored={} truncated={}",
             call.id, start_dt.isoformat(), end_dt.isoformat(),
-            result.pages, result.fetched, result.inserted, result.skipped, result.truncated,
+            result.pages, result.fetched, result.stored, result.truncated,
         )
         return result
 
@@ -174,11 +179,13 @@ class PipelineLogSyncService(BaseService):
             end_dt = start_dt + timedelta(seconds=settings.LOKI_SYNC_POST_BUFFER_SECONDS)
         return start_dt, end_dt
 
-    def _rows_for_page(self, call: Call, lines, seen: set) -> tuple[List[dict], int]:
-        """Build stamped row dicts for a page, deduping within-run by fingerprint.
+    def _entries_for_page(self, call: Call, lines, seen: set) -> tuple[List[dict], int]:
+        """Build JSON-safe log entries for a page, deduping within-run by fingerprint.
 
-        Returns the rows plus the max ts_ns seen (the pagination cursor)."""
-        rows: List[dict] = []
+        Returns the entries plus the max ts_ns seen (the pagination cursor). Each
+        entry is ``{ts, ts_ns, level, logger_name, message, raw_line}`` — identity
+        (call/org/agent/trace) is not repeated per line; it lives on the row."""
+        entries: List[dict] = []
         max_ts = 0
         for ln in lines:
             # max_ts advances over every fetched line (incl. dropped foreign ones)
@@ -186,8 +193,8 @@ class PipelineLogSyncService(BaseService):
             if ln.ts_ns > max_ts:
                 max_ts = ln.ts_ns
             # The prefix filter can match a different call that shares our 8-char
-            # short-uuid prefix; drop those instead of stamping them with this
-            # call's id. Lines with no parseable token are kept (never dropped).
+            # short-uuid prefix; drop those instead of attributing them to this
+            # call. Lines with no parseable token are kept (never dropped).
             if not _trace_belongs(extract_trace_id(ln.line), call.trace_id):
                 continue
             fp = fingerprint(ln.ts_ns, ln.labels, ln.line)
@@ -195,34 +202,48 @@ class PipelineLogSyncService(BaseService):
                 continue
             seen.add(fp)
             parsed = parse_line(ln.line)
-            rows.append(
+            entries.append(
                 {
-                    "id": uuid.uuid4(),
-                    # Stamped from the Call → reliable, tenant-scoped viewer queries.
-                    "organization_id": call.organization_id,
-                    "call_id": call.id,
-                    "agent_id": call.agent_id,
-                    "trace_id": call.trace_id,
-                    "ts": _from_ns(ln.ts_ns),
+                    "ts": _from_ns(ln.ts_ns).isoformat(),
                     "ts_ns": ln.ts_ns,
                     "level": parsed["level"],
                     "logger_name": parsed["logger_name"],
                     "message": parsed["message"],
                     "raw_line": ln.line,
-                    "labels": ln.labels or None,
-                    "fingerprint": fp,
                 }
             )
-        return rows, max_ts
+        return entries, max_ts
 
-    def _insert(self, rows: List[dict]) -> int:
-        """Idempotent bulk insert; returns the count of rows actually written."""
-        stmt = pg_insert(PipelineLog).values(rows).on_conflict_do_nothing(
-            index_elements=["fingerprint"]
+    def _upsert_call(self, call: Call, entries: List[dict]) -> int:
+        """Replace the call's stored log array in one idempotent upsert.
+
+        One row per call (``call_id`` UNIQUE): insert it or overwrite ``logs``
+        wholesale. Because ``entries`` is the full, deduped window every run, a
+        re-sync / retry / concurrent run converges on the same array — last write
+        wins with an equivalent value. Returns the stored line count."""
+        now = datetime.now(timezone.utc)
+        values = {
+            "id": uuid.uuid4(),
+            "organization_id": call.organization_id,
+            "call_id": call.id,
+            "agent_id": call.agent_id,
+            "trace_id": call.trace_id,
+            "logs": entries,
+            "synced_at": now,
+        }
+        stmt = pg_insert(CallPipelineLog).values(**values).on_conflict_do_update(
+            index_elements=["call_id"],
+            set_={
+                "logs": entries,
+                "agent_id": call.agent_id,
+                "trace_id": call.trace_id,
+                "synced_at": now,
+                "updated_at": now,
+            },
         )
-        result = self.db.execute(stmt)
+        self.db.execute(stmt)
         self.db.commit()
-        return result.rowcount or 0
+        return len(entries)
 
 
 def _trace_belongs(token: Optional[str], full_trace_id: str) -> bool:
@@ -253,8 +274,7 @@ def sync_result_payload(result: SyncResult) -> dict:
     """JSON-safe payload for the manual sync endpoint."""
     return {
         "fetched": result.fetched,
-        "inserted": result.inserted,
-        "skipped": result.skipped,
+        "stored": result.stored,
         "pages": result.pages,
         "truncated": result.truncated,
         "configured": result.configured,
@@ -264,12 +284,12 @@ def sync_result_payload(result: SyncResult) -> dict:
     }
 
 
-def _row_payload(row: PipelineLog) -> dict:
+def _entry_payload(entry: dict) -> dict:
+    """Viewer-facing shape for one stored log entry."""
     return {
-        "id": str(row.id),
-        "ts": row.ts.isoformat() if row.ts else None,
-        "level": row.level,
-        "logger_name": row.logger_name,
-        "message": row.message,
-        "raw_line": row.raw_line,
+        "ts": entry.get("ts"),
+        "level": entry.get("level"),
+        "logger_name": entry.get("logger_name"),
+        "message": entry.get("message"),
+        "raw_line": entry.get("raw_line"),
     }

--- a/core/services/post_call/actions/sync_loki_logs.py
+++ b/core/services/post_call/actions/sync_loki_logs.py
@@ -7,7 +7,7 @@ from shared.config import settings
 
 
 class SyncLokiLogsAction(PostCallAction):
-    """Read the just-ended call's log lines back from Loki into ``pipeline_logs``.
+    """Read the just-ended call's log lines back from Loki into ``call_pipeline_logs``.
 
     No enable/disable flag — always wired. Safe no-op when Loki read creds are
     absent (local dev) or the call never got a ``trace_id``, so nothing to fetch.

--- a/core/services/readiness/probes.py
+++ b/core/services/readiness/probes.py
@@ -238,20 +238,32 @@ async def probe_stt(ctx) -> ProbeResult:
     # Lazy import — pipecat is heavy and this module is imported at API startup.
     try:
         from pipecat.frames.frames import (
+            ErrorFrame,
             InterimTranscriptionFrame,
             TranscriptionFrame,
         )
         _transcript_types: Tuple[type, ...] = (TranscriptionFrame, InterimTranscriptionFrame)
+        _error_frame_type: Optional[type] = ErrorFrame
     except Exception:  # noqa: BLE001
         _transcript_types = ()
+        _error_frame_type = None
 
     try:
         transcript_text: Optional[str] = None
+        error_from_stream: Optional[str] = None
         got_any = False
         async for frame in service.run_stt(audio_bytes):
             got_any = True
             if frame is None:
                 continue
+            # WS-based STT providers signal auth/quota failures via ErrorFrame
+            # inside the stream, not by raising. Catch it here or we'd end up
+            # in the "returned frames but no transcript" branch below and mis-
+            # report a real failure as a soft ambiguity.
+            err = _extract_error_frame_message(frame, _error_frame_type)
+            if err:
+                error_from_stream = err
+                break
             # Providers vary in which frame type carries the final vs interim
             # text — accept either, since both prove the model decoded speech.
             text = _extract_transcript_text(frame, _transcript_types)
@@ -273,6 +285,12 @@ async def probe_stt(ctx) -> ProbeResult:
                     break
         except Exception as exc:  # noqa: BLE001
             logger.debug("[readiness] {} STT probe cleanup failed: {}", provider, exc)
+
+    if error_from_stream:
+        # The provider streamed an ErrorFrame — auth failure, quota exhausted,
+        # WS handshake rejected. Runtime pipelines log these; readiness must
+        # elevate to a FAIL so the badge reflects reality.
+        return ProbeResult(False, f"{provider} STT error: {error_from_stream[:180]}")
 
     if transcript_text:
         snippet = transcript_text.strip().replace("\n", " ")[:60]
@@ -369,6 +387,28 @@ def _extract_transcript_text(frame, transcript_types: Tuple[type, ...]) -> Optio
     return None
 
 
+def _extract_error_frame_message(frame, error_frame_type) -> Optional[str]:
+    """Return the error message when ``frame`` is a pipecat ``ErrorFrame``.
+
+    Pipecat WebSocket-based providers (Fish Audio TTS, Deepgram STT, ElevenLabs,
+    etc.) don't raise Python exceptions on connection failure — they push an
+    ``ErrorFrame`` into the frame stream. Runtime pipelines log these and keep
+    going; the readiness probes need to catch them explicitly, otherwise a 402
+    / 401 / model-not-found quietly yields "no audio observed" (or "no frames")
+    and the probe silently PASSes.
+
+    Duck-typed fallback: when the ``ErrorFrame`` type couldn't be imported we
+    still detect any frame whose class name ends in ``ErrorFrame`` and carries
+    an ``.error`` attribute.
+    """
+    if error_frame_type is not None and isinstance(frame, error_frame_type):
+        return str(getattr(frame, "error", "") or "provider emitted an error frame")
+    cls_name = type(frame).__name__
+    if cls_name.endswith("ErrorFrame") and hasattr(frame, "error"):
+        return str(getattr(frame, "error", "") or "provider emitted an error frame")
+    return None
+
+
 # ── TTS probe (universal — pipecat's run_tts) ────────────────────────────────
 
 
@@ -396,9 +436,16 @@ async def probe_tts(ctx) -> ProbeResult:
         )
 
     try:
-        from pipecat.frames.frames import TTSAudioRawFrame  # local — pipecat is heavy
+        # Local imports — pipecat is heavy and we don't want to pay for it
+        # at module load. ``ErrorFrame`` is the critical addition: pipecat
+        # WS-based TTS services (Fish Audio, ElevenLabs, etc.) push it into
+        # the stream on connection failure (402, 401) instead of raising, and
+        # without checking for it here the probe silently PASSes.
+        from pipecat.frames.frames import ErrorFrame, TTSAudioRawFrame
+        _error_frame_type: Optional[type] = ErrorFrame
     except Exception:  # noqa: BLE001
         TTSAudioRawFrame = None  # type: ignore
+        _error_frame_type = None
 
     # Some pipecat TTS services (e.g. Cartesia) override run_tts to require a
     # ``context_id`` for turn tracking. Inspect the signature so we can supply
@@ -419,8 +466,13 @@ async def probe_tts(ctx) -> ProbeResult:
         pass
 
     got_audio = False
+    error_from_stream: Optional[str] = None
     try:
         async for frame in service.run_tts(_TTS_PROBE_TEXT, **run_tts_kwargs):
+            err = _extract_error_frame_message(frame, _error_frame_type)
+            if err:
+                error_from_stream = err
+                break
             if TTSAudioRawFrame is not None and isinstance(frame, TTSAudioRawFrame):
                 got_audio = True
                 break
@@ -440,11 +492,20 @@ async def probe_tts(ctx) -> ProbeResult:
         except Exception as exc:  # noqa: BLE001
             logger.debug("[readiness] {} TTS probe session close failed: {}", provider, exc)
 
+    if error_from_stream:
+        # WS providers (Fish, ElevenLabs, etc.) surface 402/401/quota errors
+        # here rather than raising — must FAIL so the badge doesn't lie.
+        return ProbeResult(False, f"{provider} TTS error: {error_from_stream[:180]}")
     if got_audio:
         return ProbeResult(True, f"{provider} synthesised a sentence.")
+    # Real sentence probe: a healthy TTS must emit at least one audio frame.
+    # Historically this branch soft-passed with "accepted the request" — that
+    # let broken providers (mid-session auth failures, silent WS drops) go
+    # undetected. Flipping to FAIL matches the strict-transcript rule STT
+    # uses and the user's expectation for the new deep tests.
     return ProbeResult(
-        True,
-        f"{provider} accepted the request (no audio frame observed within probe budget).",
+        False,
+        f"{provider} TTS returned no audio for the probe sentence — provider likely rejected the request.",
     )
 
 

--- a/core/services/session_service.py
+++ b/core/services/session_service.py
@@ -141,6 +141,35 @@ class SessionService(BaseService):
         self.db.flush()
         return session
 
+    def rotate_for_org_switch(
+        self,
+        *,
+        session_id: UUIDLike,
+        new_refresh_token: str,
+        organization_id: Optional[UUIDLike],
+        device: Optional[DeviceContext] = None,
+    ) -> Optional[UserSession]:
+        """Move a live session onto a new org and store a freshly-minted
+        refresh-token hash, without requiring the old refresh token.
+
+        Used by the org-switch flow: the caller is already authenticated via
+        its access token (and membership is verified upstream), so — unlike
+        ``rotate_session`` — there is no presented-token check. Returns the
+        updated session, or ``None`` if it is unknown / revoked / expired.
+        """
+        sid = coerce_uuid(session_id)
+        if not sid:
+            return None
+        session = self.db.query(UserSession).filter(UserSession.id == sid).first()
+        if not session or session.revoked_at is not None or session.expires_at <= utcnow():
+            return None
+        session.refresh_token_hash = hash_token(new_refresh_token)
+        session.organization_id = coerce_uuid(organization_id)
+        session.last_used_at = utcnow()
+        _apply_device(session, device)
+        self.db.flush()
+        return session
+
     # ── revocation ──
 
     def revoke_session(self, session: UserSession, reason: str) -> None:

--- a/ee/api/v1/auth.py
+++ b/ee/api/v1/auth.py
@@ -2,10 +2,15 @@ from typing import Any, Dict, Optional
 from uuid import UUID
 
 from fastapi import (APIRouter, Body, Depends, Header, HTTPException, Query,
-                     Request, status)
+                     Request, Response, status)
 from sqlalchemy.orm import Session
 
 from core.database.session import get_db
+from core.middleware.auth import (
+    REFRESH_COOKIE,
+    clear_auth_cookies,
+    set_cookies_and_strip,
+)
 from core.utils.device import extract_device_context
 from ee.middleware.auth import (
     EEJWTClaims,
@@ -20,6 +25,7 @@ router = APIRouter()
 @router.post("/signup", status_code=status.HTTP_201_CREATED)
 def signup(
     request: Request,
+    response: Response,
     user_data: Dict[str, Any] = Body(...),
     db: Session = Depends(get_db),
 ):
@@ -40,7 +46,7 @@ def signup(
 
     # Prefer the v2 shape when first/last name are supplied (new auth UI).
     if first_name and last_name:
-        return EEAuthService(db).signup_v2(
+        result = EEAuthService(db).signup_v2(
             email=email,
             password=password,
             first_name=first_name,
@@ -48,9 +54,12 @@ def signup(
             organization_name=organization_name,
             device=device,
         )
-
-    profile = user_data.get("profile") or {}
-    return EEAuthService(db).signup(email, password, username or None, profile, organization_name)
+    else:
+        profile = user_data.get("profile") or {}
+        result = EEAuthService(db).signup(
+            email, password, username or None, profile, organization_name
+        )
+    return set_cookies_and_strip(response, result)
 
 
 @router.get("/check_organization_exists")
@@ -102,6 +111,7 @@ def verify_user_email(
 @router.post("/login")
 def login(
     request: Request,
+    response: Response,
     login_data: Dict[str, str] = Body(...),
     db: Session = Depends(get_db),
 ):
@@ -114,7 +124,8 @@ def login(
             detail="Email and password are required",
         )
 
-    return EEAuthService(db).login_v2(email, password, device=extract_device_context(request))
+    result = EEAuthService(db).login_v2(email, password, device=extract_device_context(request))
+    return set_cookies_and_strip(response, result)
 
 
 @router.post("/signin-code/request")
@@ -130,6 +141,7 @@ def request_signin_code(body: Dict[str, str] = Body(...), db: Session = Depends(
 @router.post("/signin-code/verify")
 def verify_signin_code(
     request: Request,
+    response: Response,
     body: Dict[str, str] = Body(...),
     db: Session = Depends(get_db),
 ):
@@ -140,29 +152,40 @@ def verify_signin_code(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="email and code are required",
         )
-    return EEAuthService(db).verify_signin_code(
+    result = EEAuthService(db).verify_signin_code(
         email, code, device=extract_device_context(request),
     )
+    return set_cookies_and_strip(response, result)
 
 
 @router.post("/refresh")
 def refresh(
     request: Request,
-    body: Dict[str, str] = Body(...),
+    response: Response,
+    body: Dict[str, str] = Body(default={}),
     db: Session = Depends(get_db),
 ):
-    refresh_token = body.get("refresh_token")
+    refresh_token = request.cookies.get(REFRESH_COOKIE) or (body or {}).get("refresh_token")
     if not refresh_token:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="refresh_token is required",
         )
-    return EEAuthService(db).refresh_tokens(refresh_token, device=extract_device_context(request))
+    result = EEAuthService(db).refresh_tokens(refresh_token, device=extract_device_context(request))
+    return set_cookies_and_strip(response, result)
 
 
 @router.post("/logout")
-def logout(body: Dict[str, Any] = Body(default={}), db: Session = Depends(get_db)):
-    return EEAuthService(db).logout(refresh_token=body.get("refresh_token"))
+def logout(
+    request: Request,
+    response: Response,
+    body: Dict[str, Any] = Body(default={}),
+    db: Session = Depends(get_db),
+):
+    refresh_token = request.cookies.get(REFRESH_COOKIE) or (body or {}).get("refresh_token")
+    result = EEAuthService(db).logout(refresh_token=refresh_token)
+    clear_auth_cookies(response)
+    return result
 
 
 @router.post("/verify-email")
@@ -229,6 +252,7 @@ def validate_invitation(token: str = Query(...), db: Session = Depends(get_db)):
 @router.post("/accept-invitation")
 def accept_invitation(
     request: Request,
+    response: Response,
     body: Dict[str, Any] = Body(...),
     db: Session = Depends(get_db),
     claims: Optional[EEJWTClaims] = Depends(get_optional_ee_jwt_claims),
@@ -238,7 +262,7 @@ def accept_invitation(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="token is required"
         )
-    return EEAuthService(db).accept_invitation_by_token(
+    result = EEAuthService(db).accept_invitation_by_token(
         token=token,
         password=body.get("password"),
         first_name=body.get("first_name"),
@@ -246,6 +270,7 @@ def accept_invitation(
         current_user_id=claims.user_id if claims else None,
         device=extract_device_context(request),
     )
+    return set_cookies_and_strip(response, result)
 
 
 @router.get("/forget-password")
@@ -265,6 +290,7 @@ def accept_forgot_password(
 
 @router.post("/switch_organization")
 def switch_organization(
+    response: Response,
     org_data: Dict[str, str] = Body(...),
     claims: EEJWTClaims = Depends(get_ee_jwt_claims),
     db: Session = Depends(get_db)
@@ -277,6 +303,9 @@ def switch_organization(
             detail="Organization ID is required"
         )
 
-    return EEAuthService(db).switch_organization(
+    # Re-mints BOTH access + refresh tokens with the (membership-verified) new
+    # org so the switch survives a silent cookie refresh (see EEAuthService).
+    result = EEAuthService(db).switch_organization(
         claims.user_id, UUID(org_id), session_id=claims.jti,
     )
+    return set_cookies_and_strip(response, result)

--- a/ee/api/v1/call_logs.py
+++ b/ee/api/v1/call_logs.py
@@ -131,7 +131,7 @@ def sync_call_logs(
     claims: EEJWTClaims = Depends(require_ee_org_member),
     db: Session = Depends(get_db),
 ):
-    """Read this call's log lines back from Loki into ``pipeline_logs`` (inline).
+    """Read this call's log lines back from Loki into ``call_pipeline_logs`` (inline).
     Idempotent — see the OSS twin in ``core/api/v1/call_logs.py``."""
     svc = PipelineLogSyncService(db, org_id=UUID(claims.org_id))
     try:

--- a/ee/middleware/auth.py
+++ b/ee/middleware/auth.py
@@ -1,10 +1,14 @@
-from fastapi import HTTPException, status, Depends, Header
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi import HTTPException, status, Depends, Header, Request
 from typing import Optional
 from uuid import UUID
 
 from core.database.session import get_db
-from core.middleware.auth import JWTClaims, _enforce_active_session, jwt_manager, security
+from core.middleware.auth import (
+    JWTClaims,
+    _enforce_active_session,
+    get_bearer_or_cookie_token,
+    jwt_manager,
+)
 from core.context import set_tenant_context
 
 
@@ -20,59 +24,81 @@ ee_jwt_manager = jwt_manager
 
 
 def get_ee_jwt_claims(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
+    request: Request,
     db=Depends(get_db),
 ) -> JWTClaims:
-    claims = jwt_manager.verify_token(credentials)
-    print(f"[get_ee_jwt_claims] org_id from JWT: {claims.org_id}")
+    token = get_bearer_or_cookie_token(request)
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+        )
+    claims = jwt_manager.decode_token(token)
     if claims.org_id:
-        print(f"[get_ee_jwt_claims] Setting tenant context with org_id: {claims.org_id}")
         set_tenant_context(org_id=claims.org_id, user_id=claims.user_id, role=claims.role)
     _enforce_active_session(claims, db)
     return claims
 
 
 def get_optional_ee_jwt_claims(
-    credentials: Optional[HTTPAuthorizationCredentials] = Depends(HTTPBearer(auto_error=False)),
+    request: Request,
     db=Depends(get_db),
 ) -> Optional[JWTClaims]:
-    if not credentials:
+    token = get_bearer_or_cookie_token(request)
+    if not token:
         return None
-    claims = jwt_manager.verify_token(credentials)
+    claims = jwt_manager.decode_token(token)
     _enforce_active_session(claims, db)
     return claims
 
 
 def get_ee_current_user(
     claims: JWTClaims = Depends(get_ee_jwt_claims),
-    tenant_id: Optional[str] = Header(None, alias="tenant_id")
+    tenant_id: Optional[str] = Header(None, alias="tenant_id"),
+    db=Depends(get_db),
 ) -> JWTClaims:
-    print(f"[get_ee_current_user] tenant_id header: {tenant_id}")
-    print(f"[get_ee_current_user] claims.org_id before: {claims.org_id}")
-    # Only use tenant_id header if it's a valid UUID, otherwise ignore it
-    if tenant_id and _validate_uuid(tenant_id):
-        claims.org_id = tenant_id
-        print(f"[get_ee_current_user] Setting tenant context with tenant_id: {tenant_id}")
-        set_tenant_context(org_id=tenant_id, user_id=claims.user_id, role=claims.role)
-    print(f"[get_ee_current_user] claims.org_id after: {claims.org_id}")
+    # The active org is authoritative in the (httpOnly-cookie) access token,
+    # which is minted with a membership-verified org on login / org-switch.
+    # The ``tenant_id`` header is a transitional client hint: honor it only
+    # when it differs from the token's org AND the caller is genuinely a
+    # member of that org — otherwise a forged header would expose another
+    # tenant's data (IDOR). Membership lookup also yields the correct per-org
+    # role so downstream role guards evaluate against the switched org.
+    if (
+        tenant_id
+        and _validate_uuid(tenant_id)
+        and str(tenant_id) != str(claims.org_id or "")
+    ):
+        from core.models.member import Member  # local import avoids import cycle
+
+        member = (
+            db.query(Member)
+            .filter(
+                Member.user_id == claims.user_uuid,
+                Member.organization_id == UUID(tenant_id),
+            )
+            .first()
+        )
+        if member:
+            claims.org_id = tenant_id
+            claims.role = member.role
+            set_tenant_context(
+                org_id=tenant_id, user_id=claims.user_id, role=member.role
+            )
     return claims
 
 
 def require_ee_org_member(claims: JWTClaims = Depends(get_ee_current_user)) -> JWTClaims:
-    print(f"[require_ee_org_member] claims.org_id: {claims.org_id}")
-    print(f"[require_ee_org_member] claims.user_id: {claims.user_id}")
     if not claims.user_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="User ID is required"
         )
     if not claims.org_id or not _validate_uuid(str(claims.org_id)):
-        print(f"[require_ee_org_member] Invalid org_id: {claims.org_id}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Valid Organization ID is required. Use tenant_id header or switch organization."
         )
-    print(f"[require_ee_org_member] Returning claims with org_id: {claims.org_id}")
     return claims
 
 

--- a/ee/services/auth_service.py
+++ b/ee/services/auth_service.py
@@ -137,12 +137,38 @@ class EEAuthService(AuthService):
             role=member.role,
             session_id=session_id,
         )
-        return {
+        result: Dict[str, Any] = {
             "access_token": access_token,
             "token_type": "bearer",
             "organization": org.to_dict(),
             "role": member.role,
         }
+
+        # Re-mint the refresh token too, carrying the NEW org, and move the
+        # session row onto it. Without this the refresh token keeps the old
+        # org and a silent ``/auth/refresh`` would snap the user back to their
+        # previous org. Skipped for pre-session (jti-less) tokens.
+        from core.services.session_service import SessionService  # local import
+
+        session_service = SessionService(self.db)
+        session = session_service.get_session(session_id) if session_id else None
+        if session is not None:
+            refresh_token = jwt_manager.create_refresh_token(
+                user_id=str(user.id),
+                email=user.email,
+                session_id=session_id,
+                family=session.refresh_token_family,
+                org_id=str(org.id),
+            )
+            session_service.rotate_for_org_switch(
+                session_id=session_id,
+                new_refresh_token=refresh_token,
+                organization_id=org.id,
+            )
+            self.db.commit()
+            result["refresh_token"] = refresh_token
+
+        return result
 
     # ── Organization details ─────────────────────────────────────────
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -299,10 +299,10 @@ Applies **solid-checklist.md** in full — SRP, OCP, LSP, ISP, DIP, code smells,
 Applies **security-checklist.md** in full — XSS, injection, SSRF, AuthN/AuthZ, secrets, runtime risks, race conditions, data integrity.
 
 - **This project critical paths**:
-  - Every new route under `src/app/(dashboard)/` must be covered by the `tone_access_token` check in `src/middleware.ts`. Verify new routes are not excluded accidentally.
-  - The Axios instance in `src/utils/axios.ts` injects `tenant_id` and `Authorization` on every request. Do not bypass it by creating a second Axios instance or using `fetch` directly without these headers.
-  - Roles and identity must come from the `login_data` cookie (read via `AuthAtom.tsx`) — never from query params or request body fields.
-  - Firebase token must never be logged or stored outside of the `tone_access_token` cookie.
+  - Every new route under `src/app/(dashboard)/` must be covered by the `access_token` httpOnly-cookie presence check in `src/middleware.ts`. Verify new routes are not excluded accidentally by the matcher.
+  - The Axios instance in `src/utils/axios.ts` uses `withCredentials: true` so the httpOnly auth cookies are sent automatically, and injects the `tenant_id` hint header. Do not bypass it by creating a second Axios instance or using `fetch` directly without `credentials: 'include'`.
+  - Roles and identity must come from the `login_data` payload in localStorage (readable UI state) or the `/auth/me` API — never decoded from the token (it's an httpOnly cookie JS cannot read) and never from query params or request body fields.
+  - The access/refresh JWTs live ONLY in httpOnly cookies — never store them in localStorage/sessionStorage or log them.
 
 #### 6. Performance
 
@@ -392,24 +392,24 @@ The app requires `NEXT_PUBLIC_BACKEND_URL` to be set (see `src/urls.ts`). This i
 - `src/app/page.tsx` — redirects `/` to `/home`
 - `src/app/(dashboard)/` — route group for all authenticated pages (agents, home, settings, phone-numbers); shares a sidebar layout via `(dashboard)/layout.tsx`
 - `src/app/auth/` — public auth pages (login, signup, forgot password, reset password). All auth forms use react-hook-form + Zod for validation (see below).
-- `src/middleware.ts` — enforces auth by checking the `tone_access_token` cookie; unauthenticated requests redirect to `/auth/login?redirect=<path>`
+- `src/middleware.ts` — server-side auth guard: checks for the `access_token` httpOnly cookie (readable by middleware, not by browser JS); unauthenticated requests redirect to `/login?next=<path>`
 
 **Page pattern**: Pages under `(dashboard)` are thin wrappers that import and render a component from `src/components/`. All the actual UI logic lives in components.
 
 **State management**: [Jotai](https://jotai.org/). Atoms live in `src/atoms/`:
 
 - `AgentsAtom.tsx` — agent list state with a write-only `fetchAgentList` atom
-- `AuthAtom.tsx` — user auth state, logout, and `getCurrentUserAtom` that reads from the `login_data` cookie
+- `AuthAtom.tsx` — user auth state, logout, and `getCurrentUserAtom` that reads from the `login_data` payload in localStorage
 - `SettingsAtom.tsx` — organization members and invitations using `jotai/utils` `loadable` for async data with refresh counters
 
 Write-only atoms (e.g., `atom(null, async (_get, set, payload) => {...})`) are the pattern for async actions that update state.
 
 **API layer**: `src/services/` contains service functions that call `src/utils/axios.ts`. The Axios instance:
 
-- Sets base URL from `NEXT_PUBLIC_BACKEND_URL`
-- Injects `tenant_id` header (from `org_tenant_id` cookie) and `Authorization: Bearer <token>` (from `tone_access_token` cookie) on every request
+- Sets base URL from `NEXT_PUBLIC_BACKEND_URL` (or a relative `/api/v1` when `NEXT_PUBLIC_USE_API_PROXY=true` routes through the Next.js dev proxy — see `next.config.ts` `rewrites`)
+- Uses `withCredentials: true` so the browser attaches the httpOnly `access_token` / `refresh_token` cookies automatically; injects only the non-sensitive `tenant_id` hint header (from `active_org_id` in localStorage). On a 401 it silently calls `/auth/refresh` (cookie-based) once and retries.
 
-**Authentication**: Firebase is used alongside JWT. Auth state is persisted in cookies (`tone_access_token`, `org_tenant_id`, `login_data`). Constants for cookie key names are in `src/constants/index.ts`.
+**Authentication**: JWT access + refresh tokens stored in **httpOnly cookies** (set/cleared by the backend on login / refresh / logout / org-switch), so JS never touches them and XSS can't exfiltrate a session. The readable `login_data` payload + `active_org_id` in localStorage are non-sensitive UI state only. Route protection is server-side in `src/middleware.ts`. Org switching goes through `POST /auth/switch_organization`, which re-mints both cookies with the (membership-verified) new org. Constants for storage keys are in `src/constants/index.ts`. (No Firebase.)
 
 **UI**: shadcn/ui primitives in `src/components/ui/` styled with Tailwind v4 and theme tokens from `src/app/globals.css` (CSS variables for color, radius, etc.). The root font is **Geist Sans** (loaded via `next/font` in `src/app/layout.tsx`, exposed as `--font-geist-sans` and bound to Tailwind's `font-sans`); `font-mono` resolves to Geist Mono. Dark mode is handled by `next-themes`. Use **lucide-react** for icons (or `src/components/icons/` for brand marks). The codebase is MUI-free — do not introduce `@mui/*` or `@emotion/*` packages.
 

--- a/frontend/docs/AUTH_FLOW_DOCUMENTATION.md
+++ b/frontend/docs/AUTH_FLOW_DOCUMENTATION.md
@@ -7,6 +7,38 @@
 
 ---
 
+## ⚠️ UPDATE — httpOnly-cookie token storage (supersedes the token-management sections below)
+
+Tokens were migrated **out of `localStorage` into httpOnly cookies**. Where any section
+below describes reading/writing `access_token`/`refresh_token` in `localStorage` or attaching
+an `Authorization: Bearer` header, treat it as **superseded** by the following:
+
+- **Token storage:** access + refresh JWTs live in **httpOnly cookies** (`access_token`,
+  `refresh_token`) set by the backend on login / signup / signin-code / accept-invite /
+  refresh / **org-switch**, and cleared on logout. JS cannot read them. `localStorage` holds
+  only non-sensitive UI state: `login_data` (profile/org payload) and `active_org_id`.
+- **Requests:** the Axios instance (`src/utils/axios.ts`) uses `withCredentials: true` — the
+  browser attaches the cookies automatically. No `Authorization` header. It still sends the
+  `tenant_id` hint header from `active_org_id`. A 401 triggers one silent, cookie-based
+  `POST /auth/refresh` then retries.
+- **Route protection:** enforced **server-side** in `src/middleware.ts` by checking the
+  `access_token` cookie's presence (the cookie carries session-length max-age; the JWT inside
+  is short-lived and rotated by silent refresh). Redirects to `/login?next=<path>`. The old
+  client-side `localStorage` token checks in `(dashboard)/layout.tsx` and `page.tsx` are gone.
+- **Role/identity:** come from the `login_data` payload or `/auth/me` — never decoded from the
+  token (unreadable) .
+- **Org switch:** the sidebar calls `POST /auth/switch_organization`; the backend verifies
+  membership and re-mints **both** cookies with the new org so a silent refresh doesn't revert.
+- **Logout:** `POST /auth/logout` (no body — refresh token read from cookie) revokes the
+  session and clears both cookies; the client clears `login_data`/`active_org_id`.
+- **Local dev:** set `NEXT_PUBLIC_USE_API_PROXY=true` so the browser talks only to the Next.js
+  origin (`/api/*` is proxied to the backend via `next.config.ts` rewrites) and the cookie is
+  same-origin. In prod the frontend + API share `*.trytone.ai` (cookie `Domain=.trytone.ai`).
+
+The page-flow, form-validation, and error-handling sections below remain accurate.
+
+---
+
 ## Table of Contents
 
 1. [Navigation & Routing](#1-navigation--routing)

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -22,6 +22,16 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  // Local-dev cookie proxy. Set NEXT_PUBLIC_USE_API_PROXY=true so the browser
+  // only ever talks to the Next.js origin — the httpOnly auth cookie becomes
+  // host-only on :3000 and the middleware can read it. In prod the frontend and
+  // API share a parent domain (*.trytone.ai) so no proxy is needed (leave it
+  // unset and point NEXT_PUBLIC_BACKEND_URL at the API host).
+  async rewrites() {
+    if (process.env.NEXT_PUBLIC_USE_API_PROXY !== 'true') return [];
+    const backend = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
+    return [{ source: '/api/:path*', destination: `${backend}/api/:path*` }];
+  },
   async redirects() {
     return [
       { source: '/auth/login', destination: '/login', permanent: false },

--- a/frontend/src/app/(dashboard)/layout.tsx
+++ b/frontend/src/app/(dashboard)/layout.tsx
@@ -6,14 +6,16 @@ import { useEffect, useRef, useState } from 'react';
 
 import { Sidebar } from '@/components/layout/sidebar';
 import { AppLoader, ErrorBoundary } from '@/components/shared';
-import { ACCESS_TOKEN } from '@/constants';
+import { LOGIN_DATA } from '@/constants';
 import { NavigationProvider, useNavigation } from '@/contexts/navigation';
+import { authApi } from '@/lib/api/auth';
 import { getAssociatedTenants } from '@/services/organizationService';
 import { useAuthStore } from '@/stores/auth';
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const hydrate = useAuthStore((s) => s.hydrate);
+  const setLoginResponse = useAuthStore((s) => s.setLoginResponse);
   const setOrganizations = useAuthStore((s) => s.setOrganizations);
   const clearAuth = useAuthStore((s) => s.clearAuth);
   const [ready, setReady] = useState(false);
@@ -22,40 +24,49 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    const token = localStorage.getItem(ACCESS_TOKEN);
-    if (!token) {
-      router.replace('/login');
-      return;
-    }
+    // Route protection is enforced server-side by src/middleware.ts (reads the
+    // httpOnly access cookie). Here we only hydrate the readable session state.
     hydrate();
     setReady(true);
 
     if (orgFetchStarted.current) return;
     orgFetchStarted.current = true;
 
-    // Pull the full list of orgs the user belongs to and seed the auth store
-    // so the sidebar switcher shows every workspace, not just the active one.
-    const controller = new AbortController();
+    // NB: results are written to the Zustand module store (not component
+    // state), so we intentionally do NOT gate them behind an AbortController —
+    // under React StrictMode's dev double-invoke that would discard the fetch
+    // result and leave the switcher stuck on "one workspace" until a reload.
     (async () => {
+      // If the readable profile is missing but the cookie let us past the
+      // middleware (e.g. localStorage was cleared), rebuild it from /me so the
+      // sidebar has a user to show.
+      if (!useAuthStore.getState().user) {
+        try {
+          const user = await authApi.me();
+          if (user) setLoginResponse({ user, organizations: [] });
+        } catch {
+          // Cookie is invalid/expired — the next API 401 tears the session down.
+        }
+      }
+
+      // Pull the full list of orgs the user belongs to and seed the auth store
+      // so the sidebar switcher shows every workspace, not just the active one.
       try {
         const orgs = await getAssociatedTenants({ page: 1, page_size: 200 });
-        if (!controller.signal.aborted) {
-          setOrganizations(orgs.map((o) => ({ id: o.id, name: o.name, role: o.role })));
-        }
+        setOrganizations(orgs.map((o) => ({ id: o.id, name: o.name, role: o.role })));
       } catch {
         // Sidebar will gracefully fall back to "one workspace" copy.
       }
     })();
-    return () => controller.abort();
-  }, [hydrate, router, setOrganizations]);
+  }, [hydrate, setLoginResponse, setOrganizations]);
 
-  // Cross-tab logout sync: when another tab clears the access token (logout,
-  // forced revocation), mirror that here so this tab does not stay "logged in"
-  // visually while the session is dead server-side.
+  // Cross-tab logout sync: when another tab clears the readable session
+  // (logout), mirror that here so this tab does not stay "logged in" visually
+  // while the session is dead server-side.
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const onStorage = (e: StorageEvent) => {
-      if (e.key === ACCESS_TOKEN && !e.newValue) {
+      if (e.key === LOGIN_DATA && !e.newValue) {
         clearAuth();
         router.replace('/login');
       }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,14 +3,17 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 
-import { ACCESS_TOKEN } from '@/constants';
+import { LOGIN_DATA, ROUTE_HOME, ROUTE_LOGIN } from '@/constants';
 import { AppLoader } from '@/components/shared';
 
 export default function RootPage() {
   const router = useRouter();
   useEffect(() => {
-    const token = typeof window !== 'undefined' ? localStorage.getItem(ACCESS_TOKEN) : null;
-    router.replace(token ? '/home' : '/login');
+    // The access token is an httpOnly cookie JS can't read; use the readable
+    // login_data payload as the client-side signal. The server-side middleware
+    // is the authoritative guard and will bounce an invalid session anyway.
+    const hasSession = typeof window !== 'undefined' && !!localStorage.getItem(LOGIN_DATA);
+    router.replace(hasSession ? ROUTE_HOME : ROUTE_LOGIN);
   }, [router]);
 
   return <AppLoader />;

--- a/frontend/src/atoms/AuthAtom.tsx
+++ b/frontend/src/atoms/AuthAtom.tsx
@@ -3,7 +3,7 @@ import { atom } from 'jotai';
 import { authApi } from '@/lib/api/auth';
 import { LOGIN_DATA, TENANT_ID } from '@/constants';
 import { abortAuthRefresh } from '@/utils/axios';
-import { endSession, getRefreshToken } from '@/utils/authSession';
+import { endSession } from '@/utils/authSession';
 
 interface User {
   id: string;
@@ -28,16 +28,13 @@ const authAtom = atom<AuthState>({
 
 const logoutAtom = atom(null, async (_get, set) => {
   set(authAtom, (prev) => ({ ...prev, isLoading: true }));
-  // Capture the refresh token BEFORE clearing storage so we can hand it to
-  // the backend, which uses it to revoke the matching session row.
-  const refreshToken = getRefreshToken();
   // Reject any requests waiting on an in-flight token refresh so they don't
-  // hang forever once storage is cleared below.
+  // hang forever once the session ends below.
   abortAuthRefresh();
   try {
-    if (refreshToken) {
-      await authApi.logout({ refresh_token: refreshToken });
-    }
+    // The refresh token is an httpOnly cookie sent automatically; the backend
+    // reads it to revoke the session row and clears both auth cookies.
+    await authApi.logout();
   } catch (error) {
     // Logout is best-effort on the server; we still log the user out locally.
     console.error('Logout error:', error);

--- a/frontend/src/atoms/OrganizationAtom.tsx
+++ b/frontend/src/atoms/OrganizationAtom.tsx
@@ -5,7 +5,6 @@ import {
   switchOrganization,
   updateOrganization,
 } from '@/services/organizationService';
-import { setToken } from '@/services/auth/helper';
 import { useAuthStore } from '@/stores/auth';
 import type { OrganizationListItem, OrganizationUpdatePayload } from '@/types/organization';
 import { atom } from 'jotai';
@@ -58,14 +57,13 @@ export const deleteOrganizationAtom = atom(null, async (_get, set, orgId: string
 });
 
 export const switchOrganizationAtom = atom(null, async (_get, _set, orgId: string) => {
-  const res = await switchOrganization(orgId);
-  // Backend returns { access_token, organization: { id, name, slug }, role }.
-  // Normalize into the shape setToken expects (organizations array).
-  const tokenData = {
-    ...res,
-    organizations: res.organization ? [res.organization] : [],
-  };
-  await setToken(tokenData);
+  // The backend verifies membership and sets fresh httpOnly cookies whose
+  // access + refresh tokens both carry the new org (so a silent refresh won't
+  // revert it). No tokens come back in the body for JS to store.
+  await switchOrganization(orgId);
+  // Persist the active org so post-reload hydration resolves the right tenant
+  // and per-org role from the membership list.
+  useAuthStore.getState().setActiveOrgId(orgId);
   window.location.reload();
 });
 

--- a/frontend/src/components/layout/AccountMenu.tsx
+++ b/frontend/src/components/layout/AccountMenu.tsx
@@ -10,7 +10,7 @@ import { CustomButton } from '@/components/shared';
 import { Popover, PopoverContent, PopoverTrigger, Separator } from '@/components/ui/primitives';
 import { authApi } from '@/lib/api/auth';
 import { getInitials } from '@/lib/utils';
-import { useAuthStore, REFRESH_TOKEN } from '@/stores/auth';
+import { useAuthStore } from '@/stores/auth';
 
 /** Standard "Settings" entry for the account menu. Every rail except the
  * settings rail itself (where you're already in Settings) passes this as
@@ -43,13 +43,10 @@ export function AccountMenu({
   const { user, clearAuth } = useAuthStore();
 
   const handleLogout = async () => {
-    // Capture the refresh token BEFORE wiping storage so we can hand it
-    // to the backend, which uses it to revoke the matching session row.
-    const refreshToken = typeof window !== 'undefined' ? localStorage.getItem(REFRESH_TOKEN) : null;
     try {
-      if (refreshToken) {
-        await authApi.logout({ refresh_token: refreshToken });
-      }
+      // The refresh token is an httpOnly cookie sent automatically; the backend
+      // reads it to revoke the session row and clears both auth cookies.
+      await authApi.logout();
     } catch (error) {
       // Logout is best-effort on the server; we still log the user out locally.
       console.error('Logout error:', error);

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -29,7 +29,9 @@ import {
 } from '@/components/ui/primitives';
 import { useNavigation } from '@/contexts/navigation';
 import { cn } from '@/lib/utils';
+import { switchOrganization } from '@/services/organizationService';
 import { useAuthStore } from '@/stores/auth';
+import { handleApiError } from '@/utils/helpers';
 
 const NAV_SECTIONS: SidebarNavGroup[] = [
   {
@@ -111,15 +113,22 @@ function WorkspaceSwitcher({ collapsed }: { collapsed: boolean }) {
                 <CustomButton
                   key={org.id}
                   type="text"
-                  onClick={() => {
+                  onClick={async () => {
                     if (String(org.id) === String(activeOrgId ?? organization?.id)) {
                       return;
                     }
-                    setActiveOrgId(String(org.id));
-                    // Reload so the new tenant_id header is picked up
-                    // by every in-flight & queued request.
-                    if (typeof window !== 'undefined') {
-                      window.location.reload();
+                    try {
+                      // Membership-verified switch: the server sets fresh
+                      // httpOnly cookies whose tokens carry the new org.
+                      await switchOrganization(String(org.id));
+                      setActiveOrgId(String(org.id));
+                      // Reload so the new session context is picked up by every
+                      // in-flight & queued request.
+                      if (typeof window !== 'undefined') {
+                        window.location.reload();
+                      }
+                    } catch (err) {
+                      handleApiError(err);
                     }
                   }}
                   className={cn(

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -11,7 +11,13 @@ export const FIREBASE_SIGNUP = '/auth/signup_with_firebase';
 export const ROUTE_LOGIN = '/login';
 export const ROUTE_HOME = '/home';
 
-export const BACKEND_URL = `${process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000'}/api/v1`;
+// When the dev API proxy is enabled the browser talks to the Next.js origin
+// (relative URL) so the httpOnly auth cookie is same-origin; otherwise it hits
+// the API host directly (prod: shared *.trytone.ai parent domain).
+export const BACKEND_URL =
+  process.env.NEXT_PUBLIC_USE_API_PROXY === 'true'
+    ? '/api/v1'
+    : `${process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000'}/api/v1`;
 
 // Grafana Loki logs link (Call History → per-call logs). Environment-specific: the base
 // host and the Loki "app" label differ between staging and production.

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { ACCESS_TOKEN, ROUTE_HOME, ROUTE_LOGIN } from '@/constants';
+
+// Public (unauthenticated) pages under the (auth) route group, plus the root
+// redirector. Everything else requires a session cookie.
+const PUBLIC_PATHS = [
+  ROUTE_LOGIN,
+  '/signup',
+  '/sign-in-with-code',
+  '/accept-invite',
+  '/forgot-password',
+  '/reset-password',
+  '/verify-email',
+];
+
+function isPublicPath(pathname: string): boolean {
+  if (pathname === '/') return true;
+  return PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+}
+
+/**
+ * Server-side auth guard. The access JWT lives in an httpOnly cookie scoped to
+ * the shared parent domain, so it reaches this Next.js origin and can be read
+ * here (JS in the browser cannot). We gate on cookie *presence*; validity is
+ * enforced per-request by the API (401 → silent refresh). The cookie outlives
+ * the short JWT (session-length max-age) so this check stays true across
+ * silent refreshes.
+ */
+export function middleware(request: NextRequest) {
+  const { pathname, search } = request.nextUrl;
+  const hasSession = request.cookies.has(ACCESS_TOKEN);
+
+  if (isPublicPath(pathname)) {
+    // Already-authenticated users shouldn't sit on the login page.
+    if (hasSession && pathname === ROUTE_LOGIN) {
+      return NextResponse.redirect(new URL(ROUTE_HOME, request.url));
+    }
+    return NextResponse.next();
+  }
+
+  if (!hasSession) {
+    const loginUrl = new URL(ROUTE_LOGIN, request.url);
+    const returnTo = `${pathname}${search}`;
+    if (returnTo && returnTo !== '/') {
+      loginUrl.searchParams.set('next', returnTo);
+    }
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  // Run on every route except API (incl. the dev proxy), Next internals, and
+  // static files (any path with a file extension, e.g. .png/.css/.ico).
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|.*\\..*).*)'],
+};

--- a/frontend/src/services/auth/helper.tsx
+++ b/frontend/src/services/auth/helper.tsx
@@ -1,14 +1,13 @@
-import { ACCESS_TOKEN, FIREBASE_SIGNUP, LOGIN_DATA, SIGNUP, TENANT_ID } from '@/constants';
+import { FIREBASE_SIGNUP, LOGIN_DATA, SIGNUP, TENANT_ID } from '@/constants';
 
 import axios from '@/utils/axios';
 import { handleApiError } from '@/utils/helpers';
 
+// Persists only the non-sensitive session payload. The access/refresh tokens
+// are set as httpOnly cookies by the server response and are never handled here.
 export const setToken = async (LogInData: any) => {
   if (typeof window === 'undefined') return LogInData;
 
-  if (LogInData?.access_token) {
-    localStorage.setItem(ACCESS_TOKEN, LogInData.access_token);
-  }
   if (LogInData?.user_id != null) {
     localStorage.setItem('user_id', String(LogInData.user_id));
   }

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -1,20 +1,7 @@
 import { create } from 'zustand';
 
-import { ACCESS_TOKEN, LOGIN_DATA, TENANT_ID } from '@/constants';
+import { LOGIN_DATA, TENANT_ID } from '@/constants';
 import type { AuthLoginResponse, Organization, User, UserOrganization } from '@/types/auth';
-import { decodeJWT } from '@/utils/jwt';
-
-function readRoleFromToken(token: string | null): string | null {
-  if (!token) return null;
-  try {
-    const claims = decodeJWT(token);
-    return (claims?.role as string) || null;
-  } catch {
-    return null;
-  }
-}
-
-const REFRESH_TOKEN = 'refresh_token';
 
 interface AuthState {
   user: User | null;
@@ -41,6 +28,17 @@ function readJSON<T>(key: string): T | null {
   } catch {
     return null;
   }
+}
+
+// Persist the membership list into the readable login_data payload so a page
+// reload rebuilds the workspace switcher from localStorage instantly, instead
+// of showing "one workspace" until the async fetch returns. The login response
+// itself does not carry the full org list — it's fetched after login.
+function persistOrganizations(orgs: UserOrganization[]) {
+  if (typeof window === 'undefined') return;
+  const loginData = readJSON<AuthLoginResponse>(LOGIN_DATA);
+  if (!loginData) return;
+  localStorage.setItem(LOGIN_DATA, JSON.stringify({ ...loginData, organizations: orgs }));
 }
 
 // Build a clean Organization + User pair from the active membership. The
@@ -71,7 +69,6 @@ function bootstrap() {
     };
   }
   const loginData = readJSON<AuthLoginResponse>(LOGIN_DATA);
-  const token = localStorage.getItem(ACCESS_TOKEN);
   const activeOrgId = localStorage.getItem(TENANT_ID);
 
   // Prefer the new tone-test shape (user + organization objects).
@@ -107,17 +104,22 @@ function bootstrap() {
   }
 
   // Role is contextual to the active membership — fall back to the login
-  // payload / token claims when no membership row carried one.
+  // payload when no membership row carried one. (The JWT is now an httpOnly
+  // cookie JS can't read, so role always comes from the login response body.)
   if (user && !user.role) {
-    user.role = (loginData?.role as string) ?? readRoleFromToken(token) ?? null;
+    user.role = (loginData?.role as string) ?? null;
   }
 
+  // The tokens live in httpOnly cookies; the presence of the readable
+  // login_data payload is our client-side signal that a session exists. The
+  // authoritative gate is the server-side Next.js middleware (which reads the
+  // cookie) plus per-request 401 handling.
   return {
     user,
     organization,
     organizations,
     activeOrgId: activeOrgId || organization?.id || null,
-    isAuthenticated: !!token,
+    isAuthenticated: !!loginData,
   };
 }
 
@@ -137,8 +139,8 @@ export const useAuthStore = create<AuthState>((set) => ({
   },
   setLoginResponse: (data) => {
     if (typeof window !== 'undefined') {
-      if (data.access_token) localStorage.setItem(ACCESS_TOKEN, data.access_token);
-      if (data.refresh_token) localStorage.setItem(REFRESH_TOKEN, data.refresh_token);
+      // Tokens are set as httpOnly cookies by the server; we persist only the
+      // non-sensitive profile/org payload for UI hydration.
       localStorage.setItem(LOGIN_DATA, JSON.stringify(data));
       if (data.user_id != null) localStorage.setItem('user_id', String(data.user_id));
       else if (data.user?.id != null) localStorage.setItem('user_id', String(data.user.id));
@@ -173,7 +175,10 @@ export const useAuthStore = create<AuthState>((set) => ({
         : null,
     }));
   },
-  setOrganizations: (orgs) =>
+  setOrganizations: (orgs) => {
+    // Cache the list so a reload hydrates the switcher without waiting for the
+    // async fetch (the login response doesn't include it).
+    persistOrganizations(orgs);
     set((s) => {
       // The full membership list arrives async (DashboardLayout fetches it
       // after bootstrap), so this is our first chance to reconcile the
@@ -187,11 +192,12 @@ export const useAuthStore = create<AuthState>((set) => ({
         organization: reconciled.organization,
         user: reconciled.user,
       };
-    }),
+    });
+  },
   clearAuth: () => {
     if (typeof window !== 'undefined') {
-      localStorage.removeItem(ACCESS_TOKEN);
-      localStorage.removeItem(REFRESH_TOKEN);
+      // Only readable state — the httpOnly token cookies are cleared by the
+      // backend `/auth/logout` call in the logout flow.
       localStorage.removeItem(TENANT_ID);
       localStorage.removeItem(LOGIN_DATA);
       localStorage.removeItem('user_id');
@@ -205,5 +211,3 @@ export const useAuthStore = create<AuthState>((set) => ({
     });
   },
 }));
-
-export { REFRESH_TOKEN };

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -31,7 +31,9 @@ export interface UserOrganization {
 }
 
 export interface AuthLoginResponse {
-  access_token: string;
+  // Tokens now ride in httpOnly cookies, not the JSON body — these remain
+  // optional only for backward-compatibility with older/non-cookie clients.
+  access_token?: string;
   refresh_token?: string;
   token_type?: string;
   expires_in?: number;

--- a/frontend/src/utils/authSession.ts
+++ b/frontend/src/utils/authSession.ts
@@ -1,36 +1,21 @@
-import { ACCESS_TOKEN, LOGIN_DATA, ROUTE_LOGIN, TENANT_ID } from '@/constants';
+import { LOGIN_DATA, ROUTE_LOGIN, TENANT_ID } from '@/constants';
 import { showToast } from '@/utils/toast';
 
-export const REFRESH_TOKEN = 'refresh_token';
 const USER_ID = 'user_id';
-const REDIRECT_QUERY_PARAM = 'redirect';
+// Must match the query param the login page reads (`?next=`) and the one the
+// Next.js middleware sets, so forced-logout returns the user to where they were.
+const REDIRECT_QUERY_PARAM = 'next';
 
 const isBrowser = () => typeof window !== 'undefined';
 
-export function getAccessToken(): string | null {
-  return isBrowser() ? localStorage.getItem(ACCESS_TOKEN) : null;
-}
-
-export function getRefreshToken(): string | null {
-  return isBrowser() ? localStorage.getItem(REFRESH_TOKEN) : null;
-}
-
-export function setTokens({
-  accessToken,
-  refreshToken,
-}: {
-  accessToken: string;
-  refreshToken?: string | null;
-}) {
-  if (!isBrowser()) return;
-  localStorage.setItem(ACCESS_TOKEN, accessToken);
-  if (refreshToken) localStorage.setItem(REFRESH_TOKEN, refreshToken);
-}
-
+/**
+ * Clears the JS-readable session state (user profile, active org). The access
+ * and refresh tokens themselves live in httpOnly cookies that JS cannot touch;
+ * those are cleared server-side by the `/auth/logout` endpoint (manual logout)
+ * or simply expire.
+ */
 export function clearAuthStorage() {
   if (!isBrowser()) return;
-  localStorage.removeItem(ACCESS_TOKEN);
-  localStorage.removeItem(REFRESH_TOKEN);
   localStorage.removeItem(TENANT_ID);
   localStorage.removeItem(LOGIN_DATA);
   localStorage.removeItem(USER_ID);

--- a/frontend/src/utils/axios.ts
+++ b/frontend/src/utils/axios.ts
@@ -1,26 +1,39 @@
 import Axios, { AxiosError, AxiosRequestConfig } from 'axios';
 
 import { BACKEND_URL, TENANT_ID } from '@/constants';
-import {
-  endSession,
-  getAccessToken,
-  getRefreshToken,
-  markAuthHandled,
-  setTokens,
-} from '@/utils/authSession';
+import { endSession, markAuthHandled } from '@/utils/authSession';
 
 interface RetriableRequestConfig extends AxiosRequestConfig {
   _retry?: boolean;
 }
 
+// Pre-auth endpoints: a 401 here is a credential/token error, not an expired
+// session, so it must NOT trigger the silent-refresh flow.
+const NON_REFRESHABLE_PREFIXES = [
+  '/auth/login',
+  '/auth/signup',
+  '/auth/refresh',
+  '/auth/signin-code',
+  '/auth/forgot-password',
+  '/auth/forget-password',
+  '/auth/reset-password',
+  '/auth/verify-email',
+  '/auth/accept-invitation',
+  '/auth/validate-invitation',
+];
+
 const axiosInstance = Axios.create({
   baseURL: BACKEND_URL,
   headers: { 'Content-Type': 'application/json' },
+  // Access + refresh JWTs live in httpOnly cookies; withCredentials makes the
+  // browser attach them (and store rotated ones) on every cross-origin call.
+  withCredentials: true,
 });
 
 axiosInstance.interceptors.request.use((config) => {
-  const token = getAccessToken();
-  if (token) config.headers.Authorization = `Bearer ${token}`;
+  // No Authorization header — the token rides in the httpOnly cookie. We only
+  // attach the non-sensitive active-org hint so the backend can scope the
+  // tenant (it re-verifies membership before honouring it).
   if (typeof window !== 'undefined') {
     const tenantId = localStorage.getItem(TENANT_ID);
     if (tenantId) config.headers['tenant_id'] = tenantId;
@@ -29,17 +42,17 @@ axiosInstance.interceptors.request.use((config) => {
 });
 
 interface QueueEntry {
-  resolve: (token: string) => void;
+  resolve: () => void;
   reject: (err: unknown) => void;
 }
 
 let isRefreshing = false;
 let queue: QueueEntry[] = [];
 
-function resolveQueue(token: string) {
+function resolveQueue() {
   const pending = queue;
   queue = [];
-  pending.forEach(({ resolve }) => resolve(token));
+  pending.forEach(({ resolve }) => resolve());
 }
 
 function rejectQueue(error: unknown) {
@@ -48,34 +61,29 @@ function rejectQueue(error: unknown) {
   pending.forEach(({ reject }) => reject(error));
 }
 
-function enqueueRefreshWaiter(): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
+function enqueueRefreshWaiter(): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
     queue.push({ resolve, reject });
   });
 }
 
 /**
  * Called from the manual logout flow so any requests waiting on an in-flight
- * refresh don't hang after storage is cleared. Safe to call at any time.
+ * refresh don't hang after the session ends. Safe to call at any time.
  */
 export function abortAuthRefresh(error?: unknown) {
   rejectQueue(error ?? new Error('Auth session ended'));
   isRefreshing = false;
 }
 
-async function refreshAccessToken(refreshToken: string): Promise<string> {
-  const { data } = await Axios.post(`${BACKEND_URL}/auth/refresh`, {
-    refresh_token: refreshToken,
-  });
-  const newAccess = data?.access_token as string | undefined;
-  if (!newAccess) throw new Error('No access_token in refresh response');
-  setTokens({ accessToken: newAccess, refreshToken: data?.refresh_token ?? null });
-  return newAccess;
+async function refreshSession(): Promise<void> {
+  // The refresh token is an httpOnly cookie — nothing to send in the body. The
+  // backend reads it from the cookie and sets a rotated cookie pair on the
+  // response; there are no tokens for JS to store.
+  await Axios.post(`${BACKEND_URL}/auth/refresh`, {}, { withCredentials: true });
 }
 
-function retryWithToken(config: RetriableRequestConfig, token: string) {
-  config.headers = config.headers || {};
-  (config.headers as Record<string, string>).Authorization = `Bearer ${token}`;
+function retryOriginal(config: RetriableRequestConfig) {
   config._retry = true;
   return axiosInstance(config);
 }
@@ -86,17 +94,19 @@ axiosInstance.interceptors.response.use(
     const original = (error.config || {}) as RetriableRequestConfig;
     const status = error.response?.status;
 
-    // Only skip the refresh dance for the refresh endpoint itself — any other
-    // /auth/* call (e.g. /auth/change-password) must still be eligible for a
-    // silent token refresh.
-    const isRefreshRoute =
-      typeof original.url === 'string' && original.url.startsWith('/auth/refresh');
+    // A 401 from a pre-auth endpoint (login, signup, refresh, code/reset flows)
+    // means bad credentials or an invalid token — NOT an expired session — so it
+    // must surface to the caller instead of triggering a silent refresh (which
+    // would fail and needlessly tear the session down). Authenticated /auth/*
+    // calls (change-password, me, switch_organization) stay refreshable.
+    const url = typeof original.url === 'string' ? original.url : '';
+    const skipRefresh = NON_REFRESHABLE_PREFIXES.some((p) => url.startsWith(p));
 
-    if (status !== 401 || isRefreshRoute) {
+    if (status !== 401 || skipRefresh) {
       return Promise.reject(error);
     }
 
-    // Second 401 after we already retried with a fresh token means the new
+    // Second 401 after we already retried with a fresh cookie means the new
     // token was also rejected — the session is unusable, log the user out
     // instead of surfacing a raw error.
     if (original._retry) {
@@ -108,16 +118,10 @@ axiosInstance.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    const refreshToken = getRefreshToken();
-    if (!refreshToken) {
-      endSession({ reason: 'expired' });
-      return Promise.reject(markAuthHandled(error));
-    }
-
     if (isRefreshing) {
       try {
-        const token = await enqueueRefreshWaiter();
-        return retryWithToken(original, token);
+        await enqueueRefreshWaiter();
+        return retryOriginal(original);
       } catch (waiterErr) {
         return Promise.reject(waiterErr);
       }
@@ -125,9 +129,9 @@ axiosInstance.interceptors.response.use(
 
     isRefreshing = true;
     try {
-      const newAccess = await refreshAccessToken(refreshToken);
-      resolveQueue(newAccess);
-      return retryWithToken(original, newAccess);
+      await refreshSession();
+      resolveQueue();
+      return retryOriginal(original);
     } catch (refreshErr) {
       const handledErr = markAuthHandled(refreshErr);
       rejectQueue(handledErr);

--- a/frontend/src/utils/jwt.tsx
+++ b/frontend/src/utils/jwt.tsx
@@ -1,9 +1,0 @@
-import { Buffer } from 'buffer';
-
-export function decodeJWT(token: any) {
-  if (token) {
-    const tokenDecodablePart = token.split('.')[1];
-    const decoded = Buffer.from(tokenDecodablePart, 'base64').toString();
-    return JSON.parse(decoded);
-  }
-}

--- a/main.py
+++ b/main.py
@@ -76,12 +76,16 @@ edition = "enterprise" if ee_enabled else "core"
 
 app = FastAPI(title=f"Tone API - {edition.title()}", version="1.0.0")
 
+# Cookie-based auth means requests are credentialed, and browsers reject
+# `Allow-Origin: *` with credentials — so we reflect an explicit allow-list
+# (exact origins for local dev + a regex for every *.trytone.ai subdomain).
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=settings.CORS_ALLOW_ORIGINS,
+    allow_origin_regex=settings.CORS_ALLOW_ORIGIN_REGEX,
     allow_credentials=True,
     allow_methods=["*"],
-    allow_headers=["*"],
+    allow_headers=["*", "Authorization", "tenant_id", "Content-Type"],
 )
 app.add_middleware(RequestContextMiddleware)
 
@@ -89,7 +93,8 @@ api_v1 = FastAPI()
 
 api_v1.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=settings.CORS_ALLOW_ORIGINS,
+    allow_origin_regex=settings.CORS_ALLOW_ORIGIN_REGEX,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*", "Authorization", "tenant_id", "Content-Type"],

--- a/shared/config.py
+++ b/shared/config.py
@@ -178,7 +178,15 @@ class Settings:
 
         # Per-call sync tuning. No enable/disable flag — the post-call action is
         # always wired; loki_read_configured() alone gates it.
-        self.LOKI_SYNC_APP_LABEL: str = get_secret("LOKI_SYNC_APP_LABEL", "tone")
+        # Loki stream selector for the per-call log fetch — the trace_id line
+        # filter does the real per-call scoping; this just narrows the streams.
+        # Set LOKI_SYNC_APP_LABEL to a single workload (builds {app="<value>"}),
+        # e.g. staging-tone-call-worker. Left blank, the query falls back to the
+        # env-agnostic {component=~"call|api"} (Alloy labels tone pods with
+        # component={call,api,worker}). NOTE: there is no app="tone" label — app
+        # values are the workload names, which is why the old default matched
+        # nothing.
+        self.LOKI_SYNC_APP_LABEL: str = get_secret("LOKI_SYNC_APP_LABEL", "").strip()
         self.LOKI_SYNC_DELAY_SECONDS: int = int(get_secret("LOKI_SYNC_DELAY_SECONDS", "120"))
         self.LOKI_SYNC_PRE_BUFFER_SECONDS: int = int(get_secret("LOKI_SYNC_PRE_BUFFER_SECONDS", "30"))
         self.LOKI_SYNC_POST_BUFFER_SECONDS: int = int(get_secret("LOKI_SYNC_POST_BUFFER_SECONDS", "60"))

--- a/shared/config.py
+++ b/shared/config.py
@@ -55,6 +55,37 @@ class Settings:
 
         self.ENVIRONMENT: str = get_secret("ENV", "development")
 
+        # ── Auth cookies (httpOnly access/refresh token transport) ──────────
+        # Tokens ride in httpOnly cookies instead of JS-readable storage so an
+        # XSS hole can't exfiltrate a session. In prod the frontend + API share
+        # a parent domain (e.g. app.trytone.ai + api.trytone.ai), so setting
+        # COOKIE_DOMAIN=.trytone.ai scopes one cookie to both. Left blank the
+        # cookie is host-only (correct for a single-origin dev proxy).
+        _cookie_env = self.ENVIRONMENT.lower()
+        _cookie_is_local = _cookie_env in ("development", "dev", "local", "test")
+        self.COOKIE_DOMAIN: str = get_secret("COOKIE_DOMAIN", "")
+        self.COOKIE_SECURE: bool = get_secret(
+            "COOKIE_SECURE", "false" if _cookie_is_local else "true"
+        ).lower() == "true"
+        # One of "lax" | "strict" | "none". "none" REQUIRES COOKIE_SECURE=true.
+        self.COOKIE_SAMESITE: str = get_secret("COOKIE_SAMESITE", "lax").lower()
+
+        # ── CORS (credentialed requests can't use a wildcard origin) ────────
+        # Browsers reject `Access-Control-Allow-Origin: *` together with
+        # credentials, so we reflect an explicit allow-list. CORS_ALLOW_ORIGINS
+        # is an exact comma-separated list (local dev); CORS_ALLOW_ORIGIN_REGEX
+        # covers every *.trytone.ai subdomain in deployed envs.
+        self.CORS_ALLOW_ORIGINS: list = [
+            o.strip()
+            for o in get_secret(
+                "CORS_ALLOW_ORIGINS", "http://localhost:3000,http://localhost:3001"
+            ).split(",")
+            if o.strip()
+        ]
+        self.CORS_ALLOW_ORIGIN_REGEX: str = get_secret(
+            "CORS_ALLOW_ORIGIN_REGEX", r"https://([a-z0-9-]+\.)*trytone\.ai"
+        )
+
         self.POD_PINNING_ENABLED: bool = get_secret("POD_PINNING_ENABLED", "false").lower() == "true"
         self.CALL_SERVER_HOST: str = get_secret("CALL_SERVER_HOST", "")
         self.CALL_WORKER_PREFIX: str = get_secret("CALL_WORKER_PREFIX", "staging-tone-call-worker")

--- a/test-cases/core/test_agent_readiness.py
+++ b/test-cases/core/test_agent_readiness.py
@@ -159,6 +159,93 @@ class TestPostReadiness:
         assert row["status"] in ("pass", "fail", "skipped")
 
 
+# ─── POST /api/v1/agent/{agent_id}/readiness with `categories` filter ───
+
+class TestPostReadinessCategoriesFilter:
+    """Tests for the ``categories`` request field on POST /readiness.
+
+    This is the API entry point the frontend uses for save-time targeted deep.
+    Unit tests in ``test_readiness_runner_filter.py`` pin down the runner
+    filter behaviour directly; these confirm the endpoint accepts / validates /
+    forwards ``categories`` correctly and that the returned report shape stays
+    intact so the frontend merge helper can operate.
+    """
+
+    def test_categories_accepted_alongside_deep(self, client_as_member):
+        """The endpoint accepts a categories array with depth=deep."""
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.post(
+            f"/api/v1/agent/{agent['id']}/readiness",
+            json={"depth": "deep", "categories": ["llm"]},
+        )
+        # 200 on success; 429 if deep-cache/rate-limit fires from a prior run
+        # in the same test session — either shape confirms the endpoint
+        # deserialised the categories array without complaint.
+        assert resp.status_code in (200, 429)
+
+    def test_categories_omitted_still_works(self, client_as_member):
+        """Backwards-compat: omitting `categories` == full deep (publish path)."""
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.post(
+            f"/api/v1/agent/{agent['id']}/readiness",
+            json={"depth": "deep"},
+        )
+        assert resp.status_code in (200, 429)
+
+    def test_categories_empty_list_accepted(self, client_as_member):
+        """Empty list is a valid input — server treats it as "probe nothing
+        deep" and every deep check comes back SKIPPED."""
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.post(
+            f"/api/v1/agent/{agent['id']}/readiness",
+            json={"depth": "deep", "categories": []},
+        )
+        assert resp.status_code in (200, 429)
+
+    def test_categories_ignored_on_shallow(self, client_as_member):
+        """Shallow doesn't run deep checks — categories is meaningless there
+        but must not cause the endpoint to reject the request."""
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.post(
+            f"/api/v1/agent/{agent['id']}/readiness",
+            json={"depth": "shallow", "categories": ["llm", "tools"]},
+        )
+        assert resp.status_code == 200
+
+    def test_categories_invalid_value_rejected(self, client_as_member):
+        """Values outside the Category enum are rejected by pydantic before
+        reaching the runner — protects against typos in the frontend diff util."""
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.post(
+            f"/api/v1/agent/{agent['id']}/readiness",
+            json={"depth": "deep", "categories": ["not_a_real_category"]},
+        )
+        assert resp.status_code == 422
+
+    def test_non_matching_deep_checks_marked_unchanged(self, client_as_member):
+        """The load-bearing behaviour: any deep check whose category isn't in
+        the filter set comes back SKIPPED with the marker string the
+        frontend's `mergeReadinessReports` keys on."""
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.post(
+            f"/api/v1/agent/{agent['id']}/readiness",
+            json={"depth": "deep", "categories": ["llm"]},
+        )
+        if resp.status_code != 200:
+            # Deep cache / rate-limit collision — test skips rather than fails
+            # because the categories-forwarding assertion above already covers
+            # the endpoint path, and this assertion is about response shape.
+            return
+        checks = resp.json()["checks"]
+        by_id = {c["check_id"]: c for c in checks}
+        # A deep check that IS NOT in {llm} must be filter-skipped with the
+        # marker the frontend uses to preserve the previous entry.
+        stt_deep = by_id.get("stt.provider_reachable")
+        if stt_deep is not None and stt_deep["status"] == "skipped":
+            reason = stt_deep.get("skip_reason") or stt_deep.get("message") or ""
+            assert "Not re-probed on this save" in reason
+
+
 # ─── GET /api/v1/agent/{agent_id}/readiness/summary ───
 
 class TestGetReadinessSummary:

--- a/test-cases/core/test_readiness_probes.py
+++ b/test-cases/core/test_readiness_probes.py
@@ -1,0 +1,463 @@
+"""Unit tests for the readiness probe helpers and probe functions.
+
+Source: core/services/readiness/probes.py + core/services/readiness/checks/tools.py
+        + core/services/readiness/checks/mcp_servers.py
+
+Kept independent from the API-level integration tests in test_agent_readiness.py.
+Those exercise the whole request path against a real DB; this file drills into
+the pipecat-facing probe internals with mocks so provider outages, ErrorFrame
+handling, transcript assertion, WAV loading and HTTP probing can be verified
+without any live LLM/STT/TTS/HTTP dependency.
+
+Async style: tests call `asyncio.run(probe(...))` so we don't need
+pytest-asyncio (not in requirements). The probes are self-contained coroutines
+so this is safe.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+
+# ─── Fakes shared across probe tests ──────────────────────────────────────────
+
+
+class _FakeAsyncStream:
+    """Async iterator that yields a fixed list of frames.
+
+    Used as the return value for mocked ``service.run_stt`` / ``run_tts`` so
+    each test controls exactly which frame shapes the probe sees.
+    """
+
+    def __init__(self, frames):
+        self._frames = list(frames)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._frames:
+            raise StopAsyncIteration
+        return self._frames.pop(0)
+
+
+def _fake_spec_ctx(service_type: str = "stt"):
+    """Build a minimal duck-typed CheckContext for a single-service probe.
+
+    The probes read ``ctx.<service>.provider``, ``.decrypted_key``,
+    ``.model``, ``.settings``. Everything else on CheckContext is untouched.
+    """
+    leg = SimpleNamespace(
+        settings={"sample_rate": 16000},
+        provider_id="pid",
+        model_id="mid",
+        provider=SimpleNamespace(slug="testprovider"),
+        model=SimpleNamespace(name="test-model"),
+        api_key=SimpleNamespace(),
+        decrypted_key="fake-key",
+    )
+    ctx = SimpleNamespace(**{service_type: leg})
+    return ctx
+
+
+# ─── URL shape (shallow tool check) ───────────────────────────────────────────
+
+
+class TestUrlShapeProblem:
+    """`_url_shape_problem` guards the shallow ToolsUsableCheck against
+    malformed URLs so the badge fails fast without a network call."""
+
+    def test_empty_urls_flagged(self):
+        from core.services.readiness.checks.tools import _url_shape_problem
+        for empty in (None, "", "   "):
+            assert _url_shape_problem(empty) == "no URL"
+
+    def test_missing_scheme_flagged(self):
+        from core.services.readiness.checks.tools import _url_shape_problem
+        assert _url_shape_problem("foo.com") == "URL scheme must be http/https"
+
+    def test_wrong_scheme_flagged(self):
+        from core.services.readiness.checks.tools import _url_shape_problem
+        assert _url_shape_problem("htps://foo.com") == "URL scheme must be http/https"
+        assert _url_shape_problem("ftp://foo.com") == "URL scheme must be http/https"
+
+    def test_missing_host_flagged(self):
+        from core.services.readiness.checks.tools import _url_shape_problem
+        assert _url_shape_problem("http://") == "URL missing host"
+
+    def test_wellformed_returns_none(self):
+        from core.services.readiness.checks.tools import _url_shape_problem
+        for good in (
+            "http://example.com",
+            "https://example.com",
+            "HTTPS://Example.com",  # urlparse normalises scheme
+            "https://example.com/api?x=1",
+        ):
+            assert _url_shape_problem(good) is None, good
+
+
+# ─── STT audio helpers (probe internals) ──────────────────────────────────────
+
+
+class TestStttAudioLoader:
+    """Verify the bundled WAV is loadable + resampling stays honest."""
+
+    def test_asset_loads_at_16k_mono_pcm16(self):
+        from core.services.readiness.probes import _load_probe_pcm16
+        _load_probe_pcm16.cache_clear()
+        loaded = _load_probe_pcm16()
+        # If a maintainer removes the WAV, this test tells them clearly.
+        assert loaded is not None, "probe_sample.wav missing from assets/"
+        pcm, rate = loaded
+        assert rate == 16000
+        # Duration must stay within the 5-10s window the STT probe expects.
+        duration_s = len(pcm) / (rate * 2)
+        assert 5.0 <= duration_s <= 10.0, f"WAV duration {duration_s:.2f}s outside 5-10s window"
+
+    def test_resample_to_different_rate(self):
+        from core.services.readiness.probes import _load_stt_audio
+        pcm_16k, real_16k = _load_stt_audio(16000)
+        pcm_8k, real_8k = _load_stt_audio(8000)
+        assert real_16k and real_8k, "using_real_audio flag should be True when WAV present"
+        # 8kHz is half of 16kHz → resampled buffer is roughly half the byte count.
+        ratio = len(pcm_8k) / len(pcm_16k)
+        assert 0.45 < ratio < 0.55, f"8kHz resample ratio {ratio:.2f} not ~0.5"
+
+    def test_silence_fallback_when_asset_missing(self):
+        """When _load_probe_pcm16 returns None, we fall back to silence
+        + flip the ``using_real_audio`` flag so the probe knows not to
+        assert on transcription."""
+        from core.services.readiness.probes import _load_stt_audio
+        with patch("core.services.readiness.probes._load_probe_pcm16", return_value=None):
+            pcm, real = _load_stt_audio(16000)
+            assert real is False
+            assert pcm == b"\x00\x00" * 8000  # 0.5s of PCM16 silence
+
+
+# ─── Frame extractors ─────────────────────────────────────────────────────────
+
+
+class TestTranscriptExtractor:
+    def test_returns_text_when_present(self):
+        from core.services.readiness.probes import _extract_transcript_text
+        frame = SimpleNamespace(text="the quick brown fox")
+        assert _extract_transcript_text(frame, ()) == "the quick brown fox"
+
+    def test_rejects_whitespace_only(self):
+        """A provider emitting ' ' between chunks isn't a real transcript."""
+        from core.services.readiness.probes import _extract_transcript_text
+        for empty in (SimpleNamespace(text=" "), SimpleNamespace(text=""), SimpleNamespace(text="\n\n")):
+            assert _extract_transcript_text(empty, ()) is None
+
+    def test_rejects_frame_without_text(self):
+        from core.services.readiness.probes import _extract_transcript_text
+        assert _extract_transcript_text(SimpleNamespace(), ()) is None
+
+
+class TestErrorFrameExtractor:
+    """Regression test for the exact production bug this file was born to catch:
+    pipecat WS providers surface auth/quota failures via ErrorFrame in the
+    stream, not by raising. Probes MUST detect these or a Fish Audio 402
+    silently passes readiness."""
+
+    def test_isinstance_path_returns_error_message(self):
+        from core.services.readiness.probes import _extract_error_frame_message
+        from pipecat.frames.frames import ErrorFrame
+        frame = ErrorFrame(error="server rejected WebSocket connection: HTTP 402")
+        msg = _extract_error_frame_message(frame, ErrorFrame)
+        assert msg and "402" in msg
+
+    def test_duck_typed_fallback_when_pipecat_import_fails(self):
+        """When ErrorFrame class isn't importable (e.g. pipecat missing at
+        readiness-check time), the duck-typed fallback still catches any
+        class whose name ends in ErrorFrame and carries an ``.error`` attr."""
+        from core.services.readiness.probes import _extract_error_frame_message
+
+        class FakeErrorFrame:
+            error = "HTTP 402"
+
+        msg = _extract_error_frame_message(FakeErrorFrame(), None)
+        assert msg == "HTTP 402"
+
+    def test_non_error_frame_returns_none(self):
+        from core.services.readiness.probes import _extract_error_frame_message
+        from pipecat.frames.frames import ErrorFrame
+        assert _extract_error_frame_message(SimpleNamespace(audio=b"\x00"), ErrorFrame) is None
+        assert _extract_error_frame_message(SimpleNamespace(text="hi"), None) is None
+
+
+# ─── TTS probe (the primary regression surface) ───────────────────────────────
+
+
+class TestProbeTts:
+    """Exercise every branch of probe_tts. Mocks pipecat via
+    ``service_factory.build_tts`` so no live provider is required."""
+
+    def _run(self, service):
+        """Call probe_tts against a fake service. Returns ProbeResult."""
+        from core.services.readiness import probes
+        ctx = _fake_spec_ctx("tts")
+        with patch.object(probes, "_build_spec", return_value={
+            "provider_name": "fake_tts",
+            "api_key": "k",
+            "model_name": "m",
+            "metadata": {},
+            "model_meta_data": {},
+        }):
+            from core.services.pipeline import service_factory
+            with patch.object(service_factory, "build_tts", return_value=service):
+                return asyncio.run(probes.probe_tts(ctx))
+
+    def test_pass_on_audio_frame(self):
+        """Healthy TTS emits a TTSAudioRawFrame with audio bytes → PASS."""
+        from pipecat.frames.frames import TTSAudioRawFrame
+        audio_frame = TTSAudioRawFrame(audio=b"\x00\x01", sample_rate=24000, num_channels=1)
+        service = MagicMock()
+        service.run_tts = MagicMock(return_value=_FakeAsyncStream([audio_frame]))
+        result = self._run(service)
+        assert result.ok is True
+        assert "synthesised" in result.message.lower()
+
+    def test_fail_on_error_frame(self):
+        """Regression: Fish Audio HTTP 402 arrives as an ErrorFrame in the
+        stream; probe MUST fail with the provider's message, not soft-pass."""
+        from pipecat.frames.frames import ErrorFrame
+        err = ErrorFrame(error="server rejected WebSocket connection: HTTP 402")
+        service = MagicMock()
+        service.run_tts = MagicMock(return_value=_FakeAsyncStream([err]))
+        result = self._run(service)
+        assert result.ok is False
+        assert "402" in result.message
+
+    def test_fail_on_no_audio(self):
+        """Regression: previously returned a soft PASS on an empty stream —
+        now a real sentence probe MUST produce audio to be considered healthy."""
+        service = MagicMock()
+        service.run_tts = MagicMock(return_value=_FakeAsyncStream([]))
+        result = self._run(service)
+        assert result.ok is False
+        assert "no audio" in result.message.lower()
+
+    def test_fail_when_construction_raises(self):
+        """A broken client construction (bad API key at init time) → clear FAIL."""
+        from core.services.readiness import probes
+        ctx = _fake_spec_ctx("tts")
+        with patch.object(probes, "_build_spec", return_value={
+            "provider_name": "fake_tts", "api_key": "k", "model_name": "m",
+            "metadata": {}, "model_meta_data": {},
+        }):
+            from core.services.pipeline import service_factory
+            with patch.object(service_factory, "build_tts", side_effect=RuntimeError("bad key")):
+                result = asyncio.run(probes.probe_tts(ctx))
+        assert result.ok is False
+        assert "bad key" in result.message
+
+
+# ─── STT probe ────────────────────────────────────────────────────────────────
+
+
+class TestProbeStt:
+    """Exercise every branch of probe_stt. Same mocking pattern as TTS."""
+
+    def _run(self, service):
+        from core.services.readiness import probes
+        ctx = _fake_spec_ctx("stt")
+        with patch.object(probes, "_build_spec", return_value={
+            "provider_name": "fake_stt", "api_key": "k", "model_name": "m",
+            "metadata": {}, "model_meta_data": {},
+        }):
+            from core.services.pipeline import service_factory
+            with patch.object(service_factory, "build_stt", return_value=service):
+                return asyncio.run(probes.probe_stt(ctx))
+
+    def test_pass_on_transcription_frame(self):
+        """Healthy STT emits TranscriptionFrame with real text → PASS with snippet."""
+        from pipecat.frames.frames import TranscriptionFrame
+        frame = TranscriptionFrame(text="the quick brown fox", user_id="u", timestamp="t")
+        service = MagicMock()
+        service.run_stt = MagicMock(return_value=_FakeAsyncStream([frame]))
+        result = self._run(service)
+        assert result.ok is True
+        assert "transcribed" in result.message.lower()
+        assert "the quick brown fox" in result.message
+
+    def test_pass_on_interim_transcription_frame(self):
+        """Providers that only emit interims (streaming-only) still pass."""
+        from pipecat.frames.frames import InterimTranscriptionFrame
+        frame = InterimTranscriptionFrame(text="hello world", user_id="u", timestamp="t")
+        service = MagicMock()
+        service.run_stt = MagicMock(return_value=_FakeAsyncStream([frame]))
+        result = self._run(service)
+        assert result.ok is True
+        assert "hello world" in result.message
+
+    def test_fail_on_error_frame(self):
+        """Regression: WS-STT auth/quota failures arrive as ErrorFrame."""
+        from pipecat.frames.frames import ErrorFrame
+        err = ErrorFrame(error="invalid api key")
+        service = MagicMock()
+        service.run_stt = MagicMock(return_value=_FakeAsyncStream([err]))
+        result = self._run(service)
+        assert result.ok is False
+        assert "invalid api key" in result.message.lower()
+
+    def test_fail_on_no_frames_with_real_audio(self):
+        """WAV was present but provider returned nothing → clear FAIL."""
+        service = MagicMock()
+        service.run_stt = MagicMock(return_value=_FakeAsyncStream([]))
+        result = self._run(service)
+        assert result.ok is False
+        assert "no frames" in result.message.lower()
+
+    def test_fail_on_frames_without_transcript(self):
+        """Frames arrived but none carried text (whitespace-only) → FAIL with
+        language/model hint since that's the usual culprit."""
+        service = MagicMock()
+        # Non-error, non-transcript frames — e.g. audio ack frames with empty
+        # text — must not fool the assertion.
+        frame = SimpleNamespace(text=" ")
+        service.run_stt = MagicMock(return_value=_FakeAsyncStream([frame, frame]))
+        result = self._run(service)
+        assert result.ok is False
+        assert "no transcript" in result.message.lower()
+
+
+# ─── Tool GET probe (deep tools.reachable) ────────────────────────────────────
+
+
+class _StubTool:
+    """Duck-typed Tool row for _probe_tool (ToolReachableCheck internals)."""
+
+    def __init__(self, url="https://api.example.com", auth_type="none", auth_config=None):
+        self.id = "tool-id"
+        self.name = "TestTool"
+        self.url = url
+        self.method = "GET"
+        self.auth_type = auth_type
+        self.auth_config = auth_config or {}
+        self.tool_type = "custom"
+        self.is_active = True
+
+
+class TestToolReachableProbe:
+    """The tool GET probe classifies HTTP responses into buckets the drawer
+    can render meaningfully. Strict 2xx pass; 401/403 flagged as auth reject;
+    other non-2xx as HTTP status; network errors as unreachable."""
+
+    def _probe(self, response_or_exc):
+        """Invoke ToolReachableCheck._probe_tool against a stub httpx client."""
+        from core.services.readiness.checks.tools import ToolReachableCheck
+        check = ToolReachableCheck()
+
+        client = MagicMock()
+        if isinstance(response_or_exc, Exception):
+            client.get = AsyncMock(side_effect=response_or_exc)
+        else:
+            client.get = AsyncMock(return_value=response_or_exc)
+
+        tool = _StubTool()
+        return asyncio.run(check._probe_tool(client, tool))
+
+    def test_pass_on_2xx(self):
+        resp = MagicMock(status_code=204)
+        assert self._probe(resp) is None  # None == PASS in the probe contract
+
+    def test_fail_on_401_401(self):
+        resp = MagicMock(status_code=401)
+        reason = self._probe(resp)
+        assert reason is not None and "401" in reason and "auth" in reason.lower()
+
+    def test_fail_on_403(self):
+        resp = MagicMock(status_code=403)
+        reason = self._probe(resp)
+        assert reason is not None and "403" in reason and "auth" in reason.lower()
+
+    def test_fail_on_500(self):
+        resp = MagicMock(status_code=500)
+        reason = self._probe(resp)
+        assert reason is not None and "500" in reason
+
+    def test_fail_on_network_error(self):
+        reason = self._probe(httpx.ConnectError("dns lookup failed"))
+        assert reason is not None and "unreachable" in reason.lower()
+
+
+class TestToolReachableFilter:
+    """The check itself skips write-method / MCP / inactive tools so
+    side-effectful endpoints are never called."""
+
+    def _is_probeable(self, **overrides):
+        from core.services.readiness.checks.tools import ToolReachableCheck
+        tool = _StubTool()
+        for k, v in overrides.items():
+            setattr(tool, k, v)
+        return ToolReachableCheck._is_probeable(tool)
+
+    def test_get_custom_active_probeable(self):
+        assert self._is_probeable() is True
+
+    def test_post_skipped(self):
+        assert self._is_probeable(method="POST") is False
+
+    def test_delete_skipped(self):
+        assert self._is_probeable(method="DELETE") is False
+
+    def test_mcp_type_skipped(self):
+        assert self._is_probeable(tool_type="mcp") is False
+
+    def test_inactive_skipped(self):
+        assert self._is_probeable(is_active=False) is False
+
+    def test_empty_url_skipped(self):
+        assert self._is_probeable(url="") is False
+
+
+# ─── MCP HTTP-layer probe ─────────────────────────────────────────────────────
+
+
+class TestMcpServerHttpReachable:
+    """Verifies the L4 MCP probe is *lenient* — any HTTP response (even 405)
+    proves the server is up. Only network errors fail. The strict correctness
+    check lives in McpServerReachableCheck (list_tools handshake)."""
+
+    def _make_server(self, url="https://mcp.example.com"):
+        return SimpleNamespace(
+            id="s1", name="MCP", server_url=url, transport_type="sse",
+            auth_type="none", auth_config={},
+        )
+
+    def _run(self, mocked_client_ctx):
+        from core.services.readiness.checks.mcp_servers import McpServerHttpReachableCheck
+        check = McpServerHttpReachableCheck()
+        ctx = SimpleNamespace(mcp_servers=[self._make_server()])
+
+        with patch("httpx.AsyncClient", return_value=mocked_client_ctx):
+            return asyncio.run(check.run(ctx))
+
+    def _client_ctx(self, *, response=None, exc=None):
+        """Build the async-context-manager stub httpx.AsyncClient() returns."""
+        client = MagicMock()
+        if exc is not None:
+            client.get = AsyncMock(side_effect=exc)
+        else:
+            client.get = AsyncMock(return_value=response)
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=client)
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        return ctx
+
+    def test_pass_on_any_http_response(self):
+        """SSE endpoints often return 405 to a bare GET — still counts as up."""
+        for status in (200, 302, 404, 405, 501):
+            result = self._run(self._client_ctx(response=MagicMock(status_code=status)))
+            assert result.status.value == "pass", f"status {status} should pass"
+
+    def test_fail_on_connect_error(self):
+        result = self._run(self._client_ctx(exc=httpx.ConnectError("dns fail")))
+        assert result.status.value == "fail"
+        assert "unreachable" in result.message.lower()

--- a/test-cases/core/test_readiness_runner_filter.py
+++ b/test-cases/core/test_readiness_runner_filter.py
@@ -1,0 +1,122 @@
+"""Unit tests for the targeted-deep filter in the readiness runner.
+
+Source: core/services/readiness/runner.py
+
+The runner filter is the load-bearing piece of "save with an LLM change only
+probes LLM live" — if it regresses, save-time targeted deep collapses into
+either (a) probing everything (expensive, defeats the point) or (b) probing
+nothing (silent regressions in the badge). These tests pin down its exact
+behaviour so a future refactor can't silently break it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.services.readiness.runner import Runner
+from core.services.readiness.schemas import Category, Depth, Status
+
+
+def _ctx():
+    """Duck-typed CheckContext just complete enough for the registered
+    check classes' ``.applies()`` calls to return False safely — we never
+    want a live probe firing inside a unit test.
+    """
+    ctx = MagicMock()
+    ctx.depth = Depth.DEEP
+    ctx.agent = SimpleNamespace(id="agent-uuid")
+    ctx.config = SimpleNamespace(id="config-uuid")
+    ctx.tools = []
+    ctx.mcp_servers = []
+    ctx.knowledge_bases = []
+    ctx.phone_numbers = []
+    ctx.is_s2s = False
+    # LLM/STT/TTS legs — provider/model unset so `.applies()` short-circuits.
+    empty_leg = SimpleNamespace(
+        provider=None, model=None, api_key=None, decrypted_key=None,
+        provider_id=None, model_id=None, settings={},
+    )
+    ctx.llm = empty_leg
+    ctx.stt = empty_leg
+    ctx.tts = empty_leg
+    ctx.voice = None
+    ctx.db = MagicMock()
+    ctx.org_id = "org-uuid"
+    return ctx
+
+
+class TestTargetedDeepFilter:
+    """`Runner.run(ctx, deep_categories=...)` must:
+      1. Still run ALL shallow checks (they carry the URL-shape / key-decrypt
+         signals that don't care what category the save touched).
+      2. SKIP deep checks whose category isn't in the filter set — with a
+         marker string the frontend uses to preserve prior status via
+         `mergeReadinessReports`.
+      3. Attempt to run deep checks whose category IS in the set (they may
+         still applies-skip for their own reasons — that's fine).
+    """
+
+    def test_non_matching_deep_checks_marked_unchanged(self):
+        """LLM-only save → STT/TTS/tools/MCP deep checks return SKIPPED with
+        the 'unchanged on this save' marker so the frontend merge helper
+        can carry over their previous state."""
+        ctx = _ctx()
+        report = asyncio.run(Runner().run(ctx, deep_categories={Category.LLM}))
+
+        by_id = {c.check_id: c for c in report.checks}
+        # These are the deep checks in categories NOT in the filter set.
+        non_filtered_deep_ids = [
+            "stt.provider_reachable",
+            "tts.provider_reachable",
+            "tools.reachable",
+            "mcp_servers.http_reachable",
+            "mcp_servers.reachable",
+        ]
+        for cid in non_filtered_deep_ids:
+            entry = by_id.get(cid)
+            assert entry is not None, f"deep check {cid} missing from report"
+            assert entry.status == Status.SKIPPED, (
+                f"{cid} should be SKIPPED by filter, got {entry.status}"
+            )
+            # This exact substring is depended on by the frontend's
+            # `mergeReadinessReports`. Do not change without updating both.
+            assert "Not re-probed on this save" in (entry.skip_reason or entry.message)
+
+    def test_matching_deep_check_still_runs(self):
+        """LLM in the filter set → LLM deep check is NOT filter-skipped. It
+        may still `applies-skip` (empty context has no provider), but the
+        skip_reason will be the check's own, not the filter marker."""
+        ctx = _ctx()
+        report = asyncio.run(Runner().run(ctx, deep_categories={Category.LLM}))
+        by_id = {c.check_id: c for c in report.checks}
+        entry = by_id["llm.provider_reachable"]
+        # Empty ctx → applies() returns False → SKIPPED for its own reason.
+        # The important assertion is: it did NOT get the targeted-filter marker.
+        assert "Not re-probed on this save" not in (entry.skip_reason or entry.message)
+
+    def test_shallow_checks_always_run(self):
+        """Shallow checks are unaffected by the deep filter — they still
+        appear in the report with real statuses. Without this, the filter
+        would silently drop URL-shape / key-decrypt signals every save."""
+        ctx = _ctx()
+        report = asyncio.run(Runner().run(ctx, deep_categories={Category.LLM}))
+        by_id = {c.check_id: c for c in report.checks}
+        # Pick a representative shallow check that always runs.
+        entry = by_id["llm.provider_configured"]
+        # Its reason should NOT be the filter marker — it should be either
+        # a real PASS/FAIL or its own applies-skip.
+        assert "Not re-probed on this save" not in (entry.skip_reason or entry.message)
+
+    def test_no_filter_runs_everything(self):
+        """`deep_categories=None` (publish gate / manual Test button path)
+        must run every deep check just like the pre-targeted-deep world."""
+        ctx = _ctx()
+        report = asyncio.run(Runner().run(ctx))
+        for c in report.checks:
+            # Nothing in the report should carry the filter marker when no
+            # filter was passed — this is the publish-gate guarantee.
+            assert "Not re-probed on this save" not in (c.skip_reason or c.message)

--- a/test-cases/test_auth_cookies.py
+++ b/test-cases/test_auth_cookies.py
@@ -1,0 +1,152 @@
+"""Unit tests for the httpOnly auth-cookie helpers.
+
+Source: core/middleware/auth.py
+Pure/fast — no DB, no TestClient. Exercises cookie set/clear/extraction and the
+`set_cookies_and_strip` response shaper used by every token-issuing route.
+"""
+
+from fastapi import Response
+from starlette.requests import Request
+
+from shared.config import settings
+from core.middleware.auth import (
+    ACCESS_COOKIE,
+    REFRESH_COOKIE,
+    REFRESH_COOKIE_PATH,
+    clear_auth_cookies,
+    get_bearer_or_cookie_token,
+    set_auth_cookies,
+    set_cookies_and_strip,
+)
+
+
+def _set_cookie_headers(response: Response):
+    """All Set-Cookie header values on a response (one per cookie)."""
+    return [v.decode() for (k, v) in response.raw_headers if k == b"set-cookie"]
+
+
+def _cookie(headers, name):
+    return next((h for h in headers if h.startswith(f"{name}=")), None)
+
+
+def _make_request(headers: dict) -> Request:
+    raw = [(k.lower().encode(), v.encode()) for k, v in headers.items()]
+    return Request({"type": "http", "headers": raw})
+
+
+# ─── set_auth_cookies ───
+
+class TestSetAuthCookies:
+    def test_sets_both_cookies_httponly(self):
+        resp = Response()
+        set_auth_cookies(resp, "access-jwt", "refresh-jwt")
+        headers = _set_cookie_headers(resp)
+
+        access = _cookie(headers, ACCESS_COOKIE)
+        refresh = _cookie(headers, REFRESH_COOKIE)
+        assert access is not None and refresh is not None
+        assert "access-jwt" in access and "refresh-jwt" in refresh
+        # Both must be httpOnly so JS can never read them.
+        assert "httponly" in access.lower()
+        assert "httponly" in refresh.lower()
+
+    def test_cookie_paths_and_session_max_age(self):
+        resp = Response()
+        set_auth_cookies(resp, "a", "r")
+        headers = _set_cookie_headers(resp)
+        access = _cookie(headers, ACCESS_COOKIE)
+        refresh = _cookie(headers, REFRESH_COOKIE)
+
+        # Both cookies are site-wide (Path=/) — REFRESH_COOKIE_PATH is "/".
+        assert "Path=/" in access
+        assert f"Path={REFRESH_COOKIE_PATH}" in refresh
+
+        # Both carry the *session* (refresh-token) lifetime, not the short
+        # access-token TTL — so the FE middleware presence-check survives a
+        # silent refresh.
+        session_max_age = settings.REFRESH_TOKEN_EXPIRE_DAYS * 86400
+        assert f"Max-Age={session_max_age}" in access
+        assert f"Max-Age={session_max_age}" in refresh
+
+    def test_samesite_from_settings(self):
+        resp = Response()
+        set_auth_cookies(resp, "a", "r")
+        access = _cookie(_set_cookie_headers(resp), ACCESS_COOKIE)
+        assert f"samesite={settings.COOKIE_SAMESITE}".lower() in access.lower()
+
+    def test_access_only_when_no_refresh(self):
+        resp = Response()
+        set_auth_cookies(resp, "access-jwt")  # refresh omitted
+        headers = _set_cookie_headers(resp)
+        assert _cookie(headers, ACCESS_COOKIE) is not None
+        assert _cookie(headers, REFRESH_COOKIE) is None
+
+
+# ─── clear_auth_cookies ───
+
+class TestClearAuthCookies:
+    def test_expires_both_cookies(self):
+        resp = Response()
+        clear_auth_cookies(resp)
+        headers = _set_cookie_headers(resp)
+        access = _cookie(headers, ACCESS_COOKIE)
+        refresh = _cookie(headers, REFRESH_COOKIE)
+        assert access is not None and refresh is not None
+        # delete_cookie zeroes Max-Age so the browser drops them immediately.
+        assert "Max-Age=0" in access
+        assert "Max-Age=0" in refresh
+        assert f"Path={REFRESH_COOKIE_PATH}" in refresh
+
+
+# ─── get_bearer_or_cookie_token ───
+
+class TestTokenExtraction:
+    def test_prefers_authorization_header(self):
+        req = _make_request(
+            {"authorization": "Bearer header-tok", "cookie": f"{ACCESS_COOKIE}=cookie-tok"}
+        )
+        assert get_bearer_or_cookie_token(req) == "header-tok"
+
+    def test_falls_back_to_cookie(self):
+        req = _make_request({"cookie": f"{ACCESS_COOKIE}=cookie-tok"})
+        assert get_bearer_or_cookie_token(req) == "cookie-tok"
+
+    def test_none_when_neither_present(self):
+        req = _make_request({})
+        assert get_bearer_or_cookie_token(req) is None
+
+    def test_ignores_non_bearer_scheme(self):
+        # No cookie, non-Bearer header → nothing usable.
+        req = _make_request({"authorization": "Basic abc123"})
+        assert get_bearer_or_cookie_token(req) is None
+
+
+# ─── set_cookies_and_strip ───
+
+class TestSetCookiesAndStrip:
+    def test_strips_tokens_and_sets_cookies(self):
+        resp = Response()
+        result = set_cookies_and_strip(
+            resp,
+            {
+                "access_token": "a",
+                "refresh_token": "r",
+                "user": {"id": "u1"},
+                "role": "owner",
+            },
+        )
+        # Tokens moved to cookies, removed from the JSON body.
+        assert "access_token" not in result
+        assert "refresh_token" not in result
+        assert result["user"] == {"id": "u1"}
+        assert result["role"] == "owner"
+        headers = _set_cookie_headers(resp)
+        assert _cookie(headers, ACCESS_COOKIE) is not None
+        assert _cookie(headers, REFRESH_COOKIE) is not None
+
+    def test_noop_without_access_token(self):
+        resp = Response()
+        payload = {"message": "verify your email"}
+        result = set_cookies_and_strip(resp, payload)
+        assert result == payload
+        assert _set_cookie_headers(resp) == []

--- a/test-cases/test_loki_log_sync.py
+++ b/test-cases/test_loki_log_sync.py
@@ -1,10 +1,11 @@
 """Hermetic unit tests for the per-call Loki -> Postgres log sync.
 
 No live database, no network: the Loki HTTP layer is stubbed (fake httpx.Client)
-and the DB insert is simulated with a fingerprint set that mimics the real
-UNIQUE-constraint dedup. Covers the parser, fingerprint, LokiClient retry/backoff,
-the sync service (insert + idempotent re-run + short-circuits + pagination + clock
-skew), and the post-call action enqueue guard.
+and the DB upsert is simulated by capturing the wholesale ``logs`` array written
+per call (mimicking the real ``on_conflict(call_id) do update`` replace). Covers
+the parser, fingerprint, LokiClient retry/backoff, the sync service (array build
++ idempotent re-run + short-circuits + pagination + clock skew), and the
+post-call action enqueue guard.
 """
 from __future__ import annotations
 
@@ -161,16 +162,16 @@ def test_query_range_401_is_non_retryable(fake_httpx):
 # ── PipelineLogSyncService ───────────────────────────────────────────────────
 
 class _FakeDB:
-    """DB stand-in that mimics the fingerprint UNIQUE dedup across runs."""
+    """Captures the wholesale ``logs`` array written per call (upsert-replace)."""
 
     def __init__(self):
-        self.stored_fingerprints: set[str] = set()
-        self.inserted_rows: list[dict] = []
+        self.stored: dict = {}    # call_id -> list[entry] (the row's logs array)
+        self.upserts: list = []   # (call, entries) per _upsert_call
 
 
 def _stub_service(monkeypatch, db, pages):
     """Return a service whose LokiClient yields ``pages`` (list of line-lists) and
-    whose _insert simulates on_conflict_do_nothing against ``db``."""
+    whose _upsert_call replaces the call's stored array against ``db``."""
     monkeypatch.setattr(settings, "loki_read_configured", lambda: True)
     monkeypatch.setattr(settings, "LOKI_SYNC_PAGE_LIMIT", 2)
 
@@ -185,14 +186,13 @@ def _stub_service(monkeypatch, db, pages):
         "core.services.pipeline_log_sync_service.LokiClient", _StubClient
     )
 
-    def fake_insert(self, rows):
-        new = [r for r in rows if r["fingerprint"] not in db.stored_fingerprints]
-        for r in new:
-            db.stored_fingerprints.add(r["fingerprint"])
-            db.inserted_rows.append(r)
-        return len(new)
+    def fake_upsert(self, call, entries):
+        # Wholesale replace — exactly what on_conflict(call_id) do update does.
+        db.stored[call.id] = list(entries)
+        db.upserts.append((call, list(entries)))
+        return len(entries)
 
-    monkeypatch.setattr(PipelineLogSyncService, "_insert", fake_insert)
+    monkeypatch.setattr(PipelineLogSyncService, "_upsert_call", fake_upsert)
     return PipelineLogSyncService(SimpleNamespace(), org_id=uuid.uuid4())
 
 
@@ -222,7 +222,7 @@ def _window_ns(offset: int = 0) -> int:
     return int((datetime.now(timezone.utc) - timedelta(seconds=60)).timestamp() * 1_000_000_000) + offset
 
 
-def test_sync_inserts_and_stamps_from_call(monkeypatch):
+def test_sync_builds_array_and_stamps_from_call(monkeypatch):
     db = _FakeDB()
     call = _make_call()
     svc = _stub_service(
@@ -232,16 +232,22 @@ def test_sync_inserts_and_stamps_from_call(monkeypatch):
 
     result = svc.sync_call(call)
 
-    assert result.inserted == 3
-    assert result.skipped == 0
+    assert result.stored == 3
     assert result.pages == 2  # full first page forces a second fetch
-    # Identity columns are stamped from the Call, not parsed.
-    for row in db.inserted_rows:
-        assert row["call_id"] == call.id
-        assert row["organization_id"] == call.organization_id
-        assert row["agent_id"] == call.agent_id
-        assert row["trace_id"] == call.trace_id
-        assert row["fingerprint"]
+
+    entries = db.stored[call.id]
+    # One row per call: all lines land in a single time-ordered array.
+    assert [e["raw_line"] for e in entries] == ["a", "b", "c"]
+    assert [e["ts_ns"] for e in entries] == sorted(e["ts_ns"] for e in entries)
+    # Entry shape — identity is NOT repeated per line; it lives on the row.
+    for e in entries:
+        assert set(e) == {"ts", "ts_ns", "level", "logger_name", "message", "raw_line"}
+    # Identity stamped from the Call onto the row (via _upsert_call).
+    upsert_call, _ = db.upserts[-1]
+    assert upsert_call.id == call.id
+    assert upsert_call.organization_id == call.organization_id
+    assert upsert_call.agent_id == call.agent_id
+    assert upsert_call.trace_id == call.trace_id
 
 
 def test_sync_is_idempotent_on_rerun(monkeypatch):
@@ -249,13 +255,14 @@ def test_sync_is_idempotent_on_rerun(monkeypatch):
     call = _make_call()
     pages = [[_line(_window_ns(1), "a"), _line(_window_ns(2), "b")], [_line(_window_ns(3), "c")]]
     svc1 = _stub_service(monkeypatch, db, pages=[list(p) for p in pages])
-    assert svc1.sync_call(call).inserted == 3
+    assert svc1.sync_call(call).stored == 3
 
-    # Second run against the same fingerprint store: nothing new.
+    # Second run re-reads the same window and replaces the array wholesale:
+    # the stored row still has exactly the same 3 lines, never 6.
     svc2 = _stub_service(monkeypatch, db, pages=[list(p) for p in pages])
     second = svc2.sync_call(call)
-    assert second.inserted == 0
-    assert second.skipped == 3
+    assert second.stored == 3
+    assert [e["raw_line"] for e in db.stored[call.id]] == ["a", "b", "c"]
 
 
 def test_sync_short_circuits_when_not_configured(monkeypatch):
@@ -263,14 +270,14 @@ def test_sync_short_circuits_when_not_configured(monkeypatch):
     svc = PipelineLogSyncService(SimpleNamespace(), org_id=uuid.uuid4())
     result = svc.sync_call(_make_call())
     assert result.configured is False
-    assert result.inserted == 0
+    assert result.stored == 0
 
 
 def test_sync_short_circuits_without_trace_id(monkeypatch):
     monkeypatch.setattr(settings, "loki_read_configured", lambda: True)
     svc = PipelineLogSyncService(SimpleNamespace(), org_id=uuid.uuid4())
     result = svc.sync_call(_make_call(trace_id=None))
-    assert result.inserted == 0
+    assert result.stored == 0
     assert "trace_id" in result.message
 
 
@@ -294,8 +301,8 @@ def test_sync_drops_foreign_prefix_collision(monkeypatch):
 
     result = svc.sync_call(call)
 
-    assert result.inserted == 1
-    assert [r["raw_line"] for r in db.inserted_rows] == [ours]
+    assert result.stored == 1
+    assert [e["raw_line"] for e in db.stored[call.id]] == [ours]
 
 
 def test_sync_keeps_early_prefix_only_lines(monkeypatch):
@@ -311,8 +318,8 @@ def test_sync_keeps_early_prefix_only_lines(monkeypatch):
 
     result = svc.sync_call(call)
 
-    assert result.inserted == 1
-    assert db.inserted_rows[0]["raw_line"] == early
+    assert result.stored == 1
+    assert db.stored[call.id][0]["raw_line"] == early
 
 
 def test_sync_clamps_future_ended_at(monkeypatch):

--- a/test-cases/test_tenant_header_guard.py
+++ b/test-cases/test_tenant_header_guard.py
@@ -1,0 +1,89 @@
+"""Unit tests for the EE tenant-header (org-switch) authorization guard.
+
+Source: ee/middleware/auth.py :: get_ee_current_user
+
+The ``tenant_id`` request header lets a client hint which org to act as. It is
+honored ONLY when the caller is a verified member of that org — otherwise a
+forged header would let one tenant act on another's data (IDOR). The membership
+lookup also supplies the correct per-org role so downstream role guards evaluate
+against the switched org. These tests pin that guard so it can't be silently
+weakened back to the old unconditional ``claims.org_id = tenant_id``.
+
+Pure/fast — the DB is mocked (shared ``mock_db`` fixture), no TestClient.
+"""
+
+import os
+import sys
+import time
+from types import SimpleNamespace
+from uuid import uuid4
+
+# The ``test-cases/ee`` test package shadows the real repo-root ``ee`` package
+# on ``sys.path`` under pytest, so ``import ee`` would otherwise resolve to the
+# test package (which has no ``middleware`` submodule). Prepend the repo root and
+# drop any shadowed ``ee`` entry so the real EE package wins. (The root conftest
+# already does the same ``sys.path.insert`` for its own imports.)
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if sys.path and sys.path[0] != _REPO_ROOT:
+    sys.path.insert(0, _REPO_ROOT)
+if getattr(sys.modules.get("ee"), "__file__", "").startswith(
+    os.path.join(_REPO_ROOT, "test-cases")
+):
+    sys.modules.pop("ee", None)
+
+from core.middleware.auth import JWTClaims
+from ee.middleware.auth import get_ee_current_user
+
+
+ORG_TOKEN = str(uuid4())  # org baked into the access token
+ORG_OTHER = str(uuid4())  # different org requested via the tenant_id header
+
+
+def _claims(org_id: str, role: str = "member") -> JWTClaims:
+    now = int(time.time())
+    return JWTClaims(
+        user_id=str(uuid4()),
+        org_id=org_id,
+        role=role,
+        email="user@example.com",
+        iat=now,
+        exp=now + 3600,
+    )
+
+
+class TestTenantHeaderGuard:
+    def test_forged_tenant_id_ignored_when_not_a_member(self, mock_db):
+        # mock_db.first() returns None → caller is NOT a member of ORG_OTHER.
+        claims = _claims(ORG_TOKEN, role="member")
+        result = get_ee_current_user(claims=claims, tenant_id=ORG_OTHER, db=mock_db)
+        # Org/role stay pinned to the token — the forged header is not trusted.
+        assert result.org_id == ORG_TOKEN
+        assert result.role == "member"
+
+    def test_valid_switch_adopts_target_org_and_role(self, mock_db):
+        # Caller IS a member of ORG_OTHER, with a different (per-org) role.
+        mock_db.first.return_value = SimpleNamespace(role="admin")
+        claims = _claims(ORG_TOKEN, role="member")
+        result = get_ee_current_user(claims=claims, tenant_id=ORG_OTHER, db=mock_db)
+        assert result.org_id == ORG_OTHER
+        assert result.role == "admin"
+
+    def test_no_membership_lookup_when_header_matches_token_org(self, mock_db):
+        # tenant_id == token org → no query, claims returned unchanged.
+        claims = _claims(ORG_TOKEN, role="owner")
+        result = get_ee_current_user(claims=claims, tenant_id=ORG_TOKEN, db=mock_db)
+        assert result.org_id == ORG_TOKEN
+        assert result.role == "owner"
+        mock_db.query.assert_not_called()
+
+    def test_invalid_tenant_id_ignored(self, mock_db):
+        claims = _claims(ORG_TOKEN, role="member")
+        result = get_ee_current_user(claims=claims, tenant_id="not-a-uuid", db=mock_db)
+        assert result.org_id == ORG_TOKEN
+        mock_db.query.assert_not_called()
+
+    def test_no_tenant_header_returns_token_claims(self, mock_db):
+        claims = _claims(ORG_TOKEN, role="member")
+        result = get_ee_current_user(claims=claims, tenant_id=None, db=mock_db)
+        assert result.org_id == ORG_TOKEN
+        mock_db.query.assert_not_called()


### PR DESCRIPTION
Promotes `dev` → `staging` (7 commits). Highlights:

- **refactor(loki-sync) #767** — per-call logs stored as one `call_pipeline_logs` JSON-array row (replaces per-line `pipeline_logs`). **Requires `alembic upgrade head` (rev `d4b2f8a1c6e3`) on the staging DB** — DROPs `pipeline_logs`, creates `call_pipeline_logs`. Migrations are manual (not in CI).
- fix(loki-sync) #761 — correct LogQL selector so per-call logs actually store.
- fix(cors) #765 — credentialed CORS on staging-aws api ingress.
- Feature: pipeline logging & observability #758.
- Feature: auth httpOnly cookie tokens #759.
- Agent readiness changes; consolidated transcripts #760.

### Post-merge action
Run the migration on the staging DB: `alembic upgrade head` → `d4b2f8a1c6e3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)