### PR TITLE
feat(contacts): Contact Directories module + scheduled/outbound call …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ The `pipecat/` directory is a custom fork (`tonehq/pipecat`) of the Pipecat AI f
 
 ## Key Conventions
 
+- **Service layer & reuse (single source of truth):** Business logic lives in a service extending `BaseService` — **never in routers/controllers**. Routers only: parse/validate input → authorize → call a service method → shape the response. Any behavior that is (or will be) invoked from more than one place — another router, a worker, a CLI, a test — MUST be a shared service method or a helper in `core/services/common/` / `core/utils/`, called by everyone; do not copy-paste or re-implement the same logic in a second location. Before writing new logic, search for an existing service/helper and extend it; when the same functionality is needed from anywhere, factor it out so there is exactly one implementation. On the frontend the mirror rule holds: shared UI → `@/components/shared`, shared logic → `@/hooks`/`@/lib`/`@/utils`, all HTTP through `@/services` / `@/lib/api` hooks — never duplicate fetch/format/validation per page. Follow the rule of three (extract on the 3rd occurrence) but extract by *responsibility*, not by shape. See the reusable-functions catalog below and `docs/code-review/`.
 - **Auth pattern:** Routes use FastAPI dependency injection — `require_authenticated`, `require_admin_or_owner`, `require_org_member`
 - **Encryption:** API keys stored AES-encrypted in DB (`core/utils/encryption.py`)
 - **Multi-tenancy:** Core edition defaults to single-tenant (`IS_MULTI_TENANT=false`, all users share `DEFAULT_ORG_ID`)
@@ -101,10 +102,26 @@ The `pipecat/` directory is a custom fork (`tonehq/pipecat`) of the Pipecat AI f
 - **Config:** Settings loaded from Infisical (if `USE_INFISICAL=true`) or `.env` with fallback defaults
 - **Logging & observability:** Use the shared loguru `logger`. Every error-handling `except` must capture a full traceback via `logger.exception(...)` (never message-only `logger.error("...", e)` or `print`); expected control-flow `except`s (parse fallbacks, cache miss, optional import, hot-loop/per-frame) use `logger.debug`; never silently swallow and never swallow `asyncio.CancelledError`. Prefix logs with a context tag (`[bot]`, `[inbound]`, `[outbound]`, service name); correlate by the per-call `trace_id`. Never call `logger.add/remove/configure` outside `core/logging.py` (it owns the single sink; pipecat shares the same loguru singleton). Per-call verbosity is DB-driven — `agent.log_level > organization.log_level > env LOG_LEVEL > INFO`, resolved only in `core/services/log_level_resolver.py` and applied by `run_bot` via `setup_logging(level=...)`; never read the `log_level` columns directly. Full reference: `docs/LOGGING_OBSERVABILITY.md`.
 
+### Common reusable functions (Contacts Directories module — reuse, don't re-implement)
+
+Registered so future work discovers them (paths are import targets):
+- **`require_admin_or_owner`** (`core/middleware/auth.py`) — shared admin/owner route guard; enforces `claims.role in {"admin","owner"}`. Use on every admin-gated route; never re-check roles inline.
+- **`apply_search_sort_pagination`** (`core/services/common/list_query.py`) — search + whitelisted sort + paginate a scoped query → `(rows, total)`. Use in every `POST /…/list`.
+- **`BaseService.get_or_404`** (`core/services/base.py`) — org-scoped, soft-delete-aware fetch-or-404.
+- **`build_contact_field_json_schema` / `make_contact_metadata_validator` / `validate_contact_metadata`** (`core/services/contacts/contact_metadata_validation.py`) — `SchemaField`s → JSON-Schema + Draft7 validator + per-row errors (manual create, multi-add, sync validation).
+- **`map_source_row_to_contact`** (`core/services/contact_ingestion/contact_mapping.py`) — `source_key→field_name` map + type coercion (null = identity).
+- **`upsert_contact`** (`core/services/contacts/contact_upsert.py`) — upsert by `(directory_id, external_id)` → `(contact, action)`; sets `sync_id`.
+- **`ContactService.list_contact_ids_in_directories`** (`core/services/contacts/contact_service.py`) — active contact ids across directories (agent-assign expansion).
+- **`get_contact_source(datasource)`** (`core/services/contact_ingestion/__init__.py`) — datasource-type → `ContactSource` factory.
+- **`run_contact_sync` / `enqueue_contact_sync[_sync]`** (`core/services/contacts/contact_sync_service.py`, `core/services/ingestion_queue.py`) — the single sync pipeline + Procrastinate deferral.
+- **`create_default_datasource`** (`core/services/contacts/contact_directory_service.py`) — provision the CSV datasource on directory create (no schema is auto-created; `default_schema_id` is optional/user-selected).
+- **`summarize_directory_deletion` / `hard_delete_directory_and_children`** (`core/services/contacts/directory_delete.py`) — delete-impact counts; FK-safe hard delete (cancels queued dial jobs, keeps org schemas, detaches syncs).
+
 ### Frontend: shared components
 
 - **Buttons:** Use `CustomButton` from `@/components/shared` only. Do not use native `<button>` or `Button` from `@/components/ui/button` in app/feature code (exception: inside `CustomButton.tsx` itself).
 - **Other UI:** Prefer shared components (`CustomModal`, `CustomTable`, `TextInput`, `SelectInput`, `CustomTab`, `CustomLink`, etc.) over raw `@/components/ui/*` or native elements. Use `@/components/ui/*` only when building or composing shared components.
+- **Date/time selection:** Use the shared `DateTimePicker` (single instant → UTC ISO) or `DateRangePicker` (range) for ALL date/time input. Do NOT use native `<input type="date"/datetime-local">` or other calendar libraries in app/feature code.
 - See `.cursor/rules/shared-components.mdc` for full rule and exceptions.
 
 ## Code Review Rules
@@ -118,8 +135,9 @@ rulebook in `docs/code-review/`. These rules are mandatory for all agents:
 
 Do not comment on style the linter/formatter already fixes (ESLint+Prettier on FE, Ruff on BE) —
 focus on correctness, security, design, and tests. Always-check blockers:
-- **FE:** no type-erasing `any`/`!`; correct `useEffect` deps (`exhaustive-deps` is OFF — the reviewer is the guard); stable list keys; no secrets in the client bundle; server state in TanStack Query; buttons use `CustomButton` and prefer shared components.
-- **BE:** every route has the right auth guard; **every query is tenant/org-scoped** (no IDOR); no raw/interpolated SQL; schema changes ship a safe Alembic migration; secrets stay AES-encrypted and are never logged; no blocking I/O in async paths; logic lives in a `BaseService`, not routers; **every `except` logs a full traceback (`logger.exception`) — no silent swallow, no message-only error log, `CancelledError` never dropped** (see Logging & observability above).
+- **Reuse & layering (both stacks):** flag logic that belongs in a service but sits in a router/component; flag duplicated logic that should be a shared service method / helper / hook (especially the *same* functionality re-implemented in a second call site instead of calling the existing one); flag a new endpoint/component that rebuilds something a shared function already provides. The fix is "call the shared service", not "copy it here."
+- **FE:** no type-erasing `any`/`!`; correct `useEffect` deps (`exhaustive-deps` is OFF — the reviewer is the guard); stable list keys; no secrets in the client bundle; server state in TanStack Query; buttons use `CustomButton` and prefer shared components; HTTP via `@/services` / `@/lib/api` hooks.
+- **BE:** every route has the right auth guard; **every query is tenant/org-scoped** (no IDOR); no raw/interpolated SQL; schema changes ship a safe Alembic migration; secrets stay AES-encrypted and are never logged; no blocking I/O in async paths; logic lives in a `BaseService`, not routers, and is reused (not duplicated) wherever the same behavior is needed; **every `except` logs a full traceback (`logger.exception`) — no silent swallow, no message-only error log, `CancelledError` never dropped** (see Logging & observability above).
 
 New behavior needs tests; bug fixes need a regression test.
 

--- a/alembic/versions/0cf24b3d86dc_merge_contacts_directories_tool_.py
+++ b/alembic/versions/0cf24b3d86dc_merge_contacts_directories_tool_.py
@@ -1,0 +1,24 @@
+"""merge contacts-directories + tool-executions heads
+
+Revision ID: 0cf24b3d86dc
+Revises: a4e9b1c7d3f5, 6ab783e9080f
+Create Date: 2026-07-18 13:12:49.364456
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '0cf24b3d86dc'
+down_revision = ('a4e9b1c7d3f5', '6ab783e9080f')
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/alembic/versions/6ab783e9080f_add_contacts_scheduled_calls_contact_id.py
+++ b/alembic/versions/6ab783e9080f_add_contacts_scheduled_calls_contact_id.py
@@ -1,0 +1,244 @@
+"""add contact directories + schemas + syncs + contacts + agent_contacts + scheduled_calls.contact_id
+
+Revision ID: 6ab783e9080f
+Revises: c5d9a4e7b2f1
+Create Date: 2026-07-17 20:47:45.117376
+
+The single, clean Contact **Directories** migration. Creates the whole module:
+``contact_schemas`` (org-level reusable) + ``schema_fields`` (replaces the dropped
+``contact_field_definitions``), ``contact_directories``, ``datasources``,
+``contact_syncs``, ``contacts`` (directory-scoped, ``sync_id``, no ``source_upload_id``),
+``agent_contacts``, and adds ``scheduled_calls.contact_id``. Additive-only: unrelated
+pre-existing model/DB drift is intentionally left out so this revision touches only the
+contacts/directories surface.
+
+FK creation order is dependency-safe: referenced tables are created before referencing
+ones (schemas → schema_fields → directories → datasources → contact_syncs → contacts →
+agent_contacts).
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '6ab783e9080f'
+down_revision = 'c5d9a4e7b2f1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ---------------------------------------------------------- contact_schemas
+    op.create_table(
+        'contact_schemas',
+        sa.Column('name', sa.String(length=120), nullable=False),
+        sa.Column('description', sa.String(length=500), nullable=True),
+        sa.Column('created_by_user_id', sa.UUID(), nullable=True),
+        sa.Column('is_active', sa.Boolean(), nullable=False),
+        sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('organization_id', sa.UUID(), nullable=False),
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_contact_schemas_organization_id'), 'contact_schemas', ['organization_id'], unique=False)
+    op.create_index('ix_contact_schemas_org_name', 'contact_schemas', ['organization_id', 'name'], unique=False)
+
+    # ------------------------------------------------------------- schema_fields
+    op.create_table(
+        'schema_fields',
+        sa.Column('schema_id', sa.UUID(), nullable=False),
+        sa.Column('field_name', sa.String(length=64), nullable=False),
+        sa.Column('label', sa.String(length=120), nullable=True),
+        sa.Column('is_mandatory', sa.Boolean(), nullable=False),
+        sa.Column('type', sa.String(length=20), nullable=False),
+        sa.Column('format', sa.String(length=32), nullable=True),
+        sa.Column('validators', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('options', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column('source_key', sa.String(length=120), nullable=True),
+        sa.Column('field_metadata', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('display_order', sa.Integer(), nullable=False),
+        sa.Column('is_active', sa.Boolean(), nullable=False),
+        sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('organization_id', sa.UUID(), nullable=False),
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(['schema_id'], ['contact_schemas.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('schema_id', 'field_name', name='uq_schema_fields_schema_field_name'),
+    )
+    op.create_index(op.f('ix_schema_fields_organization_id'), 'schema_fields', ['organization_id'], unique=False)
+    op.create_index(op.f('ix_schema_fields_schema_id'), 'schema_fields', ['schema_id'], unique=False)
+
+    # ------------------------------------------------------- contact_directories
+    op.create_table(
+        'contact_directories',
+        sa.Column('name', sa.String(length=120), nullable=False),
+        sa.Column('description', sa.String(length=500), nullable=True),
+        sa.Column('default_schema_id', sa.UUID(), nullable=True),
+        sa.Column('created_by_user_id', sa.UUID(), nullable=True),
+        sa.Column('is_active', sa.Boolean(), nullable=False),
+        sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('organization_id', sa.UUID(), nullable=False),
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(['default_schema_id'], ['contact_schemas.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_contact_directories_organization_id'), 'contact_directories', ['organization_id'], unique=False)
+    op.create_index(op.f('ix_contact_directories_default_schema_id'), 'contact_directories', ['default_schema_id'], unique=False)
+    op.create_index('ix_contact_directories_org_name', 'contact_directories', ['organization_id', 'name'], unique=False)
+
+    # ---------------------------------------------------------------- datasources
+    op.create_table(
+        'datasources',
+        sa.Column('directory_id', sa.UUID(), nullable=True),
+        sa.Column('name', sa.String(length=120), nullable=False),
+        sa.Column('type', sa.String(length=20), nullable=False),
+        sa.Column('config', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('is_active', sa.Boolean(), nullable=False),
+        sa.Column('created_by_user_id', sa.UUID(), nullable=True),
+        sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('organization_id', sa.UUID(), nullable=False),
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(['directory_id'], ['contact_directories.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_datasources_organization_id'), 'datasources', ['organization_id'], unique=False)
+    op.create_index(op.f('ix_datasources_directory_id'), 'datasources', ['directory_id'], unique=False)
+
+    # -------------------------------------------------------------- contact_syncs
+    op.create_table(
+        'contact_syncs',
+        sa.Column('directory_id', sa.UUID(), nullable=True),
+        sa.Column('datasource_id', sa.UUID(), nullable=True),
+        sa.Column('schema_id', sa.UUID(), nullable=False),
+        sa.Column('upload_id', sa.UUID(), nullable=True),
+        sa.Column('agent_id', sa.UUID(), nullable=True),
+        sa.Column('status', sa.String(length=20), nullable=False),
+        sa.Column('counts', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('row_errors', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('error', sa.String(length=500), nullable=True),
+        sa.Column('app_id', sa.String(length=255), nullable=True),
+        sa.Column('connection_id', sa.String(length=255), nullable=True),
+        sa.Column('created_by_user_id', sa.UUID(), nullable=True),
+        sa.Column('organization_id', sa.UUID(), nullable=False),
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(['directory_id'], ['contact_directories.id'], ondelete='SET NULL'),
+        sa.ForeignKeyConstraint(['datasource_id'], ['datasources.id'], ondelete='SET NULL'),
+        sa.ForeignKeyConstraint(['schema_id'], ['contact_schemas.id'], ondelete='RESTRICT'),
+        sa.ForeignKeyConstraint(['upload_id'], ['uploads.id'], ondelete='SET NULL'),
+        sa.ForeignKeyConstraint(['agent_id'], ['agents.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_contact_syncs_organization_id'), 'contact_syncs', ['organization_id'], unique=False)
+    op.create_index(op.f('ix_contact_syncs_directory_id'), 'contact_syncs', ['directory_id'], unique=False)
+    op.create_index(op.f('ix_contact_syncs_datasource_id'), 'contact_syncs', ['datasource_id'], unique=False)
+    op.create_index(op.f('ix_contact_syncs_schema_id'), 'contact_syncs', ['schema_id'], unique=False)
+    op.create_index(op.f('ix_contact_syncs_agent_id'), 'contact_syncs', ['agent_id'], unique=False)
+    op.create_index(op.f('ix_contact_syncs_status'), 'contact_syncs', ['status'], unique=False)
+
+    # ------------------------------------------------------------------- contacts
+    op.create_table(
+        'contacts',
+        sa.Column('directory_id', sa.UUID(), nullable=False),
+        sa.Column('external_id', sa.String(length=255), nullable=False),
+        sa.Column('name', sa.String(length=255), nullable=True),
+        sa.Column('phone_number', sa.String(length=20), nullable=True),
+        sa.Column('contact_metadata', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('sync_id', sa.UUID(), nullable=True),
+        sa.Column('created_by_user_id', sa.UUID(), nullable=True),
+        sa.Column('is_active', sa.Boolean(), nullable=False),
+        sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('archived_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('organization_id', sa.UUID(), nullable=False),
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(['directory_id'], ['contact_directories.id'], ondelete='RESTRICT'),
+        sa.ForeignKeyConstraint(['sync_id'], ['contact_syncs.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('directory_id', 'external_id', name='uq_contacts_directory_external_id'),
+    )
+    op.create_index(op.f('ix_contacts_organization_id'), 'contacts', ['organization_id'], unique=False)
+    op.create_index(op.f('ix_contacts_directory_id'), 'contacts', ['directory_id'], unique=False)
+    op.create_index(op.f('ix_contacts_external_id'), 'contacts', ['external_id'], unique=False)
+    op.create_index(op.f('ix_contacts_phone_number'), 'contacts', ['phone_number'], unique=False)
+    op.create_index('ix_contacts_org_phone_number', 'contacts', ['organization_id', 'phone_number'], unique=False)
+
+    # ------------------------------------------------------------- agent_contacts
+    op.create_table(
+        'agent_contacts',
+        sa.Column('agent_id', sa.UUID(), nullable=False),
+        sa.Column('contact_id', sa.UUID(), nullable=False),
+        sa.Column('created_by_user_id', sa.UUID(), nullable=True),
+        sa.Column('organization_id', sa.UUID(), nullable=False),
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(['agent_id'], ['agents.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['contact_id'], ['contacts.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('agent_id', 'contact_id', name='uq_agent_contacts_agent_contact'),
+    )
+    op.create_index(op.f('ix_agent_contacts_organization_id'), 'agent_contacts', ['organization_id'], unique=False)
+    op.create_index(op.f('ix_agent_contacts_agent_id'), 'agent_contacts', ['agent_id'], unique=False)
+    op.create_index(op.f('ix_agent_contacts_contact_id'), 'agent_contacts', ['contact_id'], unique=False)
+
+    # ---------------------------------------------------- scheduled_calls.contact_id
+    op.add_column('scheduled_calls', sa.Column('contact_id', sa.UUID(), nullable=True))
+    op.create_index(op.f('ix_scheduled_calls_contact_id'), 'scheduled_calls', ['contact_id'], unique=False)
+    op.create_foreign_key(
+        'fk_scheduled_calls_contact_id', 'scheduled_calls', 'contacts',
+        ['contact_id'], ['id'], ondelete='SET NULL',
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint('fk_scheduled_calls_contact_id', 'scheduled_calls', type_='foreignkey')
+    op.drop_index(op.f('ix_scheduled_calls_contact_id'), table_name='scheduled_calls')
+    op.drop_column('scheduled_calls', 'contact_id')
+
+    op.drop_index(op.f('ix_agent_contacts_contact_id'), table_name='agent_contacts')
+    op.drop_index(op.f('ix_agent_contacts_agent_id'), table_name='agent_contacts')
+    op.drop_index(op.f('ix_agent_contacts_organization_id'), table_name='agent_contacts')
+    op.drop_table('agent_contacts')
+
+    op.drop_index('ix_contacts_org_phone_number', table_name='contacts')
+    op.drop_index(op.f('ix_contacts_phone_number'), table_name='contacts')
+    op.drop_index(op.f('ix_contacts_external_id'), table_name='contacts')
+    op.drop_index(op.f('ix_contacts_directory_id'), table_name='contacts')
+    op.drop_index(op.f('ix_contacts_organization_id'), table_name='contacts')
+    op.drop_table('contacts')
+
+    op.drop_index(op.f('ix_contact_syncs_status'), table_name='contact_syncs')
+    op.drop_index(op.f('ix_contact_syncs_agent_id'), table_name='contact_syncs')
+    op.drop_index(op.f('ix_contact_syncs_schema_id'), table_name='contact_syncs')
+    op.drop_index(op.f('ix_contact_syncs_datasource_id'), table_name='contact_syncs')
+    op.drop_index(op.f('ix_contact_syncs_directory_id'), table_name='contact_syncs')
+    op.drop_index(op.f('ix_contact_syncs_organization_id'), table_name='contact_syncs')
+    op.drop_table('contact_syncs')
+
+    op.drop_index(op.f('ix_datasources_directory_id'), table_name='datasources')
+    op.drop_index(op.f('ix_datasources_organization_id'), table_name='datasources')
+    op.drop_table('datasources')
+
+    op.drop_index('ix_contact_directories_org_name', table_name='contact_directories')
+    op.drop_index(op.f('ix_contact_directories_default_schema_id'), table_name='contact_directories')
+    op.drop_index(op.f('ix_contact_directories_organization_id'), table_name='contact_directories')
+    op.drop_table('contact_directories')
+
+    op.drop_index(op.f('ix_schema_fields_schema_id'), table_name='schema_fields')
+    op.drop_index(op.f('ix_schema_fields_organization_id'), table_name='schema_fields')
+    op.drop_table('schema_fields')
+
+    op.drop_index('ix_contact_schemas_org_name', table_name='contact_schemas')
+    op.drop_index(op.f('ix_contact_schemas_organization_id'), table_name='contact_schemas')
+    op.drop_table('contact_schemas')

--- a/build/kubernetes/staging-aws/worker/deployment.yaml
+++ b/build/kubernetes/staging-aws/worker/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             - "--app=core.services.ingestion_queue.app"
             - worker
             - "--name=$(POD_NAME)"
-            - "--queues=ingestion,pod_sync,outbound_calls,call_overlaps,call_transcripts,call_metrics,log_sync"
+            - "--queues=ingestion,pod_sync,outbound_calls,call_overlaps,call_transcripts,call_metrics,log_sync,contact_import"
             - "--concurrency=1"
             - "--no-listen-notify"
             - "--fetch-job-polling-interval=5"

--- a/build/kubernetes/staging/worker/deployment.yaml
+++ b/build/kubernetes/staging/worker/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             - "--app=core.services.ingestion_queue.app"
             - worker
             - "--name=$(POD_NAME)"
-            - "--queues=ingestion,pod_sync,outbound_calls,call_overlaps,call_transcripts,call_metrics,log_sync"
+            - "--queues=ingestion,pod_sync,outbound_calls,call_overlaps,call_transcripts,call_metrics,log_sync,contact_import"
             - "--concurrency=1"
             - "--no-listen-notify"
             - "--fetch-job-polling-interval=5"

--- a/core/api/v1/agent_contacts.py
+++ b/core/api/v1/agent_contacts.py
@@ -1,0 +1,103 @@
+"""Agent-contacts router — assign / list / unassign contacts on an agent.
+
+All handlers are org-scoped via ``require_org_member`` (assign/list/unassign are all
+MEMBER actions per the Permissions matrix — there is no scheduling gate). Directories in
+the assign body are expanded to their active contacts server-side so a whole-directory
+pick is sent as one id, not thousands of rows.
+"""
+
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from core.database.session import get_db
+from core.middleware.auth import JWTClaims, require_org_member
+from core.services.contacts.agent_contact_service import AgentContactService
+from shared.config import settings
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Request schemas
+# ---------------------------------------------------------------------------
+
+class AssignContactsRequest(BaseModel):
+    directory_ids: Optional[List[UUID]] = Field(default=None, max_length=500)
+    contact_ids: Optional[List[UUID]] = Field(default=None, max_length=1000)
+
+
+class ListAgentContactsRequest(BaseModel):
+    page_no: int = Field(default=1, ge=1)
+    page_size: int = Field(default=20, ge=1, le=100)
+    search: Optional[str] = None
+    sort_by: Optional[str] = None
+    sort_order: str = Field(default="desc", pattern="^(asc|desc)$")
+
+
+class UnassignContactsRequest(BaseModel):
+    contact_ids: List[UUID] = Field(min_length=1, max_length=1000)
+
+
+# ---------------------------------------------------------------------------
+# Service helper
+# ---------------------------------------------------------------------------
+
+def _agent_contact_service(claims: JWTClaims, db: Session) -> AgentContactService:
+    org_id = UUID(str(claims.org_id)) if claims.org_id else UUID(settings.DEFAULT_ORG_ID)
+    user_id = UUID(str(claims.user_id)) if getattr(claims, "user_id", None) else None
+    return AgentContactService(db, user_id=user_id, org_id=org_id)
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@router.post("/{agent_id}/contacts/assign")
+def assign_contacts(
+    agent_id: UUID,
+    body: AssignContactsRequest,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    """Assign contacts to the agent from directories and/or explicit contact ids
+    (idempotent). Returns ``{assigned, skipped}``."""
+    return _agent_contact_service(claims, db).assign_contacts_to_agent(
+        agent_id,
+        directory_ids=body.directory_ids,
+        contact_ids=body.contact_ids,
+    )
+
+
+@router.post("/{agent_id}/contacts/list")
+def list_agent_contacts(
+    agent_id: UUID,
+    body: ListAgentContactsRequest,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    """Paginated list of contacts assigned to the agent."""
+    return _agent_contact_service(claims, db).list_agent_contacts(
+        agent_id,
+        page_no=body.page_no,
+        page_size=body.page_size,
+        search=body.search,
+        sort_by=body.sort_by,
+        sort_order=body.sort_order,
+    )
+
+
+@router.post("/{agent_id}/contacts/unassign")
+def unassign_contacts(
+    agent_id: UUID,
+    body: UnassignContactsRequest,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    """Remove the given contacts from the agent (contacts/directory untouched)."""
+    return _agent_contact_service(claims, db).unassign_contacts_from_agent(
+        agent_id, body.contact_ids
+    )

--- a/core/api/v1/contact_datasources.py
+++ b/core/api/v1/contact_datasources.py
@@ -1,0 +1,93 @@
+"""Contact Datasources router — CRUD over the CSV datasources that feed directories.
+
+Create/delete require admin/owner; list requires any org member. CSV-only at launch.
+"""
+
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from core.database.session import get_db
+from core.middleware.auth import JWTClaims, require_admin_or_owner, require_org_member
+from core.services.contacts.contact_datasource_service import ContactDatasourceService
+from shared.config import settings
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Request schemas
+# ---------------------------------------------------------------------------
+
+class CreateDatasourceRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+    directory_id: Optional[UUID] = None
+    type: str = Field(default="csv")
+    config: Optional[Dict[str, Any]] = None
+
+
+class ListDatasourcesRequest(BaseModel):
+    directory_id: Optional[UUID] = None
+    page_no: int = Field(default=1, ge=1)
+    page_size: int = Field(default=20, ge=1, le=100)
+    search: Optional[str] = None
+    sort_by: Optional[str] = None
+    sort_order: str = Field(default="desc", pattern="^(asc|desc)$")
+
+
+# ---------------------------------------------------------------------------
+# Service helper
+# ---------------------------------------------------------------------------
+
+def _service(claims: JWTClaims, db: Session) -> ContactDatasourceService:
+    org_id = UUID(str(claims.org_id)) if claims.org_id else UUID(settings.DEFAULT_ORG_ID)
+    user_id = UUID(str(claims.user_id)) if getattr(claims, "user_id", None) else None
+    return ContactDatasourceService(db, user_id=user_id, org_id=org_id)
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+def create_datasource(
+    body: CreateDatasourceRequest,
+    claims: JWTClaims = Depends(require_admin_or_owner),
+    db: Session = Depends(get_db),
+):
+    datasource = _service(claims, db).create_datasource(
+        name=body.name,
+        directory_id=body.directory_id,
+        type=body.type,
+        config=body.config,
+    )
+    return datasource.to_dict()
+
+
+@router.post("/list")
+def list_datasources(
+    body: ListDatasourcesRequest,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    return _service(claims, db).list_datasources(
+        directory_id=body.directory_id,
+        page_no=body.page_no,
+        page_size=body.page_size,
+        search=body.search,
+        sort_by=body.sort_by,
+        sort_order=body.sort_order,
+    )
+
+
+@router.delete("/{datasource_id}")
+def delete_datasource(
+    datasource_id: UUID,
+    claims: JWTClaims = Depends(require_admin_or_owner),
+    db: Session = Depends(get_db),
+):
+    _service(claims, db).delete_datasource(datasource_id)
+    return {"ok": True}

--- a/core/api/v1/contact_directories.py
+++ b/core/api/v1/contact_directories.py
@@ -1,0 +1,130 @@
+"""Contact Directories router — CRUD over user-created directories.
+
+Writes (create/update/delete/delete-impact) require admin/owner; reads (get/list)
+require any org member. All handlers are org-scoped via the service layer (no IDOR).
+"""
+
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from core.database.session import get_db
+from core.middleware.auth import JWTClaims, require_admin_or_owner, require_org_member
+from core.services.contacts.contact_directory_service import ContactDirectoryService
+from shared.config import settings
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Request schemas
+# ---------------------------------------------------------------------------
+
+class CreateDirectoryRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+    description: Optional[str] = Field(default=None, max_length=500)
+    # Optional: point the new directory at an existing org schema as its default.
+    # Omitted → no default schema (no schema is auto-created per directory).
+    default_schema_id: Optional[UUID] = None
+
+
+class UpdateDirectoryRequest(BaseModel):
+    name: Optional[str] = Field(default=None, min_length=1, max_length=120)
+    description: Optional[str] = Field(default=None, max_length=500)
+    is_active: Optional[bool] = None
+    default_schema_id: Optional[UUID] = None
+
+
+class ListDirectoriesRequest(BaseModel):
+    page_no: int = Field(default=1, ge=1)
+    page_size: int = Field(default=20, ge=1, le=100)
+    search: Optional[str] = None
+    sort_by: Optional[str] = None
+    sort_order: str = Field(default="desc", pattern="^(asc|desc)$")
+
+
+# ---------------------------------------------------------------------------
+# Service helper
+# ---------------------------------------------------------------------------
+
+def _service(claims: JWTClaims, db: Session) -> ContactDirectoryService:
+    org_id = UUID(str(claims.org_id)) if claims.org_id else UUID(settings.DEFAULT_ORG_ID)
+    user_id = UUID(str(claims.user_id)) if getattr(claims, "user_id", None) else None
+    return ContactDirectoryService(db, user_id=user_id, org_id=org_id)
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+def create_directory(
+    body: CreateDirectoryRequest,
+    claims: JWTClaims = Depends(require_admin_or_owner),
+    db: Session = Depends(get_db),
+):
+    directory = _service(claims, db).create_directory(
+        name=body.name,
+        description=body.description,
+        default_schema_id=body.default_schema_id,
+    )
+    return directory.to_dict()
+
+
+@router.post("/list")
+def list_directories(
+    body: ListDirectoriesRequest,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    return _service(claims, db).list_directories(
+        page_no=body.page_no,
+        page_size=body.page_size,
+        search=body.search,
+        sort_by=body.sort_by,
+        sort_order=body.sort_order,
+    )
+
+
+@router.get("/{directory_id}")
+def get_directory(
+    directory_id: UUID,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    return _service(claims, db).get_directory(directory_id).to_dict()
+
+
+@router.patch("/{directory_id}")
+def update_directory(
+    directory_id: UUID,
+    body: UpdateDirectoryRequest,
+    claims: JWTClaims = Depends(require_admin_or_owner),
+    db: Session = Depends(get_db),
+):
+    directory = _service(claims, db).update_directory(
+        directory_id,
+        **body.model_dump(exclude_unset=True),
+    )
+    return directory.to_dict()
+
+
+@router.get("/{directory_id}/delete-impact")
+def directory_delete_impact(
+    directory_id: UUID,
+    claims: JWTClaims = Depends(require_admin_or_owner),
+    db: Session = Depends(get_db),
+):
+    return _service(claims, db).delete_impact(directory_id)
+
+
+@router.delete("/{directory_id}")
+def delete_directory(
+    directory_id: UUID,
+    claims: JWTClaims = Depends(require_admin_or_owner),
+    db: Session = Depends(get_db),
+):
+    return _service(claims, db).delete_directory(directory_id)

--- a/core/api/v1/contact_schemas.py
+++ b/core/api/v1/contact_schemas.py
@@ -1,0 +1,202 @@
+"""Contact schemas router — org-level, reusable ``ContactSchema`` + ``SchemaField`` CRUD.
+
+Schemas are shared across directories (a directory's ``default_schema_id``) and syncs;
+this router owns their lifecycle only. Setting a directory's default is done via
+``PATCH /contact-directories/{id}`` — NOT here.
+
+Two routers are exported:
+- ``router`` (prefix ``/contact-schemas``): schema CRUD + nested field-create.
+- ``field_router`` (prefix ``/schema-fields``): update/delete a field by its own id.
+
+Guards: writes = admin/owner (``require_admin_or_owner``), reads = member
+(``require_org_member``). Every handler is org-scoped inside the service.
+"""
+
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from core.database.session import get_db
+from core.middleware.auth import JWTClaims, require_admin_or_owner, require_org_member
+from core.services.contacts.contact_schema_service import ContactSchemaService
+from shared.config import settings
+
+router = APIRouter(prefix="/contact-schemas", tags=["contact-schemas"])
+field_router = APIRouter(prefix="/schema-fields", tags=["contact-schemas"])
+
+
+# ---------------------------------------------------------------------------
+# Request schemas
+# ---------------------------------------------------------------------------
+
+class CreateSchemaRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+    description: Optional[str] = Field(default=None, max_length=500)
+    is_active: bool = True
+
+
+class UpdateSchemaRequest(BaseModel):
+    name: Optional[str] = Field(default=None, min_length=1, max_length=120)
+    description: Optional[str] = Field(default=None, max_length=500)
+    is_active: Optional[bool] = None
+
+
+class ListSchemasRequest(BaseModel):
+    page_no: int = Field(default=1, ge=1)
+    page_size: int = Field(default=20, ge=1, le=100)
+    search: Optional[str] = None
+    sort_by: Optional[str] = None
+    sort_order: str = Field(default="desc", pattern="^(asc|desc)$")
+
+
+class CreateSchemaFieldRequest(BaseModel):
+    field_name: str = Field(min_length=1, max_length=64)
+    type: str = "string"
+    label: Optional[str] = None
+    format: Optional[str] = None
+    is_mandatory: bool = False
+    validators: Optional[Dict[str, Any]] = None
+    options: Optional[List[Dict[str, Any]]] = None
+    source_key: Optional[str] = None
+    display_order: int = 0
+
+
+class UpdateSchemaFieldRequest(BaseModel):
+    label: Optional[str] = None
+    type: Optional[str] = None
+    format: Optional[str] = None
+    is_mandatory: Optional[bool] = None
+    validators: Optional[Dict[str, Any]] = None
+    options: Optional[List[Dict[str, Any]]] = None
+    source_key: Optional[str] = None
+    display_order: Optional[int] = None
+    is_active: Optional[bool] = None
+
+
+# ---------------------------------------------------------------------------
+# Service helper
+# ---------------------------------------------------------------------------
+
+def _schema_service(claims: JWTClaims, db: Session) -> ContactSchemaService:
+    org_id = UUID(str(claims.org_id)) if claims.org_id else UUID(settings.DEFAULT_ORG_ID)
+    user_id = UUID(str(claims.user_id)) if getattr(claims, "user_id", None) else None
+    return ContactSchemaService(db, user_id=user_id, org_id=org_id)
+
+
+# ---------------------------------------------------------------------------
+# Schema CRUD
+# ---------------------------------------------------------------------------
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+def create_schema(
+    body: CreateSchemaRequest,
+    claims: JWTClaims = Depends(require_admin_or_owner),
+    db: Session = Depends(get_db),
+):
+    schema = _schema_service(claims, db).create_schema(
+        name=body.name,
+        description=body.description,
+        is_active=body.is_active,
+    )
+    return schema.to_dict()
+
+
+@router.post("/list")
+def list_schemas(
+    body: ListSchemasRequest,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    return _schema_service(claims, db).list_schemas(
+        page_no=body.page_no,
+        page_size=body.page_size,
+        search=body.search,
+        sort_by=body.sort_by,
+        sort_order=body.sort_order,
+    )
+
+
+@router.get("/{schema_id}")
+def get_schema(
+    schema_id: UUID,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    """Schema with its active fields + a ``referenced_by`` count (directories/syncs)."""
+    return _schema_service(claims, db).get_schema_detail(schema_id)
+
+
+@router.patch("/{schema_id}")
+def update_schema(
+    schema_id: UUID,
+    body: UpdateSchemaRequest,
+    claims: JWTClaims = Depends(require_admin_or_owner),
+    db: Session = Depends(get_db),
+):
+    return _schema_service(claims, db).update_schema(
+        schema_id, **body.model_dump(exclude_unset=True)
+    )
+
+
+@router.delete("/{schema_id}")
+def delete_schema(
+    schema_id: UUID,
+    claims: JWTClaims = Depends(require_admin_or_owner),
+    db: Session = Depends(get_db),
+):
+    return _schema_service(claims, db).delete_schema(schema_id)
+
+
+# ---------------------------------------------------------------------------
+# Field create (nested under a schema)
+# ---------------------------------------------------------------------------
+
+@router.post("/{schema_id}/fields", status_code=status.HTTP_201_CREATED)
+def create_schema_field(
+    schema_id: UUID,
+    body: CreateSchemaFieldRequest,
+    claims: JWTClaims = Depends(require_admin_or_owner),
+    db: Session = Depends(get_db),
+):
+    field = _schema_service(claims, db).create_schema_field(
+        schema_id,
+        field_name=body.field_name,
+        type=body.type,
+        label=body.label,
+        format=body.format,
+        is_mandatory=body.is_mandatory,
+        validators=body.validators,
+        options=body.options,
+        source_key=body.source_key,
+        display_order=body.display_order,
+    )
+    return field.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Field update / delete (by field id)
+# ---------------------------------------------------------------------------
+
+@field_router.patch("/{field_id}")
+def update_schema_field(
+    field_id: UUID,
+    body: UpdateSchemaFieldRequest,
+    claims: JWTClaims = Depends(require_admin_or_owner),
+    db: Session = Depends(get_db),
+):
+    field = _schema_service(claims, db).update_schema_field(
+        field_id, **body.model_dump(exclude_unset=True)
+    )
+    return field.to_dict()
+
+
+@field_router.delete("/{field_id}")
+def delete_schema_field(
+    field_id: UUID,
+    claims: JWTClaims = Depends(require_admin_or_owner),
+    db: Session = Depends(get_db),
+):
+    return _schema_service(claims, db).delete_schema_field(field_id)

--- a/core/api/v1/contact_syncs.py
+++ b/core/api/v1/contact_syncs.py
@@ -1,0 +1,89 @@
+"""Contact syncs router — datasource-driven imports into a directory.
+
+Endpoints (all ``require_org_member`` — any member can run a sync):
+- ``POST /contact-syncs`` (multipart): create + enqueue a sync from an uploaded CSV.
+- ``POST /contact-syncs/list``: paginated list of syncs (optionally by directory).
+- ``GET  /contact-syncs/{id}``: one sync's status/counts (incl. ``row_errors``).
+"""
+
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, File, Form, UploadFile, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from core.database.session import get_db
+from core.middleware.auth import JWTClaims, require_org_member
+from core.services.contacts.contact_sync_service import ContactSyncService
+from shared.config import settings
+
+router = APIRouter()
+
+
+class ListContactSyncsRequest(BaseModel):
+    directory_id: Optional[UUID] = None
+    status: Optional[str] = Field(default=None, pattern="^(pending|processing|completed|failed)$")
+    page_no: int = Field(default=1, ge=1)
+    page_size: int = Field(default=20, ge=1, le=100)
+    sort_by: Optional[str] = None
+    sort_order: str = Field(default="desc", pattern="^(asc|desc)$")
+
+
+def _resolve_ids(claims: JWTClaims):
+    org_id = UUID(str(claims.org_id)) if claims.org_id else UUID(settings.DEFAULT_ORG_ID)
+    user_id = UUID(str(claims.user_id)) if getattr(claims, "user_id", None) else None
+    return org_id, user_id
+
+
+def _sync_service(claims: JWTClaims, db: Session) -> ContactSyncService:
+    org_id, user_id = _resolve_ids(claims)
+    return ContactSyncService(db, user_id=user_id, org_id=org_id)
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+def create_contact_sync(
+    directory_id: UUID = Form(...),
+    schema_id: UUID = Form(...),
+    agent_id: Optional[UUID] = Form(None),
+    file: UploadFile = File(...),
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    """Store the uploaded CSV, insert a pending sync, and enqueue its parse job.
+
+    Returns the sync immediately (``status="pending"``); the client polls
+    ``GET /contact-syncs/{id}`` while the worker imports.
+    """
+    sync = _sync_service(claims, db).create_contact_sync(
+        directory_id=directory_id,
+        schema_id=schema_id,
+        agent_id=agent_id,
+        file=file,
+    )
+    return sync.to_dict()
+
+
+@router.post("/list")
+def list_contact_syncs(
+    body: ListContactSyncsRequest,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    return _sync_service(claims, db).list_contact_syncs(
+        directory_id=body.directory_id,
+        status=body.status,
+        page_no=body.page_no,
+        page_size=body.page_size,
+        sort_by=body.sort_by,
+        sort_order=body.sort_order,
+    )
+
+
+@router.get("/{sync_id}")
+def get_contact_sync(
+    sync_id: UUID,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    return _sync_service(claims, db).get_contact_sync(sync_id).to_dict()

--- a/core/api/v1/contacts.py
+++ b/core/api/v1/contacts.py
@@ -1,0 +1,202 @@
+"""Contacts router — directory-scoped contact CRUD + schedule-calls.
+
+Every contact lives inside a ``ContactDirectory``; the list/create/bulk-delete routes are
+nested under ``/contact-directories/{directory_id}``, while single-contact update/delete
+address the contact by id (the service still org- + directory-scopes the lookup, so no
+IDOR). All handlers are org-scoped via ``require_org_member``.
+
+Multi-add is PARTIAL: ``POST /contact-directories/{id}/contacts`` returns
+``{"created": [...], "failed": [{index, errors}]}`` (see C-7) for both single- and
+multi-row bodies. The standalone ``POST /schedule-calls`` (delegating to
+``OutboundCallService``) is kept unchanged.
+
+Upload/import and schema/field endpoints have moved out (to the sync + schema services).
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from core.database.session import get_db
+from core.middleware.auth import JWTClaims, require_org_member
+from core.services.contacts.contact_service import ContactService
+from core.services.outbound_call_service import OutboundCallService
+from shared.config import settings
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Request schemas
+# ---------------------------------------------------------------------------
+
+class ListContactsRequest(BaseModel):
+    page_no: int = Field(default=1, ge=1)
+    page_size: int = Field(default=20, ge=1, le=100)
+    search: Optional[str] = None
+    sort_by: Optional[str] = None
+    sort_order: str = Field(default="desc", pattern="^(asc|desc)$")
+
+
+class ContactRow(BaseModel):
+    name: Optional[str] = None
+    phone_number: Optional[str] = None
+    external_id: Optional[str] = None
+    contact_metadata: Optional[Dict[str, Any]] = None
+
+
+class CreateContactsRequest(BaseModel):
+    """Single- or multi-row create. Exactly one of ``contact`` / ``contacts`` is used;
+    both shapes normalise to a list so the response is always ``{created, failed}``."""
+
+    contact: Optional[ContactRow] = None
+    contacts: Optional[List[ContactRow]] = Field(default=None, max_length=1000)
+    # Optional agent assignment: when set, the created contacts are also assigned to this
+    # agent (idempotent) in the same request. When omitted the contacts are just created.
+    agent_id: Optional[UUID] = None
+
+    def as_rows(self) -> List[Dict[str, Any]]:
+        rows = self.contacts if self.contacts is not None else (
+            [self.contact] if self.contact is not None else []
+        )
+        return [r.model_dump() for r in rows]
+
+
+class UpdateContactRequest(BaseModel):
+    name: Optional[str] = None
+    phone_number: Optional[str] = None
+    contact_metadata: Optional[Dict[str, Any]] = None
+
+
+class BulkDeleteContactsRequest(BaseModel):
+    ids: List[UUID] = Field(min_length=1, max_length=500)
+
+
+class ScheduleContactCallsRequest(BaseModel):
+    agent_id: UUID
+    from_number: str
+    contact_ids: List[UUID] = Field(min_length=1, max_length=500)
+    scheduled_at: Optional[datetime] = None
+
+
+# ---------------------------------------------------------------------------
+# Service helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_ids(claims: JWTClaims):
+    org_id = UUID(str(claims.org_id)) if claims.org_id else UUID(settings.DEFAULT_ORG_ID)
+    user_id = UUID(str(claims.user_id)) if getattr(claims, "user_id", None) else None
+    return org_id, user_id
+
+
+def _contact_service(claims: JWTClaims, db: Session) -> ContactService:
+    org_id, user_id = _resolve_ids(claims)
+    return ContactService(db, user_id=user_id, org_id=org_id)
+
+
+def _outbound_service(claims: JWTClaims, db: Session) -> OutboundCallService:
+    org_id, user_id = _resolve_ids(claims)
+    return OutboundCallService(db, user_id=user_id, org_id=org_id)
+
+
+# ---------------------------------------------------------------------------
+# Directory-scoped contact CRUD
+# ---------------------------------------------------------------------------
+
+@router.post("/contact-directories/{directory_id}/contacts/list")
+def list_contacts(
+    directory_id: UUID,
+    body: ListContactsRequest,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    return _contact_service(claims, db).list_contacts(
+        directory_id,
+        page_no=body.page_no,
+        page_size=body.page_size,
+        search=body.search,
+        sort_by=body.sort_by,
+        sort_order=body.sort_order,
+    )
+
+
+@router.post("/contact-directories/{directory_id}/contacts", status_code=status.HTTP_201_CREATED)
+def create_contacts(
+    directory_id: UUID,
+    body: CreateContactsRequest,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    """Create one or many contacts (partial success). Returns
+    ``{"created": [...], "failed": [{index, errors}]}`` (C-7).
+
+    When ``agent_id`` is provided, the freshly-created contacts are ALSO assigned to that
+    agent in the same request (idempotent — reuses ``AgentContactService`` so the
+    directory General view and the agent Contacts tab share one create endpoint).
+    """
+    return _contact_service(claims, db).create_contacts(
+        directory_id, body.as_rows(), agent_id=body.agent_id
+    )
+
+
+@router.patch("/contacts/{contact_id}")
+def update_contact(
+    contact_id: UUID,
+    body: UpdateContactRequest,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    contact = _contact_service(claims, db).update_contact(
+        contact_id,
+        name=body.name,
+        phone_number=body.phone_number,
+        contact_metadata=body.contact_metadata,
+    )
+    return contact.to_dict()
+
+
+@router.delete("/contacts/{contact_id}")
+def delete_contact(
+    contact_id: UUID,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    _contact_service(claims, db).delete_contact(contact_id)
+    return {"ok": True}
+
+
+@router.post("/contact-directories/{directory_id}/contacts/bulk-delete")
+def bulk_delete_contacts(
+    directory_id: UUID,
+    body: BulkDeleteContactsRequest,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    return _contact_service(claims, db).bulk_delete_contacts(directory_id, body.ids)
+
+
+# ---------------------------------------------------------------------------
+# Scheduling (unchanged)
+# ---------------------------------------------------------------------------
+
+@router.post("/contact/schedule-calls")
+def schedule_contact_calls(
+    body: ScheduleContactCallsRequest,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+):
+    """Schedule outbound calls to the selected contacts. Reuses OutboundCallService's
+    agent/from-number validation and the ``scheduled_calls`` infrastructure; each row
+    carries its ``contact_id`` and per-contact schedule time."""
+    service = _outbound_service(claims, db)
+    return service.schedule_calls_for_contacts(
+        agent_id=body.agent_id,
+        from_number=body.from_number,
+        contact_ids=body.contact_ids,
+        scheduled_at=body.scheduled_at,
+        created_by_user_id=service.user_id,
+    )

--- a/core/middleware/auth.py
+++ b/core/middleware/auth.py
@@ -331,7 +331,9 @@ def require_org_member(claims: JWTClaims = Depends(get_jwt_claims)) -> JWTClaims
 
 
 def require_admin_or_owner(claims: JWTClaims = Depends(get_jwt_claims)) -> JWTClaims:
-    if not claims.user_id:
+    """Shared admin/owner guard — reuse this on every admin-gated route instead of
+    re-checking roles inline. Raises 403 unless the caller's role is admin or owner."""
+    if claims.role not in {"admin", "owner"}:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Admin or Owner role required"

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -46,6 +46,15 @@ from core.models.tool import Tool
 from core.models.node import Node
 from core.models.pod import Pod
 
+# Contacts (dial targets grouped into user-created directories)
+from core.models.contact_schema import ContactSchema
+from core.models.schema_field import SchemaField
+from core.models.contact_directory import ContactDirectory
+from core.models.datasource import Datasource
+from core.models.contact_sync import ContactSync
+from core.models.contact import Contact
+from core.models.agent_contact import AgentContact
+
 # Calls & Metrics
 from core.models.call import Call
 from core.models.call_metrics import CallMetrics

--- a/core/models/agent_contact.py
+++ b/core/models/agent_contact.py
@@ -1,0 +1,41 @@
+from sqlalchemy import Column, ForeignKey, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+
+from core.models.base import OrgScopedModel
+
+
+class AgentContact(OrgScopedModel):
+    """Join between an agent and a contact assigned to it (no scheduling gate).
+
+    Populated by assigning contacts/directories to an agent (or by a sync's auto-assign
+    ``agent_id``). Both FKs CASCADE so the row is auto-removed when either side is
+    deleted; unique ``(agent_id, contact_id)`` keeps assignment idempotent.
+    """
+
+    __tablename__ = "agent_contacts"
+    __table_args__ = (
+        UniqueConstraint("agent_id", "contact_id", name="uq_agent_contacts_agent_contact"),
+    )
+
+    agent_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("agents.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    contact_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("contacts.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    created_by_user_id = Column(UUID(as_uuid=True), nullable=True)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": str(self.id),
+            "agent_id": str(self.agent_id),
+            "contact_id": str(self.contact_id),
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/core/models/contact.py
+++ b/core/models/contact.py
@@ -1,0 +1,60 @@
+from sqlalchemy import Column, String, Boolean, ForeignKey, DateTime, Index, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+from core.models.base import OrgScopedModel
+
+
+class Contact(OrgScopedModel):
+    """A dial target that belongs to exactly one ``ContactDirectory``.
+
+    The dialed number lives in the dedicated, indexed ``phone_number`` column (E.164)
+    — NOT in ``contact_metadata`` — so scheduling can join/dial it directly. Any extra
+    columns from the source land in ``contact_metadata`` (including an optional per-row
+    ``scheduled_at`` used to override a batch schedule time).
+
+    Contacts are deduplicated per DIRECTORY on ``external_id`` (synthesized by the
+    ingestion layer when a source row has none), so re-importing the same file upserts
+    rather than duplicating. ``directory_id`` is RESTRICT so a directory can only be
+    removed via the explicit hard-delete path (which deletes its contacts first);
+    ``sync_id`` records the sync run that last wrote the contact (SET NULL on sync loss).
+    """
+
+    __tablename__ = "contacts"
+    __table_args__ = (
+        UniqueConstraint("directory_id", "external_id", name="uq_contacts_directory_external_id"),
+        Index("ix_contacts_org_phone_number", "organization_id", "phone_number"),
+    )
+
+    directory_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("contact_directories.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+    external_id = Column(String(255), nullable=False, index=True)
+    name = Column(String(255), nullable=True)
+    # Primary dial target, E.164 (e.g. +14155550123). Nullable so a contact can be
+    # imported without a number yet (it just can't be scheduled until one is set).
+    phone_number = Column(String(20), nullable=True, index=True)
+    contact_metadata = Column(JSONB, nullable=False, default=dict)
+    sync_id = Column(
+        UUID(as_uuid=True), ForeignKey("contact_syncs.id", ondelete="SET NULL"), nullable=True
+    )
+    created_by_user_id = Column(UUID(as_uuid=True), nullable=True)
+    is_active = Column(Boolean, nullable=False, default=True)
+    deleted_at = Column(DateTime(timezone=True), nullable=True)
+    archived_at = Column(DateTime(timezone=True), nullable=True)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": str(self.id),
+            "directory_id": str(self.directory_id) if self.directory_id else None,
+            "external_id": self.external_id,
+            "name": self.name,
+            "phone_number": self.phone_number,
+            "contact_metadata": self.contact_metadata or {},
+            "sync_id": str(self.sync_id) if self.sync_id else None,
+            "is_active": self.is_active,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/core/models/contact_directory.py
+++ b/core/models/contact_directory.py
@@ -1,0 +1,43 @@
+from sqlalchemy import Column, String, Boolean, DateTime, ForeignKey, Index
+from sqlalchemy.dialects.postgresql import UUID
+
+from core.models.base import OrgScopedModel
+
+
+class ContactDirectory(OrgScopedModel):
+    """A user-created contact directory — the container that owns its contacts and a
+    CSV datasource, and references one reusable org-level schema as its default shape.
+
+    An org has MANY directories. Each directory auto-provisions a CSV datasource on
+    create and points ``default_schema_id`` at a ``ContactSchema`` (the manual-Add form
+    + validation shape). ``default_schema_id`` is SET NULL so deleting a shared schema
+    never cascades into directories.
+    """
+
+    __tablename__ = "contact_directories"
+    __table_args__ = (
+        Index("ix_contact_directories_org_name", "organization_id", "name"),
+    )
+
+    name = Column(String(120), nullable=False)
+    description = Column(String(500), nullable=True)
+    default_schema_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("contact_schemas.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    created_by_user_id = Column(UUID(as_uuid=True), nullable=True)
+    is_active = Column(Boolean, nullable=False, default=True)
+    deleted_at = Column(DateTime(timezone=True), nullable=True)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": str(self.id),
+            "name": self.name,
+            "description": self.description,
+            "default_schema_id": str(self.default_schema_id) if self.default_schema_id else None,
+            "is_active": self.is_active,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/core/models/contact_schema.py
+++ b/core/models/contact_schema.py
@@ -1,0 +1,36 @@
+from sqlalchemy import Column, String, Boolean, DateTime, Index
+from sqlalchemy.dialects.postgresql import UUID
+
+from core.models.base import OrgScopedModel
+
+
+class ContactSchema(OrgScopedModel):
+    """An ORG-LEVEL, reusable contact-shape template (parent of ``SchemaField``).
+
+    Replaces the old flat ``contact_field_definitions``: a schema groups a set of
+    ``schema_fields`` and can be referenced by MANY directories (as a directory's
+    ``default_schema_id`` — its manual-Add form + validation shape) and by MANY syncs
+    (as the external→target mapping). It carries NO ``directory_id`` / ``datasource_id``
+    / ``is_default`` — those bindings live on the referencing directory/sync.
+    """
+
+    __tablename__ = "contact_schemas"
+    __table_args__ = (
+        Index("ix_contact_schemas_org_name", "organization_id", "name"),
+    )
+
+    name = Column(String(120), nullable=False)
+    description = Column(String(500), nullable=True)
+    created_by_user_id = Column(UUID(as_uuid=True), nullable=True)
+    is_active = Column(Boolean, nullable=False, default=True)
+    deleted_at = Column(DateTime(timezone=True), nullable=True)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": str(self.id),
+            "name": self.name,
+            "description": self.description,
+            "is_active": self.is_active,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/core/models/contact_sync.py
+++ b/core/models/contact_sync.py
@@ -1,0 +1,74 @@
+from sqlalchemy import Column, String, DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+from core.models.base import OrgScopedModel
+
+
+class ContactSync(OrgScopedModel):
+    """One run of the datasource-driven import pipeline into a directory.
+
+    Records the mapping schema, optional CSV upload, optional auto-assign ``agent_id``,
+    lifecycle ``status`` (pending|processing|completed|failed), per-run ``counts``
+    ({created,updated,skipped,failed}) and per-row ``row_errors`` for a downloadable
+    partial-failure report. ``directory_id``/``datasource_id`` are SET NULL so a sync
+    survives as detached audit when its directory is hard-deleted.
+    """
+
+    __tablename__ = "contact_syncs"
+
+    directory_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("contact_directories.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    datasource_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("datasources.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    schema_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("contact_schemas.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+    upload_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("uploads.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    agent_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("agents.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    # pending | processing | completed | failed
+    status = Column(String(20), nullable=False, default="pending", index=True)
+    counts = Column(JSONB, nullable=False, default=dict)  # {created,updated,skipped,failed}
+    row_errors = Column(JSONB, nullable=False, default=list)  # [{row,field,message}]
+    error = Column(String(500), nullable=True)  # hard-failure message
+    # Optional external integration references (e.g. a future REST/app datasource sync).
+    app_id = Column(String(255), nullable=True)
+    connection_id = Column(String(255), nullable=True)
+    created_by_user_id = Column(UUID(as_uuid=True), nullable=True)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": str(self.id),
+            "directory_id": str(self.directory_id) if self.directory_id else None,
+            "datasource_id": str(self.datasource_id) if self.datasource_id else None,
+            "schema_id": str(self.schema_id) if self.schema_id else None,
+            "upload_id": str(self.upload_id) if self.upload_id else None,
+            "agent_id": str(self.agent_id) if self.agent_id else None,
+            "app_id": self.app_id,
+            "connection_id": self.connection_id,
+            "status": self.status,
+            "counts": self.counts or {},
+            "row_errors": self.row_errors or [],
+            "error": self.error,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/core/models/datasource.py
+++ b/core/models/datasource.py
@@ -1,0 +1,43 @@
+from sqlalchemy import Column, String, Boolean, DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+from core.models.base import OrgScopedModel
+
+
+class Datasource(OrgScopedModel):
+    """A source that feeds contacts into a directory through the sync pipeline.
+
+    CSV-only at launch (auto-provisioned one-per-directory). ``config`` (JSONB) is
+    reserved for future ``rest`` datasources (base_url + AES-encrypted creds).
+    ``directory_id`` is nullable/SET NULL: auto-provisioned CSV datasources are
+    directory-owned, while future org-level REST datasources leave it null and survive
+    a directory delete.
+    """
+
+    __tablename__ = "datasources"
+
+    directory_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("contact_directories.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    name = Column(String(120), nullable=False)
+    # 'csv' now; 'rest'/... later
+    type = Column(String(20), nullable=False, default="csv")
+    config = Column(JSONB, nullable=False, default=dict)
+    is_active = Column(Boolean, nullable=False, default=True)
+    created_by_user_id = Column(UUID(as_uuid=True), nullable=True)
+    deleted_at = Column(DateTime(timezone=True), nullable=True)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": str(self.id),
+            "directory_id": str(self.directory_id) if self.directory_id else None,
+            "name": self.name,
+            "type": self.type,
+            "config": self.config or {},
+            "is_active": self.is_active,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/core/models/scheduled_call.py
+++ b/core/models/scheduled_call.py
@@ -18,6 +18,9 @@ class ScheduledCall(OrgScopedModel):
 
     agent_id = Column(UUID(as_uuid=True), ForeignKey("agents.id", ondelete="RESTRICT"), nullable=False)
     channel_id = Column(UUID(as_uuid=True), ForeignKey("channels.id", ondelete="SET NULL"), nullable=True)
+    # The contact this call targets, when scheduled from the Contacts page. SET NULL so
+    # deleting a contact doesn't cascade-delete its scheduled-call history.
+    contact_id = Column(UUID(as_uuid=True), ForeignKey("contacts.id", ondelete="SET NULL"), nullable=True, index=True)
     from_number = Column(String(20), nullable=False)
     to_number = Column(String(20), nullable=False)
     scheduled_at = Column(DateTime(timezone=True), nullable=False, index=True)

--- a/core/models/schema_field.py
+++ b/core/models/schema_field.py
@@ -1,0 +1,62 @@
+from sqlalchemy import Column, String, Boolean, Integer, DateTime, ForeignKey, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+from core.models.base import OrgScopedModel
+
+
+class SchemaField(OrgScopedModel):
+    """A single field within a ``ContactSchema`` (replaces ``contact_field_definitions``).
+
+    A field names a **target** (``field_name`` — a reserved contact column or a
+    ``contact_metadata`` key) and reads from an optional external ``source_key`` (the
+    CSV/API header; ``null`` = identity mapping, used by a directory's default schema).
+    ``validators`` holds a constrained JSON-Schema subset (minLength/maxLength/pattern/
+    minimum/maximum) applied — with ``type`` and ``is_mandatory`` — on contact
+    create/update and per-row on sync.
+    """
+
+    __tablename__ = "schema_fields"
+    __table_args__ = (
+        UniqueConstraint("schema_id", "field_name", name="uq_schema_fields_schema_field_name"),
+    )
+
+    schema_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("contact_schemas.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    field_name = Column(String(64), nullable=False)  # the target contact column / metadata key
+    label = Column(String(120), nullable=True)  # human label for the form
+    is_mandatory = Column(Boolean, nullable=False, default=False)
+    # string | number | integer | boolean | enum
+    type = Column(String(20), nullable=False, default="string")
+    format = Column(String(32), nullable=True)  # optional: email | date | uri ...
+    validators = Column(JSONB, nullable=False, default=dict)  # JSON-Schema-subset
+    options = Column(JSONB, nullable=True)  # enum choices [{value,label}] for type=enum
+    # External header this field reads from when used as a sync mapping. NULL = identity
+    # (the target column/metadata key is also the source key).
+    source_key = Column(String(120), nullable=True)
+    field_metadata = Column(JSONB, nullable=False, default=dict)
+    display_order = Column(Integer, nullable=False, default=0)
+    is_active = Column(Boolean, nullable=False, default=True)
+    deleted_at = Column(DateTime(timezone=True), nullable=True)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": str(self.id),
+            "schema_id": str(self.schema_id),
+            "field_name": self.field_name,
+            "label": self.label,
+            "is_mandatory": self.is_mandatory,
+            "type": self.type,
+            "format": self.format,
+            "validators": self.validators or {},
+            "options": self.options,
+            "source_key": self.source_key,
+            "field_metadata": self.field_metadata or {},
+            "display_order": self.display_order,
+            "is_active": self.is_active,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/core/services/base.py
+++ b/core/services/base.py
@@ -47,6 +47,24 @@ class BaseService:
             q = q.filter(model.organization_id == self.org_id)
         return q
 
+    def get_or_404(self, model: Type[T], id: Any, name: str = "Resource") -> T:
+        """Fetch a single row of ``model`` by primary key, org-scoped (via ``query``)
+        and excluding soft-deleted rows, or raise a 404.
+
+        Reuse this instead of re-writing per-service get-by-id lookups: it enforces the
+        org filter (no IDOR) and the ``deleted_at IS NULL`` guard in one place. ``name``
+        is used only for the 404 message (e.g. "Directory not found.").
+        """
+        from fastapi import HTTPException
+
+        q = self.query(model).filter(model.id == id)
+        if hasattr(model, 'deleted_at'):
+            q = q.filter(model.deleted_at.is_(None))
+        row = q.first()
+        if row is None:
+            raise HTTPException(status_code=404, detail=f"{name} not found.")
+        return row
+
     def upsert(self, model, values: Dict[str, Any], conflict_fields: List[str],
                update_fields: List[str], extra_update: Optional[Dict[str, Any]] = None,
                auto_commit: bool = True):

--- a/core/services/common/__init__.py
+++ b/core/services/common/__init__.py
@@ -1,0 +1,1 @@
+"""Cross-service reusable helpers (search/sort/paginate, etc.)."""

--- a/core/services/common/list_query.py
+++ b/core/services/common/list_query.py
@@ -1,0 +1,64 @@
+"""Reusable list-query helper — search + sort + paginate an already-org-scoped query.
+
+Use ``apply_search_sort_pagination`` for every ``POST /…/list`` endpoint (directories,
+contacts, schemas, syncs, agent-contacts) instead of hand-rolling the same
+``ilike`` / ``order_by`` / ``offset+limit`` + ``count`` block in each service.
+
+The caller passes a query that is ALREADY org-scoped (via ``BaseService.query``) and
+already filtered for soft-delete where relevant; this helper only layers search, sort,
+and pagination on top and returns ``(rows, total)``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Query
+
+
+def apply_search_sort_pagination(
+    query: Query,
+    *,
+    search: Optional[str] = None,
+    search_fields: Optional[Sequence] = None,
+    sort_by: Optional[str] = None,
+    sort_order: str = "desc",
+    sort_map: Optional[Dict[str, Any]] = None,
+    page_no: int = 1,
+    page_size: int = 20,
+) -> Tuple[List[Any], int]:
+    """Apply case-insensitive search, whitelisted sort, and pagination to ``query``.
+
+    Args:
+        query: an already-scoped SQLAlchemy ``Query``.
+        search: free-text term; matched (``ilike``) against every column in
+            ``search_fields``. Ignored when blank or when ``search_fields`` is empty.
+        search_fields: model columns to search across.
+        sort_by: key into ``sort_map`` selecting the sort column; falls back to the
+            first ``sort_map`` entry (or no explicit sort) when unknown.
+        sort_order: ``"asc"`` or ``"desc"`` (default ``"desc"``).
+        sort_map: whitelist mapping public sort keys → model columns. Only keys here
+            are sortable, so a client can never sort by an arbitrary column.
+        page_no / page_size: 1-based pagination.
+
+    Returns:
+        ``(rows, total)`` — the page of rows and the total pre-pagination count.
+    """
+    term = (search or "").strip()
+    if term and search_fields:
+        like = f"%{term}%"
+        query = query.filter(or_(*[col.ilike(like) for col in search_fields]))
+
+    total = query.count()
+
+    if sort_map:
+        col = sort_map.get(sort_by) if sort_by else None
+        if col is None:
+            col = next(iter(sort_map.values()))
+        query = query.order_by(col.asc() if sort_order == "asc" else col.desc())
+
+    page_no = max(page_no, 1)
+    page_size = min(max(page_size, 1), 200)
+    rows = query.offset((page_no - 1) * page_size).limit(page_size).all()
+    return rows, total

--- a/core/services/contact_ingestion/__init__.py
+++ b/core/services/contact_ingestion/__init__.py
@@ -1,0 +1,47 @@
+"""Contact ingestion package — data-source-agnostic parsing of contact blobs.
+
+Use ``get_contact_source(datasource)`` to obtain a parser for a ``Datasource`` row; the
+factory dispatches on ``datasource.type`` (``csv`` today, ``rest`` later). Adding a new
+source is a new ``ContactSource`` subclass plus one entry in ``_SOURCES``.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from core.services.contact_ingestion.base import ContactSource, ParsedContact
+from core.services.contact_ingestion.csv_source import CSVContactSource
+from core.services.contact_ingestion.rest_source import RestContactSource
+
+# datasource.type -> parser. New source types register exactly one entry here.
+_SOURCES: Dict[str, Type[ContactSource]] = {
+    "csv": CSVContactSource,
+    "rest": RestContactSource,
+}
+
+
+def get_contact_source(datasource) -> ContactSource:
+    """Return a ``ContactSource`` for a ``Datasource`` row, keyed by ``datasource.type``.
+
+    ``datasource`` is any object exposing a ``.type`` attribute (a ``Datasource`` model
+    row). Raises ``ValueError`` for an unsupported type so a misconfigured sync fails
+    loudly instead of silently importing nothing.
+    """
+    source_type = getattr(datasource, "type", None)
+    key = (source_type or "csv").strip().lower()
+    source_cls = _SOURCES.get(key)
+    if source_cls is None:
+        raise ValueError(
+            f"Unsupported datasource type {source_type!r}. "
+            f"Supported: {', '.join(sorted(_SOURCES))}."
+        )
+    return source_cls()
+
+
+__all__ = [
+    "ContactSource",
+    "ParsedContact",
+    "CSVContactSource",
+    "RestContactSource",
+    "get_contact_source",
+]

--- a/core/services/contact_ingestion/base.py
+++ b/core/services/contact_ingestion/base.py
@@ -1,0 +1,37 @@
+"""Data-source-agnostic contact ingestion.
+
+A ``ContactSource`` parses a raw blob (whatever a data source hands us — a CSV file
+today, an API export or spreadsheet tomorrow) into a stream of ``ParsedContact``.
+Adding a new source = a new ``ContactSource`` subclass + a factory entry; nothing
+downstream (the service upsert, the router, the parse job) has to change.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterator, Optional
+
+
+@dataclass
+class ParsedContact:
+    """One normalized contact row, independent of the originating source format.
+
+    ``phone_number`` is the dedicated dial target (E.164 where the source provided a
+    parseable one). ``metadata`` holds every other column from the source, including an
+    optional ``scheduled_at`` (ISO-8601) that later overrides a batch schedule time.
+    """
+
+    external_id: str
+    name: Optional[str] = None
+    phone_number: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class ContactSource(ABC):
+    """Parse a raw blob into ``ParsedContact`` rows."""
+
+    @abstractmethod
+    def parse(self, raw: bytes) -> Iterator[ParsedContact]:
+        """Yield one ``ParsedContact`` per source record. Blank rows are skipped."""
+        raise NotImplementedError

--- a/core/services/contact_ingestion/contact_mapping.py
+++ b/core/services/contact_ingestion/contact_mapping.py
@@ -1,0 +1,88 @@
+"""Reusable source-row → contact mapping.
+
+``map_source_row_to_contact`` translates a raw source record (a dict of external
+header → value, e.g. one parsed CSV row) into a normalized contact dict, driven by a
+schema's ``SchemaField`` rows: each field reads from its ``source_key`` (the external
+header) and writes to its ``field_name`` (the target contact column or metadata key).
+A ``null`` ``source_key`` is identity (read from ``field_name`` itself), which is how a
+directory's default schema maps manual input.
+
+Reserved targets (``name``, ``phone_number``, ``external_id``) become top-level contact
+attributes; every other target lands in ``contact_metadata``. Values are coerced to the
+field's ``type`` (best-effort; un-coercible values are left as-is so the downstream
+validator can report a clean per-row error instead of crashing the run). Used by the CSV
+source today and the future REST source.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Sequence
+
+from loguru import logger
+
+# Targets that are first-class contact columns rather than metadata keys.
+_RESERVED_TARGETS = {"name", "phone_number", "external_id"}
+
+
+def _coerce(value: Any, type_: str) -> Any:
+    """Best-effort coerce ``value`` to ``type_``. On failure return the original value
+    (the metadata validator will surface a clean per-row error)."""
+    if value is None:
+        return None
+    if type_ in ("string", "enum"):
+        return value if isinstance(value, str) else str(value)
+    text = value.strip() if isinstance(value, str) else value
+    if text == "" or text is None:
+        return None
+    try:
+        if type_ == "integer":
+            return int(text)
+        if type_ == "number":
+            return float(text)
+        if type_ == "boolean":
+            if isinstance(text, bool):
+                return text
+            return str(text).strip().lower() in {"true", "1", "yes", "y", "t"}
+    except (ValueError, TypeError):
+        logger.debug("[contact_ingestion] could not coerce {!r} to {}; keeping raw", value, type_)
+        return value
+    return value
+
+
+def map_source_row_to_contact(raw: Dict[str, Any], schema_fields: Sequence) -> Dict[str, Any]:
+    """Map one raw source row to a contact dict using a schema's fields.
+
+    Args:
+        raw: external header → cell value for one source record.
+        schema_fields: the schema's ``SchemaField`` rows (active ones; caller-filtered).
+
+    Returns:
+        ``{"name", "phone_number", "external_id", "contact_metadata"}`` — reserved
+        targets promoted to top level, everything else nested in ``contact_metadata``.
+    """
+    name: Optional[str] = None
+    phone_number: Optional[str] = None
+    external_id: Optional[str] = None
+    metadata: Dict[str, Any] = {}
+
+    for f in schema_fields:
+        source_key = f.source_key if f.source_key else f.field_name
+        if source_key not in raw:
+            continue
+        value = _coerce(raw.get(source_key), f.type)
+        if f.field_name == "name":
+            name = value if value in (None,) or isinstance(value, str) else str(value)
+        elif f.field_name == "phone_number":
+            phone_number = value if value in (None,) or isinstance(value, str) else str(value)
+        elif f.field_name == "external_id":
+            external_id = value if value in (None,) or isinstance(value, str) else str(value)
+        else:
+            if value is not None and value != "":
+                metadata[f.field_name] = value
+
+    return {
+        "name": name,
+        "phone_number": phone_number,
+        "external_id": external_id,
+        "contact_metadata": metadata,
+    }

--- a/core/services/contact_ingestion/csv_source.py
+++ b/core/services/contact_ingestion/csv_source.py
@@ -1,0 +1,156 @@
+"""CSV contact source (stdlib ``csv``).
+
+Header handling is case-insensitive and tolerant of the common aliases a user's
+spreadsheet might carry:
+
+- ``name`` -> ``ParsedContact.name``
+- ``phone`` / ``phone_number`` -> ``ParsedContact.phone_number`` (normalized to E.164)
+- ``scheduled_at`` / ``schedule_time`` / ``scheduled_time`` / ``call_time`` ->
+  ``metadata["scheduled_at"]`` (ISO-8601; a naive timestamp is assumed UTC)
+- ``external_id`` -> ``ParsedContact.external_id`` (synthesized, stably, when absent so
+  re-importing the same file upserts instead of duplicating)
+- every other column -> ``metadata``
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+import re
+from datetime import datetime, timezone
+from typing import Dict, Iterator, Optional
+
+from loguru import logger
+
+from core.services.contact_ingestion.base import ContactSource, ParsedContact
+
+_NAME_HEADERS = {"name", "full_name", "contact_name"}
+_PHONE_HEADERS = {"phone", "phone_number", "phonenumber", "mobile", "number"}
+_EXTERNAL_ID_HEADERS = {"external_id", "externalid", "id", "contact_id"}
+_SCHEDULED_AT_HEADERS = {"scheduled_at", "schedule_time", "scheduled_time", "call_time"}
+
+# Reserved headers consumed into first-class fields — everything else flows to metadata.
+_RESERVED = _NAME_HEADERS | _PHONE_HEADERS | _EXTERNAL_ID_HEADERS | _SCHEDULED_AT_HEADERS
+
+_NON_DIAL_CHARS = re.compile(r"[\s\-().]")
+# A trailing ``*`` (with optional surrounding whitespace) marks a "required" column in
+# downloadable sample templates; strip it so ``city*`` still maps to the ``city`` field.
+_REQUIRED_MARKER = re.compile(r"\s*\*+\s*$")
+
+
+def _decode_csv_bytes(raw: bytes) -> str:
+    """Decode uploaded CSV bytes tolerantly.
+
+    Prefer UTF-8 (BOM-aware, for Excel exports), then fall back to cp1252/latin-1 so a
+    spreadsheet saved on Windows/Excel with a single non-UTF-8 byte (é, £, a smart quote)
+    doesn't hard-fail the whole import with a cryptic ``UnicodeDecodeError``. latin-1 maps
+    every byte, so the final replace-fallback is only a belt-and-suspenders guard.
+    """
+    for encoding in ("utf-8-sig", "cp1252", "latin-1"):
+        try:
+            return raw.decode(encoding)
+        except UnicodeDecodeError:
+            logger.debug("[contact_ingestion] CSV not decodable as %s; trying next", encoding)
+    return raw.decode("utf-8", errors="replace")
+
+
+def _normalize_header(header: Optional[str]) -> str:
+    """Normalize a CSV header to its lookup key: strip whitespace, drop a trailing
+    required-marker ``*``, and lowercase."""
+    return _REQUIRED_MARKER.sub("", (header or "").strip()).strip().lower()
+
+
+def _normalize_phone(raw: str) -> Optional[str]:
+    """Best-effort E.164 normalization. Strips spaces/dashes/parens/dots; keeps a
+    leading ``+``. Returns None for blanks. Validation (and rejection of un-dialable
+    numbers) is left to the scheduling path, which already enforces strict E.164."""
+    if not raw:
+        return None
+    cleaned = _NON_DIAL_CHARS.sub("", raw.strip())
+    if not cleaned:
+        return None
+    # A bare international number without '+' but with a leading '00' -> '+'.
+    if cleaned.startswith("00"):
+        cleaned = "+" + cleaned[2:]
+    return cleaned
+
+
+def _normalize_scheduled_at(raw: str) -> Optional[str]:
+    """Parse an ISO-8601 timestamp and return it as an ISO string with a UTC offset.
+    A naive timestamp (no tz) is assumed to be UTC. Unparseable values are dropped."""
+    value = (raw or "").strip()
+    if not value:
+        return None
+    try:
+        # Tolerate a trailing 'Z' which fromisoformat historically rejected.
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        logger.debug("[contact_ingestion] unparseable scheduled_at {!r}; ignoring", raw)
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+class CSVContactSource(ContactSource):
+    def parse(self, raw: bytes) -> Iterator[ParsedContact]:
+        text = _decode_csv_bytes(raw)  # BOM-aware UTF-8, then cp1252/latin-1 fallback
+        reader = csv.DictReader(io.StringIO(text))
+        if not reader.fieldnames:
+            return
+
+        # Map each real header to a normalized (lower/stripped) key once. A trailing
+        # ``*`` (with any surrounding whitespace) is stripped so downloadable sample
+        # templates can mark required columns as e.g. ``city*`` and still map to ``city``.
+        header_map = {h: _normalize_header(h) for h in reader.fieldnames}
+
+        for row in reader:
+            name: Optional[str] = None
+            phone: Optional[str] = None
+            external_id: Optional[str] = None
+            scheduled_at: Optional[str] = None
+            metadata: Dict[str, object] = {}
+
+            for header, value in row.items():
+                key = header_map.get(header, _normalize_header(header))
+                cell = (value or "").strip()
+                if key in _NAME_HEADERS:
+                    name = cell or None
+                elif key in _PHONE_HEADERS:
+                    phone = _normalize_phone(cell)
+                elif key in _EXTERNAL_ID_HEADERS:
+                    external_id = cell or None
+                elif key in _SCHEDULED_AT_HEADERS:
+                    parsed = _normalize_scheduled_at(cell)
+                    if parsed:
+                        scheduled_at = parsed
+                elif key and key not in _RESERVED:
+                    # Preserve extra columns under their original (normalized) header.
+                    if cell:
+                        metadata[key] = cell
+
+            if scheduled_at:
+                metadata["scheduled_at"] = scheduled_at
+
+            # Skip fully-blank rows (no name, no phone, no external id, no metadata).
+            if not any([name, phone, external_id, metadata]):
+                continue
+
+            if not external_id:
+                # Synthesize a STABLE id so re-importing the same file upserts rather
+                # than duplicating: prefer the phone, else a hash of the row content.
+                if phone:
+                    external_id = phone
+                else:
+                    digest = hashlib.sha256(
+                        "|".join(f"{k}={v}" for k, v in sorted(row.items())).encode("utf-8")
+                    ).hexdigest()[:32]
+                    external_id = f"csv-{digest}"
+
+            yield ParsedContact(
+                external_id=external_id,
+                name=name,
+                phone_number=phone,
+                metadata=metadata,
+            )

--- a/core/services/contact_ingestion/rest_source.py
+++ b/core/services/contact_ingestion/rest_source.py
@@ -1,0 +1,23 @@
+"""REST contact source (future — stub).
+
+A placeholder ``ContactSource`` registered for the ``rest`` datasource type so the sync
+pipeline's factory (``get_contact_source``) resolves it uniformly. It shares the same
+``ContactSource`` ABC as ``CSVContactSource``; ``parse`` intentionally raises
+``NotImplementedError`` until REST ingestion is built, so a misconfigured ``rest``
+datasource fails loudly with a clear message rather than silently importing nothing.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator
+
+from core.services.contact_ingestion.base import ContactSource, ParsedContact
+
+
+class RestContactSource(ContactSource):
+    """Future REST-datasource parser (not yet implemented)."""
+
+    def parse(self, raw: bytes) -> Iterator[ParsedContact]:
+        raise NotImplementedError(
+            "RestContactSource is not implemented yet; only 'csv' datasources are supported."
+        )

--- a/core/services/contacts/__init__.py
+++ b/core/services/contacts/__init__.py
@@ -1,0 +1,2 @@
+"""Contacts service package — directories, datasources, schemas, contacts, syncs,
+agent assignment, and their shared reusable helpers (metadata validation, upsert)."""

--- a/core/services/contacts/agent_contact_service.py
+++ b/core/services/contacts/agent_contact_service.py
@@ -1,0 +1,222 @@
+"""AgentContactService — assign/list/unassign contacts on an agent (no scheduling gate).
+
+An ``AgentContact`` row is a plain assignment: a contact is attached to an agent so the
+agent's outbound flows can dial it. Assignment is idempotent (unique ``(agent_id,
+contact_id)``) and can target whole directories (expanded server-side to their active
+contacts) and/or explicit contact ids. Assigning does NOT schedule anything.
+
+Context tag: ``[agent-contacts]``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence
+from uuid import UUID
+
+from fastapi import HTTPException
+from loguru import logger
+from sqlalchemy.exc import IntegrityError
+
+from core.models.agent import Agent
+from core.models.agent_contact import AgentContact
+from core.models.contact import Contact
+from core.services.base import BaseService
+from core.services.common.list_query import apply_search_sort_pagination
+
+_LOG_TAG = "[agent-contacts]"
+
+
+class AgentContactService(BaseService):
+    """Manage the contacts assigned to an agent.
+
+    All reads/writes are org-scoped via ``BaseService.query``; the agent is verified to
+    belong to the caller's org before any assignment so there is no IDOR.
+    """
+
+    # ------------------------------------------------------------------ helpers
+    def _get_agent_or_404(self, agent_id: UUID) -> Agent:
+        """Fetch the agent org-scoped (excludes soft-deleted) or raise 404.
+
+        Guards every entry point so a caller can never assign/list/unassign against an
+        agent outside their organization.
+        """
+        return self.get_or_404(Agent, agent_id, name="Agent")
+
+    # ----------------------------------------------------------------- assign
+    def assign_contacts_to_agent(
+        self,
+        agent_id: UUID,
+        *,
+        directory_ids: Optional[Sequence[UUID]] = None,
+        contact_ids: Optional[Sequence[UUID]] = None,
+    ) -> Dict[str, int]:
+        """Assign contacts to ``agent_id`` from directories and/or explicit contact ids.
+
+        ``directory_ids`` are expanded to their ACTIVE contact ids via
+        ``ContactService.list_contact_ids_in_directories`` (the pinned shared helper),
+        then unioned with ``contact_ids``. Existing ``agent_contacts`` rows are skipped
+        (idempotent — unique ``(agent_id, contact_id)``). There is **no scheduling gate**.
+
+        Returns ``{"assigned": n, "skipped": m}``.
+        """
+        agent = self._get_agent_or_404(agent_id)
+
+        target_ids: set[UUID] = set(contact_ids or [])
+
+        directory_ids = list(directory_ids or [])
+        if directory_ids:
+            # ContactService owns directory→contact expansion; reuse its pinned helper so
+            # a whole-directory pick becomes exactly its active contacts (empty directory
+            # → no ids → no-op).
+            from core.services.contacts.contact_service import ContactService
+
+            contact_service = ContactService(self.db, user_id=self._user_id, org_id=self._org_id)
+            expanded = contact_service.list_contact_ids_in_directories(directory_ids)
+            target_ids.update(expanded)
+
+        if not target_ids:
+            logger.info(
+                f"{_LOG_TAG} assign no-op agent_id={agent_id} "
+                f"directories={len(directory_ids)} — no contacts to assign"
+            )
+            return {"assigned": 0, "skipped": 0}
+
+        # Only assign contacts that actually belong to this org (guards against ids from
+        # another tenant sneaking in via the explicit contact_ids list).
+        valid_ids = {
+            row[0]
+            for row in self.query(Contact)
+            .filter(Contact.id.in_(target_ids), Contact.deleted_at.is_(None))
+            .with_entities(Contact.id)
+            .all()
+        }
+
+        already_assigned = {
+            row[0]
+            for row in self.db.query(AgentContact.contact_id)
+            .filter(
+                AgentContact.agent_id == agent.id,
+                AgentContact.contact_id.in_(valid_ids),
+            )
+            .all()
+        } if valid_ids else set()
+
+        to_assign = valid_ids - already_assigned
+        skipped = len(target_ids) - len(to_assign)
+
+        assigned = 0
+        for contact_id in to_assign:
+            try:
+                with self.db.begin_nested():
+                    self.db.add(
+                        AgentContact(
+                            organization_id=self.org_id,
+                            agent_id=agent.id,
+                            contact_id=contact_id,
+                            created_by_user_id=self.user_id,
+                        )
+                    )
+                assigned += 1
+            except IntegrityError:
+                # Expected control-flow: a concurrent insert already created this
+                # (agent_id, contact_id) pair; the unique constraint makes assign
+                # idempotent, so skip rather than error.
+                logger.debug(
+                    f"{_LOG_TAG} race inserting agent_contact "
+                    f"agent_id={agent.id} contact_id={contact_id}; skipping"
+                )
+                skipped += 1
+
+        self.db.commit()
+        logger.info(
+            f"{_LOG_TAG} assigned agent_id={agent.id} "
+            f"assigned={assigned} skipped={skipped}"
+        )
+        return {"assigned": assigned, "skipped": skipped}
+
+    # ------------------------------------------------------------------ list
+    def list_agent_contacts(
+        self,
+        agent_id: UUID,
+        *,
+        page_no: int = 1,
+        page_size: int = 20,
+        search: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        sort_order: str = "desc",
+    ) -> Dict[str, Any]:
+        """Paginated list of contacts assigned to ``agent_id`` (joins contact details).
+
+        Org-scoped and soft-delete aware. Searchable by contact name / phone; sortable by
+        ``name``, ``phone_number``, or assignment ``created_at``.
+        """
+        agent = self._get_agent_or_404(agent_id)
+
+        query = (
+            self.query(AgentContact)
+            .join(Contact, Contact.id == AgentContact.contact_id)
+            .filter(
+                AgentContact.agent_id == agent.id,
+                Contact.deleted_at.is_(None),
+            )
+            .with_entities(AgentContact, Contact)
+        )
+
+        rows, total = apply_search_sort_pagination(
+            query,
+            search=search,
+            search_fields=[Contact.name, Contact.phone_number],
+            sort_by=sort_by,
+            sort_order=sort_order,
+            sort_map={
+                "name": Contact.name,
+                "phone_number": Contact.phone_number,
+                "created_at": AgentContact.created_at,
+            },
+            page_no=page_no,
+            page_size=page_size,
+        )
+
+        data = [
+            {
+                **contact.to_dict(),
+                "assignment_id": str(assignment.id),
+                "assigned_at": assignment.created_at.isoformat() if assignment.created_at else None,
+            }
+            for assignment, contact in rows
+        ]
+        return {
+            "data": data,
+            "total": total,
+            "page_no": page_no,
+            "page_size": page_size,
+        }
+
+    # ---------------------------------------------------------------- unassign
+    def unassign_contacts_from_agent(
+        self, agent_id: UUID, contact_ids: Sequence[UUID]
+    ) -> Dict[str, int]:
+        """Remove the ``agent_contacts`` rows linking ``agent_id`` to ``contact_ids``.
+
+        Deletes only the join rows — the contacts and their directory are untouched.
+        Returns ``{"unassigned": n}`` (rows actually removed).
+        """
+        agent = self._get_agent_or_404(agent_id)
+
+        ids = list(contact_ids or [])
+        if not ids:
+            return {"unassigned": 0}
+
+        removed = (
+            self.query(AgentContact)
+            .filter(
+                AgentContact.agent_id == agent.id,
+                AgentContact.contact_id.in_(ids),
+            )
+            .delete(synchronize_session=False)
+        )
+        self.db.commit()
+        logger.info(
+            f"{_LOG_TAG} unassigned agent_id={agent.id} removed={removed}"
+        )
+        return {"unassigned": removed}

--- a/core/services/contacts/contact_datasource_service.py
+++ b/core/services/contacts/contact_datasource_service.py
@@ -1,0 +1,148 @@
+"""ContactDatasourceService — org-scoped CRUD over ``datasources`` (CSV-only at launch).
+
+A directory auto-provisions exactly one CSV datasource on create; admins can add more
+later. ``ensure_csv_datasource`` is the shared idempotent accessor used by the sync
+pipeline to resolve (or lazily create) a directory's CSV datasource without duplicating.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from fastapi import HTTPException
+from loguru import logger
+
+from core.models.datasource import Datasource
+from core.services.base import BaseService
+from core.services.common.list_query import apply_search_sort_pagination
+
+
+class ContactDatasourceService(BaseService):
+    """Manage the datasources that feed contacts into directories (CSV type only)."""
+
+    def create_datasource(
+        self,
+        *,
+        name: str,
+        directory_id: Optional[UUID] = None,
+        type: str = "csv",
+        config: Optional[Dict[str, Any]] = None,
+    ) -> Datasource:
+        """Create a datasource (CSV only at launch). ``directory_id`` may be null for a
+        future org-level (REST) datasource."""
+        if type != "csv":
+            raise HTTPException(status_code=400, detail="Only 'csv' datasources are supported.")
+        if directory_id is not None:
+            # Validate the directory is org-owned before binding to it (no IDOR).
+            from core.models.contact_directory import ContactDirectory
+
+            self.get_or_404(ContactDirectory, directory_id, name="Directory")
+
+        datasource = Datasource(
+            organization_id=self.org_id,
+            directory_id=directory_id,
+            name=name,
+            type=type,
+            config=config or {},
+            created_by_user_id=self.user_id,
+            is_active=True,
+        )
+        self.db.add(datasource)
+        self.db.commit()
+        self.db.refresh(datasource)
+        logger.info(
+            "[contact-datasource] created id={} name={} directory_id={}",
+            datasource.id, name, directory_id,
+        )
+        return datasource
+
+    def ensure_csv_datasource(self, directory_id: UUID) -> Datasource:
+        """Return the directory's existing CSV datasource, or create one if absent.
+
+        Idempotent — safe to call from the sync pipeline on every run. Validates the
+        directory is org-owned first (no IDOR). Does NOT re-create when one already
+        exists (returns the first active CSV datasource bound to the directory).
+
+        Does NOT commit — the new row is flushed so it gets an id, but the caller owns
+        the transaction (so directory-create and sync-create stay atomic).
+        """
+        from core.models.contact_directory import ContactDirectory
+
+        self.get_or_404(ContactDirectory, directory_id, name="Directory")
+
+        existing = (
+            self.query(Datasource)
+            .filter(
+                Datasource.directory_id == directory_id,
+                Datasource.type == "csv",
+                Datasource.deleted_at.is_(None),
+            )
+            .order_by(Datasource.created_at.asc())
+            .first()
+        )
+        if existing is not None:
+            return existing
+
+        datasource = Datasource(
+            organization_id=self.org_id,
+            directory_id=directory_id,
+            name="CSV Import",
+            type="csv",
+            config={},
+            created_by_user_id=self.user_id,
+            is_active=True,
+        )
+        self.db.add(datasource)
+        self.db.flush()  # assign the id without committing — the caller owns the txn
+        logger.info(
+            "[contact-datasource] auto-provisioned CSV datasource id={} directory_id={}",
+            datasource.id, directory_id,
+        )
+        return datasource
+
+    def list_datasources(
+        self,
+        *,
+        directory_id: Optional[UUID] = None,
+        page_no: int = 1,
+        page_size: int = 20,
+        search: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        sort_order: str = "desc",
+    ) -> Dict[str, Any]:
+        """List org datasources (optionally scoped to one directory), paginated."""
+        query = self.query(Datasource).filter(Datasource.deleted_at.is_(None))
+        if directory_id is not None:
+            query = query.filter(Datasource.directory_id == directory_id)
+
+        rows, total = apply_search_sort_pagination(
+            query,
+            search=search,
+            search_fields=[Datasource.name],
+            sort_by=sort_by,
+            sort_order=sort_order,
+            sort_map={
+                "name": Datasource.name,
+                "created_at": Datasource.created_at,
+                "updated_at": Datasource.updated_at,
+            },
+            page_no=page_no,
+            page_size=page_size,
+        )
+        return {
+            "data": [row.to_dict() for row in rows],
+            "total": total,
+            "page_no": page_no,
+            "page_size": page_size,
+        }
+
+    def delete_datasource(self, datasource_id: UUID) -> None:
+        """Soft-delete a datasource (org-scoped)."""
+        from datetime import datetime, timezone
+
+        datasource = self.get_or_404(Datasource, datasource_id, name="Datasource")
+        datasource.deleted_at = datetime.now(timezone.utc)
+        datasource.is_active = False
+        self.db.commit()
+        logger.info("[contact-datasource] deleted id={}", datasource_id)

--- a/core/services/contacts/contact_directory_service.py
+++ b/core/services/contacts/contact_directory_service.py
@@ -1,0 +1,183 @@
+"""ContactDirectoryService — CRUD over ``contact_directories`` plus the atomic
+create-time provisioning of a directory's CSV datasource. Schemas are org-level and
+reusable, so none is auto-created per directory; a directory's ``default_schema_id`` is
+optional and user-selected.
+
+Reuses the shared foundations: ``apply_search_sort_pagination`` (list),
+``BaseService.get_or_404`` (fetch), ``ContactDatasourceService.ensure_csv_datasource``
+(CSV provisioning), and ``directory_delete.*`` (impact summary + hard delete).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from fastapi import HTTPException
+from loguru import logger
+from sqlalchemy import func
+
+from core.models.contact import Contact
+from core.models.contact_directory import ContactDirectory
+from core.models.contact_schema import ContactSchema
+from core.services.base import BaseService
+from core.services.common.list_query import apply_search_sort_pagination
+from core.services.contacts.contact_datasource_service import ContactDatasourceService
+from core.services.contacts.directory_delete import (
+    hard_delete_directory_and_children,
+    summarize_directory_deletion,
+)
+
+
+class ContactDirectoryService(BaseService):
+    """Manage contact directories (the container that owns contacts + a CSV datasource)."""
+
+    def create_directory(
+        self,
+        *,
+        name: str,
+        description: Optional[str] = None,
+        default_schema_id: Optional[UUID] = None,
+    ) -> ContactDirectory:
+        """Create a directory and provision its CSV datasource. Single transaction.
+
+        Schemas are org-level and reusable, so a directory does NOT get an auto-created
+        schema — that would pollute the shared library with one throwaway schema per
+        directory. ``default_schema_id`` is optional: when the caller passes one (chosen
+        by the user), it is validated org-owned and set; otherwise the directory has no
+        default schema until the user assigns one (manual add / sync still work — they
+        just skip field validation while no schema is set).
+        """
+        directory = ContactDirectory(
+            organization_id=self.org_id,
+            name=name,
+            description=description,
+            created_by_user_id=self.user_id,
+            is_active=True,
+        )
+        if default_schema_id is not None:
+            # Validate the schema belongs to this org (no IDOR / cross-org reference).
+            self.get_or_404(ContactSchema, default_schema_id, name="Schema")
+            directory.default_schema_id = default_schema_id
+
+        self.db.add(directory)
+        self.db.flush()  # assign directory.id without committing yet
+
+        self.create_default_datasource(directory)
+
+        self.db.commit()
+        self.db.refresh(directory)
+        logger.info(
+            "[contact-directory] created id={} name={} default_schema_id={}",
+            directory.id, name, directory.default_schema_id,
+        )
+        return directory
+
+    def create_default_datasource(self, directory: ContactDirectory) -> None:
+        """Provision one CSV datasource for ``directory`` (idempotent). Does NOT commit —
+        the caller owns the transaction. No schema is created here (schemas are org-level
+        and user-managed via the schema library)."""
+        datasource_service = ContactDatasourceService(
+            self.db, user_id=self.user_id, org_id=self.org_id
+        )
+        datasource_service.ensure_csv_datasource(directory.id)
+        self.db.flush()
+
+    def list_directories(
+        self,
+        *,
+        page_no: int = 1,
+        page_size: int = 20,
+        search: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        sort_order: str = "desc",
+    ) -> Dict[str, Any]:
+        """List org directories (paginated), each enriched with its ``contact_count``."""
+        query = self.query(ContactDirectory).filter(ContactDirectory.deleted_at.is_(None))
+        rows, total = apply_search_sort_pagination(
+            query,
+            search=search,
+            search_fields=[ContactDirectory.name],
+            sort_by=sort_by,
+            sort_order=sort_order,
+            sort_map={
+                "name": ContactDirectory.name,
+                "created_at": ContactDirectory.created_at,
+                "updated_at": ContactDirectory.updated_at,
+            },
+            page_no=page_no,
+            page_size=page_size,
+        )
+
+        dir_ids = [d.id for d in rows]
+        counts_by_dir: Dict[Any, int] = {}
+        if dir_ids:
+            count_rows = (
+                self.db.query(Contact.directory_id, func.count(Contact.id))
+                .filter(
+                    Contact.organization_id == self.org_id,
+                    Contact.directory_id.in_(dir_ids),
+                    Contact.deleted_at.is_(None),
+                )
+                .group_by(Contact.directory_id)
+                .all()
+            )
+            counts_by_dir = {dir_id: cnt for dir_id, cnt in count_rows}
+
+        data = []
+        for directory in rows:
+            item = directory.to_dict()
+            item["contact_count"] = counts_by_dir.get(directory.id, 0)
+            data.append(item)
+
+        return {
+            "data": data,
+            "total": total,
+            "page_no": page_no,
+            "page_size": page_size,
+        }
+
+    def get_directory(self, directory_id: UUID) -> ContactDirectory:
+        """Fetch a single org-owned directory or raise 404."""
+        return self.get_or_404(ContactDirectory, directory_id, name="Directory")
+
+    def update_directory(
+        self,
+        directory_id: UUID,
+        *,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        is_active: Optional[bool] = None,
+        default_schema_id: Optional[UUID] = None,
+    ) -> ContactDirectory:
+        """Update a directory. ``default_schema_id`` may be re-pointed to any org schema
+        (validated org-owned first — never allow pointing at another org's schema)."""
+        directory = self.get_or_404(ContactDirectory, directory_id, name="Directory")
+
+        if name is not None:
+            directory.name = name
+        if description is not None:
+            directory.description = description
+        if is_active is not None:
+            directory.is_active = is_active
+        if default_schema_id is not None:
+            # Validate the schema belongs to this org (no IDOR / cross-org reference).
+            self.get_or_404(ContactSchema, default_schema_id, name="Schema")
+            directory.default_schema_id = default_schema_id
+
+        directory.updated_at = datetime.now(timezone.utc)
+        self.db.commit()
+        self.db.refresh(directory)
+        logger.info("[contact-directory] updated id={}", directory_id)
+        return directory
+
+    def delete_impact(self, directory_id: UUID) -> Dict[str, Any]:
+        """Summarize the blast radius of deleting ``directory_id`` (for the confirm
+        modal). Reuses ``summarize_directory_deletion``."""
+        return summarize_directory_deletion(self.db, self.org_id, directory_id)
+
+    def delete_directory(self, directory_id: UUID) -> Dict[str, Any]:
+        """Hard-delete the directory and its owned children (FK-safe, single txn).
+        Reuses ``hard_delete_directory_and_children``."""
+        return hard_delete_directory_and_children(self.db, self.org_id, directory_id)

--- a/core/services/contacts/contact_metadata_validation.py
+++ b/core/services/contacts/contact_metadata_validation.py
@@ -1,0 +1,107 @@
+"""Reusable contact-metadata validation — compose a schema's fields into one JSON
+Schema and validate a contact's ``contact_metadata`` against it.
+
+Ported from the old ``ContactFieldDefinitionService`` (now removed): the same logic,
+but operating on a schema's ``SchemaField`` rows instead of org-level field definitions.
+Reused by manual create, multi-add, and per-row sync validation — build the validator
+ONCE (``make_contact_metadata_validator``) and reuse it across many rows.
+
+Only a constrained JSON-Schema subset is honoured from ``validators`` (minLength,
+maxLength, pattern, minimum, maximum) so a user can't inject arbitrary/exploitable
+schema; ``enum`` choices come from ``options``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+
+from jsonschema import Draft7Validator
+
+# Validator keys accepted per underlying JSON-Schema primitive.
+_STRING_VALIDATORS = {"minLength", "maxLength", "pattern"}
+_NUMBER_VALIDATORS = {"minimum", "maximum"}
+
+
+def build_contact_field_json_schema(fields: Sequence) -> Dict[str, Any]:
+    """Compose a schema's ``SchemaField`` rows into one JSON Schema object.
+
+    Each field's ``field_name`` becomes a property keyed by ``type`` (string/number/
+    integer/boolean/enum), carrying its whitelisted validators + optional ``format``.
+    Mandatory fields go into ``required``. Only active (caller-filtered) fields should
+    be passed in.
+    """
+    properties: Dict[str, Any] = {}
+    required: List[str] = []
+    for f in fields:
+        prop: Dict[str, Any] = {}
+        if f.type == "enum":
+            prop["enum"] = [
+                o.get("value") if isinstance(o, dict) else o for o in (f.options or [])
+            ]
+        elif f.type == "boolean":
+            prop["type"] = "boolean"
+        elif f.type == "integer":
+            prop["type"] = "integer"
+        elif f.type == "number":
+            prop["type"] = "number"
+        else:
+            prop["type"] = "string"
+        for k, v in (f.validators or {}).items():
+            if k in _STRING_VALIDATORS or k in _NUMBER_VALIDATORS:
+                prop[k] = v
+        if f.format:
+            prop["format"] = f.format
+        properties[f.field_name] = prop
+        if f.is_mandatory:
+            required.append(f.field_name)
+    schema: Dict[str, Any] = {"type": "object", "properties": properties}
+    if required:
+        schema["required"] = required
+    return schema
+
+
+def make_contact_metadata_validator(
+    fields: Sequence,
+) -> Tuple[Set[str], Optional[Draft7Validator]]:
+    """Build ``(managed_keys, Draft7Validator)`` from a schema's fields.
+
+    Returns ``(set(), None)`` when there are no fields, so callers can cheaply skip
+    validation. Build once and reuse across every row of an import rather than
+    re-composing the schema per row.
+    """
+    if not fields:
+        return set(), None
+    managed = {f.field_name for f in fields}
+    return managed, Draft7Validator(build_contact_field_json_schema(fields))
+
+
+def _is_empty(value: Any) -> bool:
+    """A value counts as "not provided" for required-field enforcement when it is None
+    or a blank/whitespace-only string (e.g. an empty CSV cell). Numbers/booleans —
+    including ``0`` and ``False`` — are real values and never treated as empty."""
+    return value is None or (isinstance(value, str) and value.strip() == "")
+
+
+def validate_contact_metadata(
+    metadata: Optional[Dict[str, Any]],
+    managed: Set[str],
+    validator: Optional[Draft7Validator],
+) -> List[str]:
+    """Validate one metadata dict against a prebuilt validator, returning a list of
+    human-readable error strings (empty = valid).
+
+    Only keys that are ``managed`` (have a field in the schema) are constrained;
+    unmanaged extra keys are allowed through (e.g. surplus CSV columns). Empty values
+    (None / blank string — a blank CSV cell or cleared input) are dropped so a mandatory
+    field that is *present but empty* still fails its ``required`` constraint.
+    """
+    if validator is None:
+        return []
+    subset = {
+        k: v for k, v in (metadata or {}).items() if k in managed and not _is_empty(v)
+    }
+    errors: List[str] = []
+    for err in validator.iter_errors(subset):
+        loc = ".".join(str(p) for p in err.path)
+        errors.append(f"{loc}: {err.message}" if loc else err.message)
+    return errors

--- a/core/services/contacts/contact_schema_service.py
+++ b/core/services/contacts/contact_schema_service.py
@@ -1,0 +1,389 @@
+"""Org-level contact-schema + field CRUD (``ContactSchemaService``).
+
+Replaces the old flat ``ContactFieldDefinitionService``. A ``ContactSchema`` is an
+ORG-LEVEL, reusable contact-shape template that owns a set of ``SchemaField`` rows; it
+carries no ``directory_id`` — a directory *references* one via
+``contact_directories.default_schema_id`` and a sync may pick any org schema. This
+service therefore serves both directories and syncs from one place.
+
+Guards live on the router (writes = admin/owner, reads = member); every method is
+org-scoped through ``BaseService.query`` (no IDOR). Field validation reuses the shared
+``contact_metadata_validation`` helpers rather than duplicating any JSON-Schema logic.
+
+Reference-safety rules (edit/delete of a shared schema):
+- On edit/delete we surface a ``referenced_by`` count (directories whose
+  ``default_schema_id`` points here + syncs whose ``schema_id`` points here) so callers
+  can warn the user that the change is shared.
+- Deleting a schema that is any directory's ``default_schema_id`` is BLOCKED (409) — the
+  caller must repoint those directories first, so we never leave a dangling default.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from fastapi import HTTPException
+from loguru import logger
+
+from core.models.contact_directory import ContactDirectory
+from core.models.contact_schema import ContactSchema
+from core.models.contact_sync import ContactSync
+from core.models.schema_field import SchemaField
+from core.services.base import BaseService
+from core.services.common.list_query import apply_search_sort_pagination
+from core.services.contacts.contact_metadata_validation import (
+    build_contact_field_json_schema,
+)
+
+# Field ``type`` values we accept — anything else is rejected up front so a malformed
+# JSON Schema can never be composed.
+_ALLOWED_FIELD_TYPES = {"string", "number", "integer", "boolean", "enum"}
+# Validator keys accepted per underlying primitive (mirrors contact_metadata_validation).
+_STRING_VALIDATORS = {"minLength", "maxLength", "pattern"}
+_NUMBER_VALIDATORS = {"minimum", "maximum"}
+
+
+class ContactSchemaService(BaseService):
+    """CRUD for org-level ``ContactSchema`` templates and their ``SchemaField`` rows."""
+
+    # --------------------------------------------------------------- schema CRUD
+
+    def create_schema(
+        self,
+        name: str,
+        description: Optional[str] = None,
+        is_active: bool = True,
+    ) -> ContactSchema:
+        """Create an empty org-level schema. Fields are added via ``create_schema_field``."""
+        clean = (name or "").strip()
+        if not clean:
+            raise HTTPException(status_code=400, detail="Schema name is required.")
+        schema = ContactSchema(
+            organization_id=self.org_id,
+            name=clean,
+            description=(description or None),
+            is_active=is_active,
+            created_by_user_id=self.user_id,
+        )
+        self.db.add(schema)
+        self.db.commit()
+        self.db.refresh(schema)
+        logger.info("[contact-schema] created schema id={} name={}", schema.id, clean)
+        return schema
+
+    def list_schemas(
+        self,
+        page_no: int = 1,
+        page_size: int = 20,
+        search: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        sort_order: str = "desc",
+    ) -> Dict[str, Any]:
+        """Paginated list of the org's active (non-soft-deleted) schemas."""
+        q = self.query(ContactSchema).filter(ContactSchema.deleted_at.is_(None))
+        rows, total = apply_search_sort_pagination(
+            q,
+            search=search,
+            search_fields=[ContactSchema.name, ContactSchema.description],
+            sort_by=sort_by,
+            sort_order=sort_order,
+            sort_map={
+                "name": ContactSchema.name,
+                "created_at": ContactSchema.created_at,
+                "updated_at": ContactSchema.updated_at,
+            },
+            page_no=page_no,
+            page_size=page_size,
+        )
+        return {
+            "data": [s.to_dict() for s in rows],
+            "total": total,
+            "page_no": page_no,
+            "page_size": page_size,
+        }
+
+    def get_schema(self, schema_id) -> ContactSchema:
+        """Fetch one org-scoped schema or 404."""
+        return self.get_or_404(ContactSchema, schema_id, name="Schema")
+
+    def get_schema_detail(self, schema_id) -> Dict[str, Any]:
+        """Schema dict enriched with its active fields and a ``referenced_by`` count."""
+        schema = self.get_schema(schema_id)
+        data = schema.to_dict()
+        data["fields"] = [f.to_dict() for f in self._active_fields(schema_id)]
+        data["referenced_by"] = self._referenced_by(schema_id)
+        return data
+
+    def update_schema(
+        self,
+        schema_id,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        is_active: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        """Update schema attributes. Returns the schema dict plus ``referenced_by`` so
+        the caller can warn that the edit is shared across N directories/syncs."""
+        schema = self.get_schema(schema_id)
+        if name is not None:
+            clean = name.strip()
+            if not clean:
+                raise HTTPException(status_code=400, detail="Schema name is required.")
+            schema.name = clean
+        if description is not None:
+            schema.description = description or None
+        if is_active is not None:
+            schema.is_active = is_active
+        self.db.commit()
+        self.db.refresh(schema)
+        referenced_by = self._referenced_by(schema_id)
+        logger.info(
+            "[contact-schema] updated schema id={} referenced_by={}",
+            schema_id,
+            referenced_by,
+        )
+        out = schema.to_dict()
+        out["referenced_by"] = referenced_by
+        return out
+
+    def delete_schema(self, schema_id) -> Dict[str, Any]:
+        """Soft-delete a schema (and its fields). Blocked (409) while any directory uses
+        it as ``default_schema_id`` — the caller must repoint those first so we never
+        leave a dangling default."""
+        schema = self.get_schema(schema_id)
+        referenced_by = self._referenced_by(schema_id)
+        if referenced_by["directories"] > 0:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"Schema is the default for {referenced_by['directories']} "
+                    "directory(ies). Repoint them to another schema before deleting."
+                ),
+            )
+        now = datetime.now(timezone.utc)
+        schema.deleted_at = now
+        schema.is_active = False
+        # Soft-delete the schema's fields too so a re-created schema starts clean.
+        self.query(SchemaField).filter(
+            SchemaField.schema_id == schema_id,
+            SchemaField.deleted_at.is_(None),
+        ).update(
+            {SchemaField.deleted_at: now, SchemaField.is_active: False},
+            synchronize_session=False,
+        )
+        self.db.commit()
+        logger.info(
+            "[contact-schema] deleted schema id={} referenced_by_syncs={}",
+            schema_id,
+            referenced_by["syncs"],
+        )
+        return {"ok": True, "referenced_by": referenced_by}
+
+    # ---------------------------------------------------------------- field CRUD
+
+    def create_schema_field(
+        self,
+        schema_id,
+        field_name: str,
+        type: str = "string",
+        label: Optional[str] = None,
+        format: Optional[str] = None,
+        is_mandatory: bool = False,
+        validators: Optional[Dict[str, Any]] = None,
+        options: Optional[List[Dict[str, Any]]] = None,
+        source_key: Optional[str] = None,
+        display_order: int = 0,
+    ) -> SchemaField:
+        """Add a field to a schema. Validates type/validator/enum guardrails, then
+        composes the JSON Schema once to prove the field is well-formed before commit.
+
+        The ``(schema_id, field_name)`` unique constraint counts soft-deleted rows, so a
+        previously removed field name is REVIVED (re-activated + overwritten) rather than
+        raising a constraint violation.
+        """
+        schema = self.get_schema(schema_id)  # org-scope + existence check
+        name = (field_name or "").strip()
+        if not name:
+            raise HTTPException(status_code=400, detail="field_name is required.")
+        self._validate_field_shape(type, validators, options)
+
+        existing = (
+            self.db.query(SchemaField)
+            .filter(SchemaField.schema_id == schema.id, SchemaField.field_name == name)
+            .first()
+        )
+        if existing is not None and existing.deleted_at is None:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Field '{name}' already exists in this schema.",
+            )
+
+        target = existing if existing is not None else SchemaField(
+            organization_id=self.org_id,
+            schema_id=schema.id,
+            field_name=name,
+        )
+        target.type = type
+        target.label = label
+        target.format = format
+        target.is_mandatory = is_mandatory
+        target.validators = validators or {}
+        target.options = options
+        target.source_key = source_key
+        target.display_order = display_order
+        target.is_active = True
+        target.deleted_at = None
+        if existing is None:
+            self.db.add(target)
+
+        # Compose the full schema once — surfaces any JSON-Schema issue before commit.
+        self._assert_composes(schema.id, replacement=target)
+        self.db.commit()
+        self.db.refresh(target)
+        logger.info(
+            "[contact-schema] created field schema_id={} field={} type={}",
+            schema.id,
+            name,
+            type,
+        )
+        return target
+
+    def update_schema_field(self, field_id, **changes: Any) -> SchemaField:
+        """Update a field's attributes. Re-validates the resulting type/validator/enum
+        combination and re-composes the schema before committing."""
+        field = self.get_or_404(SchemaField, field_id, name="Field")
+        # Resolve the post-update shape for validation.
+        new_type = changes.get("type", field.type)
+        new_validators = changes.get("validators", field.validators)
+        new_options = changes.get("options", field.options)
+        self._validate_field_shape(new_type, new_validators, new_options)
+
+        allowed = {
+            "label",
+            "type",
+            "format",
+            "is_mandatory",
+            "validators",
+            "options",
+            "source_key",
+            "display_order",
+            "is_active",
+        }
+        for key, value in changes.items():
+            if key in allowed:
+                setattr(field, key, value)
+        if changes.get("is_active") is True:
+            field.deleted_at = None
+
+        self._assert_composes(field.schema_id, replacement=field)
+        self.db.commit()
+        self.db.refresh(field)
+        logger.info("[contact-schema] updated field id={}", field_id)
+        return field
+
+    def delete_schema_field(self, field_id) -> Dict[str, Any]:
+        """Soft-delete (disable) a field. Existing contacts keep their metadata and are
+        NOT retro-validated; the field simply stops being enforced going forward."""
+        field = self.get_or_404(SchemaField, field_id, name="Field")
+        field.deleted_at = datetime.now(timezone.utc)
+        field.is_active = False
+        self.db.commit()
+        logger.info(
+            "[contact-schema] deleted field id={} schema_id={}", field_id, field.schema_id
+        )
+        return {"ok": True}
+
+    # ------------------------------------------------------------------ helpers
+
+    def _active_fields(self, schema_id) -> List[SchemaField]:
+        return (
+            self.query(SchemaField)
+            .filter(
+                SchemaField.schema_id == schema_id,
+                SchemaField.is_active.is_(True),
+                SchemaField.deleted_at.is_(None),
+            )
+            .order_by(SchemaField.display_order.asc(), SchemaField.created_at.asc())
+            .all()
+        )
+
+    def _referenced_by(self, schema_id) -> Dict[str, int]:
+        """Count how many directories default to this schema and how many syncs use it."""
+        directories = (
+            self.query(ContactDirectory)
+            .filter(
+                ContactDirectory.default_schema_id == schema_id,
+                ContactDirectory.deleted_at.is_(None),
+            )
+            .count()
+        )
+        syncs = (
+            self.query(ContactSync).filter(ContactSync.schema_id == schema_id).count()
+        )
+        return {"directories": int(directories), "syncs": int(syncs)}
+
+    def _validate_field_shape(
+        self,
+        type: str,
+        validators: Optional[Dict[str, Any]],
+        options: Optional[List[Dict[str, Any]]],
+    ) -> None:
+        """Reject bad ``type``, validators illegal for the type, or an enum without
+        options — before anything is composed or written."""
+        if type not in _ALLOWED_FIELD_TYPES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported field type '{type}'.",
+            )
+        if type == "enum" and not options:
+            raise HTTPException(
+                status_code=400,
+                detail="Enum fields require a non-empty 'options' list.",
+            )
+        if validators:
+            if type in {"string", "enum"}:
+                permitted = _STRING_VALIDATORS
+            else:  # number / integer / boolean
+                permitted = _NUMBER_VALIDATORS
+            illegal = set(validators) - permitted
+            if illegal:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Validator(s) {sorted(illegal)} are not supported for a "
+                        f"'{type}' field."
+                    ),
+                )
+            # A ``pattern`` value is only compiled lazily by jsonschema at contact
+            # write time, so validate it here — otherwise a bad regex is accepted and
+            # later crashes every create/update against this schema with a 500.
+            pattern = validators.get("pattern")
+            if pattern is not None:
+                try:
+                    re.compile(pattern)
+                except re.error as exc:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Invalid 'pattern' validator: {exc}",
+                    ) from exc
+
+    def _assert_composes(self, schema_id, replacement: SchemaField) -> None:
+        """Compose the schema (active fields, with ``replacement`` swapped in) into a
+        JSON Schema to prove it is well-formed. Reuses the shared builder so the exact
+        validation shape matches enforcement at contact create/sync time."""
+        fields = [
+            f for f in self._active_fields(schema_id) if f.id != replacement.id
+        ]
+        if replacement.is_active and replacement.deleted_at is None:
+            fields.append(replacement)
+        try:
+            build_contact_field_json_schema(fields)
+        except Exception:
+            logger.exception(
+                "[contact-schema] failed to compose JSON schema schema_id={}", schema_id
+            )
+            raise HTTPException(
+                status_code=400,
+                detail="Field configuration produces an invalid schema.",
+            )

--- a/core/services/contacts/contact_service.py
+++ b/core/services/contacts/contact_service.py
@@ -1,0 +1,347 @@
+"""Directory-scoped contact service — CRUD + bulk partial multi-add.
+
+Every contact belongs to exactly one ``ContactDirectory``; all reads/writes are both
+org-scoped (via ``self.query``) AND directory-scoped so a caller can never touch another
+organization's — or another directory's — contacts (no IDOR).
+
+Metadata is validated against the *directory's default schema* (a reusable org-level
+``ContactSchema``) using the shared validator in ``contact_metadata_validation``; the
+write itself goes through the shared ``upsert_contact`` helper so the
+``(directory_id, external_id)`` uniqueness rule and ``sync_id`` handling live in one place.
+
+Upload/import (CSV → R2 → Procrastinate) and schema/field CRUD are intentionally NOT here:
+importing moved to the sync service and schema CRUD moved to the schema service.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from uuid import UUID, uuid4
+
+from fastapi import HTTPException
+from loguru import logger
+
+from core.models.contact import Contact
+from core.models.contact_directory import ContactDirectory
+from core.models.schema_field import SchemaField
+from core.services.base import BaseService
+from core.services.common.list_query import apply_search_sort_pagination
+from core.services.contacts.contact_metadata_validation import (
+    make_contact_metadata_validator,
+    validate_contact_metadata,
+)
+from core.services.contacts.contact_upsert import upsert_contact
+
+
+class ContactService(BaseService):
+    """Directory-scoped CRUD for ``Contact`` rows."""
+
+    # Cap a single multi-add so one request can't create unbounded rows in one commit.
+    MAX_CREATE_ROWS = 1_000
+
+    # --------------------------------------------------------------- directory
+
+    def _get_directory(self, directory_id: UUID) -> ContactDirectory:
+        """Fetch an org-owned directory or 404 (shared IDOR guard for every
+        directory-scoped operation)."""
+        return self.get_or_404(ContactDirectory, directory_id, name="Directory")
+
+    def _metadata_validator(self, directory: ContactDirectory):
+        """Build the ``(managed_keys, validator)`` pair from the directory's default
+        schema, or ``(set(), None)`` when the directory has no default schema (so
+        contacts still work before any schema is attached).
+
+        Only the schema's ACTIVE, non-deleted fields are used.
+        """
+        if not directory.default_schema_id:
+            return set(), None
+        fields = (
+            self.query(SchemaField)
+            .filter(
+                SchemaField.schema_id == directory.default_schema_id,
+                SchemaField.deleted_at.is_(None),
+                SchemaField.is_active.is_(True),
+            )
+            .all()
+        )
+        return make_contact_metadata_validator(fields)
+
+    # -------------------------------------------------------------------- read
+
+    def list_contacts(
+        self,
+        directory_id: UUID,
+        page_no: int = 1,
+        page_size: int = 20,
+        search: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        sort_order: str = "desc",
+    ) -> Dict[str, Any]:
+        """List the active contacts in ``directory_id`` (org- + directory-scoped)."""
+        self._get_directory(directory_id)
+        q = self.query(Contact).filter(
+            Contact.directory_id == directory_id,
+            Contact.deleted_at.is_(None),
+        )
+        rows, total = apply_search_sort_pagination(
+            q,
+            search=search,
+            search_fields=[Contact.name, Contact.external_id, Contact.phone_number],
+            sort_by=sort_by,
+            sort_order=sort_order,
+            sort_map={
+                "created_at": Contact.created_at,
+                "name": Contact.name,
+                "updated_at": Contact.updated_at,
+                "phone_number": Contact.phone_number,
+            },
+            page_no=page_no,
+            page_size=page_size,
+        )
+        return {
+            "data": [c.to_dict() for c in rows],
+            "total": total,
+            "page_no": page_no,
+            "page_size": page_size,
+        }
+
+    def get_contact(self, contact_id: UUID) -> Contact:
+        """Fetch a single org-owned, non-deleted contact or 404."""
+        return self.get_or_404(Contact, contact_id, name="Contact")
+
+    # ------------------------------------------------------------------- write
+
+    def create_contacts(
+        self, directory_id: UUID, rows: List[Dict[str, Any]], *, agent_id: Optional[UUID] = None
+    ) -> Dict[str, Any]:
+        """Bulk-create contacts in ``directory_id`` with PARTIAL success.
+
+        Each row is validated against the directory's default schema; valid rows are
+        saved (upsert on ``(directory_id, external_id)``) and invalid rows are collected.
+        A duplicate ``external_id`` within the same directory upserts the existing row
+        (counted as created output) rather than failing.
+
+        When ``agent_id`` is given, the freshly-created contacts are ALSO assigned to that
+        agent (Agent Contacts flow) via ``AgentContactService`` — kept here so the router
+        stays thin and create+assign is one reusable service call. The response then also
+        carries ``"assigned"``.
+
+        Returns ``{"created": [contact_dict, ...], "failed": [{"index", "errors"}, ...]}``
+        (plus ``"assigned"`` when ``agent_id`` was provided). Valid rows commit even when
+        some rows fail (all-or-nothing is NOT used).
+        """
+        directory = self._get_directory(directory_id)
+        if not rows:
+            raise HTTPException(status_code=400, detail="Provide at least one contact.")
+        if len(rows) > self.MAX_CREATE_ROWS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Too many contacts in one request (max {self.MAX_CREATE_ROWS}).",
+            )
+
+        managed, validator = self._metadata_validator(directory)
+
+        created_by_ext: Dict[str, Contact] = {}
+        failed: List[Dict[str, Any]] = []
+
+        for index, row in enumerate(rows):
+            metadata = row.get("contact_metadata") or {}
+            errors = validate_contact_metadata(metadata, managed, validator)
+            if errors:
+                failed.append({"index": index, "errors": errors})
+                continue
+
+            name = (row.get("name") or "").strip() or None
+            phone_number = (row.get("phone_number") or "").strip() or None
+            # A contact must carry at least one identifying value — never create a
+            # fully-empty row (name + phone both blank).
+            if not name and not phone_number:
+                failed.append(
+                    {"index": index, "errors": ["A contact needs at least a name or phone number."]}
+                )
+                continue
+            external_id = (
+                (row.get("external_id") or "").strip()
+                or (phone_number or "")
+                or f"manual-{uuid4().hex[:16]}"
+            )
+            parsed = {
+                "external_id": external_id,
+                "name": name,
+                "phone_number": phone_number,
+                "contact_metadata": metadata,
+            }
+            contact, _action = upsert_contact(
+                self.db,
+                directory_id,
+                parsed,
+                organization_id=self.org_id,
+                created_by_user_id=self.user_id,
+            )
+            created_by_ext[external_id] = contact
+
+        created = list(created_by_ext.values())
+
+        if created:
+            try:
+                self.db.commit()
+                for c in created:
+                    self.db.refresh(c)
+            except Exception:
+                logger.exception(
+                    "[contacts] multi-add commit failed directory_id={}", directory_id
+                )
+                self.db.rollback()
+                raise
+
+        logger.info(
+            "[contacts] multi-add directory_id={} created={} failed={}",
+            directory_id,
+            len(created),
+            len(failed),
+        )
+        result: Dict[str, Any] = {"created": [c.to_dict() for c in created], "failed": failed}
+
+        # Optionally assign the freshly-created contacts to an agent (Agent Contacts flow).
+        # Done in the service so the router stays thin and create+assign is one call.
+        if agent_id and created:
+            try:
+                assignment = self._assign_created_contacts_to_agent(agent_id, [c.id for c in created])
+                result["assigned"] = assignment.get("assigned", 0)
+            except Exception:
+                logger.exception(
+                    "[contacts] created contacts but agent-assign failed agent_id={} directory_id={}",
+                    agent_id, directory_id,
+                )
+                result["assigned"] = 0
+                result["assign_failed"] = True
+
+        return result
+
+    def _assign_created_contacts_to_agent(
+        self, agent_id: UUID, contact_ids: List[UUID]
+    ) -> Dict[str, Any]:
+        """Assign the given contacts to ``agent_id`` (idempotent), reusing
+        ``AgentContactService.assign_contacts_to_agent``. Imported locally to avoid a
+        service-layer import cycle."""
+        from core.services.contacts.agent_contact_service import AgentContactService
+
+        assignment = AgentContactService(
+            self.db, user_id=self.user_id, org_id=self.org_id
+        ).assign_contacts_to_agent(agent_id, contact_ids=contact_ids)
+        logger.info(
+            "[contacts] created contacts assigned to agent agent_id={} assigned={}",
+            agent_id,
+            assignment.get("assigned"),
+        )
+        return assignment
+
+    def update_contact(
+        self,
+        contact_id: UUID,
+        name: Optional[str] = None,
+        phone_number: Optional[str] = None,
+        contact_metadata: Optional[Dict[str, Any]] = None,
+    ) -> Contact:
+        """Update a single org-owned contact; validates metadata against its directory's
+        default schema when metadata is provided."""
+        contact = self.get_contact(contact_id)
+        if contact_metadata is not None:
+            directory = self._get_directory(contact.directory_id)
+            managed, validator = self._metadata_validator(directory)
+            errors = validate_contact_metadata(contact_metadata, managed, validator)
+            if errors:
+                raise HTTPException(status_code=400, detail="; ".join(errors))
+            contact.contact_metadata = contact_metadata
+        # Preserve the create-time invariant: a contact must keep at least one of
+        # name / phone_number, otherwise it becomes an identity-less, un-dialable row.
+        # Validate the resulting identity BEFORE mutating so a rejected update leaves
+        # the row untouched.
+        new_name = (name or None) if name is not None else contact.name
+        new_phone = (phone_number or None) if phone_number is not None else contact.phone_number
+        if not new_name and not new_phone:
+            raise HTTPException(
+                status_code=400,
+                detail="A contact needs at least a name or phone number.",
+            )
+        if name is not None:
+            contact.name = new_name
+        if phone_number is not None:
+            contact.phone_number = new_phone
+        try:
+            self.db.commit()
+            self.db.refresh(contact)
+        except Exception:
+            logger.exception("[contacts] update failed contact_id={}", contact_id)
+            self.db.rollback()
+            raise
+        return contact
+
+    def delete_contact(self, contact_id: UUID) -> None:
+        """Soft-delete a single org-owned contact."""
+        contact = self.get_contact(contact_id)
+        contact.deleted_at = datetime.now(timezone.utc)
+        contact.is_active = False
+        try:
+            self.db.commit()
+        except Exception:
+            logger.exception("[contacts] delete failed contact_id={}", contact_id)
+            self.db.rollback()
+            raise
+
+    def bulk_delete_contacts(
+        self, directory_id: UUID, ids: List[UUID]
+    ) -> Dict[str, Any]:
+        """Soft-delete many contacts within ``directory_id`` (org- + directory-scoped)."""
+        self._get_directory(directory_id)
+        now = datetime.now(timezone.utc)
+        try:
+            deleted = (
+                self.query(Contact)
+                .filter(
+                    Contact.directory_id == directory_id,
+                    Contact.id.in_(ids),
+                    Contact.deleted_at.is_(None),
+                )
+                .update(
+                    {Contact.deleted_at: now, Contact.is_active: False},
+                    synchronize_session=False,
+                )
+            )
+            self.db.commit()
+        except Exception:
+            logger.exception(
+                "[contacts] bulk delete failed directory_id={}", directory_id
+            )
+            self.db.rollback()
+            raise
+        logger.info(
+            "[contacts] bulk delete directory_id={} deleted={}", directory_id, int(deleted)
+        )
+        return {"deleted": int(deleted)}
+
+    # ------------------------------------------------------------- shared helper
+
+    def list_contact_ids_in_directories(
+        self, directory_ids: List[UUID]
+    ) -> List[UUID]:
+        """Return the active (non-deleted) contact ids across ``directory_ids``.
+
+        REUSABLE shared helper — used to expand a whole-directory selection into its
+        contacts (e.g. agent assignment) without materialising full rows. Org-scoped, so
+        a directory id from another org contributes nothing. Returns ``[]`` for an empty
+        input.
+        """
+        if not directory_ids:
+            return []
+        rows = (
+            self.query(Contact)
+            .filter(
+                Contact.directory_id.in_(directory_ids),
+                Contact.deleted_at.is_(None),
+            )
+            .with_entities(Contact.id)
+            .all()
+        )
+        return [r[0] for r in rows]

--- a/core/services/contacts/contact_sync_service.py
+++ b/core/services/contacts/contact_sync_service.py
@@ -1,0 +1,488 @@
+"""ContactSyncService — the datasource-driven import pipeline into a directory.
+
+A ``ContactSync`` is one run of: resolve the directory's CSV datasource → store the
+uploaded file in R2 (as an ``Upload`` row, ``purpose="contact_import"``) → insert a
+pending ``ContactSync`` → enqueue a Procrastinate job. The worker then executes
+``run_contact_sync``:
+
+    load sync → mark processing → get source → per row: map + validate
+      → valid rows upsert (partial success; invalid rows collected in ``row_errors`` and
+        SKIPPED) → optional agent auto-assign → write counts + status.
+
+Everything is org-scoped via ``BaseService.query`` (no IDOR). The run is **idempotent**
+on redelivery: ``upsert_contact`` keys on ``(directory_id, external_id)`` and a completed
+sync short-circuits, so a re-delivered job converges to the same result rather than
+duplicating contacts.
+
+Reuse map: ``get_contact_source`` (datasource → parser), ``map_source_row_to_contact``
+(schema mapping), ``make_contact_metadata_validator`` / ``validate_contact_metadata``
+(per-row validation), ``upsert_contact`` (the single directory-scoped write-site),
+``ContactDatasourceService.ensure_csv_datasource`` (pinned), ``AgentContactService.
+assign_contacts_to_agent`` (pinned auto-assign).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from uuid import UUID, uuid4
+
+from fastapi import HTTPException
+from loguru import logger
+
+from core.models.contact_directory import ContactDirectory
+from core.models.contact_sync import ContactSync
+from core.models.datasource import Datasource
+from core.models.schema_field import SchemaField
+from core.models.upload import Upload
+from core.services.base import BaseService
+from core.services.common.list_query import apply_search_sort_pagination
+from core.services.contact_ingestion import get_contact_source
+from core.services.contact_ingestion.contact_mapping import map_source_row_to_contact
+from core.services.contacts.contact_metadata_validation import (
+    make_contact_metadata_validator,
+    validate_contact_metadata,
+)
+from core.services.contacts.contact_upsert import upsert_contact
+from core.services.r2_storage_service import R2StorageService
+from shared.config import settings
+
+_LOG_TAG = "[contact-sync]"
+
+
+class ContactSyncService(BaseService):
+    """Create and run datasource-driven contact syncs into a directory."""
+
+    # Cap a single sync so one huge file can't create unbounded rows in one job.
+    MAX_SYNC_ROWS = 50_000
+
+    # ------------------------------------------------------------------ create
+
+    def create_contact_sync(
+        self,
+        directory_id: UUID,
+        schema_id: UUID,
+        agent_id: Optional[UUID] = None,
+        file=None,
+    ) -> ContactSync:
+        """Resolve the directory's CSV datasource, store the upload, insert a pending
+        ``ContactSync`` and enqueue its Procrastinate job.
+
+        Args:
+            directory_id: the org-owned directory to import into.
+            schema_id: the org-level ``ContactSchema`` whose fields drive the mapping.
+            agent_id: optional agent to auto-assign the imported contacts to on success.
+            file: a ``fastapi.UploadFile``-like object (``.file``, ``.filename``,
+                ``.content_type``) carrying the CSV to import.
+
+        The upload is stored in R2 with its own ``Upload`` row; on any failure after the
+        blob lands, the orphan blob is best-effort deleted so R2 is not littered.
+        """
+        directory = self.get_or_404(ContactDirectory, directory_id, name="Directory")
+        # Validate the schema is an org-owned, live schema (no IDOR / dangling ref).
+        from core.models.contact_schema import ContactSchema
+
+        self.get_or_404(ContactSchema, schema_id, name="Schema")
+        if agent_id is not None:
+            from core.models.agent import Agent
+
+            self.get_or_404(Agent, agent_id, name="Agent")
+
+        # Resolve (or lazily create) the directory's CSV datasource via the pinned
+        # ContactDatasourceService interface.
+        from core.services.contacts.contact_datasource_service import ContactDatasourceService
+
+        datasource = ContactDatasourceService(
+            self.db, user_id=self.user_id, org_id=self.org_id
+        ).ensure_csv_datasource(directory_id)
+
+        upload = self._store_contact_upload(file) if file is not None else None
+
+        try:
+            sync = ContactSync(
+                organization_id=self.org_id,
+                directory_id=directory.id,
+                datasource_id=datasource.id,
+                schema_id=schema_id,
+                upload_id=upload.id if upload is not None else None,
+                agent_id=agent_id,
+                status="pending",
+                counts={},
+                row_errors=[],
+                created_by_user_id=self.user_id,
+            )
+            self.db.add(sync)
+            self.db.commit()
+            self.db.refresh(sync)
+        except Exception:
+            logger.exception(
+                f"{_LOG_TAG} failed to create sync directory_id={directory_id}"
+            )
+            self.db.rollback()
+            raise
+
+        from core.services.ingestion_queue import enqueue_contact_sync_sync
+
+        try:
+            enqueue_contact_sync_sync(sync.id, self.org_id)
+        except Exception:
+            logger.exception(
+                f"{_LOG_TAG} failed to enqueue sync sync_id={sync.id}; marking failed"
+            )
+            sync.status = "failed"
+            sync.error = "Failed to enqueue import job."
+            self.db.commit()
+            raise
+
+        logger.info(
+            f"{_LOG_TAG} created sync_id={sync.id} directory_id={directory_id} "
+            f"schema_id={schema_id} agent_id={agent_id} upload_id="
+            f"{upload.id if upload else None}"
+        )
+        return sync
+
+    def _store_contact_upload(self, file) -> Upload:
+        """Stream an uploaded CSV to R2 and create its ``Upload`` row.
+
+        Stored under a ``contacts/`` prefix and tagged ``purpose="contact_import"``.
+        Implemented here (not on the deleted ``ContactService.create_upload``) so the
+        sync flow owns its file storage. On a DB failure after the blob lands, the orphan
+        blob is best-effort deleted.
+        """
+        fileobj = file.file
+        fileobj.seek(0, 2)
+        size_bytes = fileobj.tell()
+        fileobj.seek(0)
+        if not size_bytes:
+            raise HTTPException(status_code=400, detail="Empty file")
+
+        file_name = getattr(file, "filename", None) or "contacts.csv"
+        content_type = getattr(file, "content_type", None) or "text/csv"
+
+        org_id = self.org_id
+        object_key = f"contacts/{org_id}/{uuid4()}/{file_name}"
+        r2 = R2StorageService()
+        r2.upload_fileobj(fileobj, object_key, content_type=content_type)
+
+        try:
+            upload = Upload(
+                organization_id=org_id,
+                container_name=settings.R2_BUCKET_NAME,
+                file_path=object_key,
+                file_name=file_name,
+                file_type=content_type,
+                size_bytes=size_bytes,
+                purpose="contact_import",
+                status="ready",
+                meta_data={},
+                created_by_user_id=self.user_id,
+                is_active=True,
+            )
+            self.db.add(upload)
+            self.db.commit()
+            self.db.refresh(upload)
+            return upload
+        except Exception:
+            logger.exception(
+                f"{_LOG_TAG} upload DB write failed; cleaning up R2 blob key={object_key}"
+            )
+            self.db.rollback()
+            try:
+                r2.delete_file(object_key)
+            except Exception:
+                logger.exception(
+                    f"{_LOG_TAG} best-effort R2 cleanup failed key={object_key}"
+                )
+            raise
+
+    # --------------------------------------------------------------------- run
+
+    def run_contact_sync(self, sync: ContactSync) -> ContactSync:
+        """Execute a sync: source → per-row map+validate → upsert valid rows → optional
+        auto-assign → write counts + status.
+
+        Partial success: invalid rows are collected into ``row_errors`` and skipped; the
+        run still completes (status ``completed``). Hard failures (missing datasource,
+        unreadable file, all-rows-invalid) set status ``failed`` with ``error`` and import
+        nothing. Idempotent — a run already in a terminal state is a no-op on redelivery.
+
+        C-3: inside the run, the directory is re-checked (still exists / not soft-deleted)
+        before upserting; if it was hard-deleted mid-run the sync aborts cleanly as
+        ``failed`` (error="directory deleted") without upserting against the RESTRICT FK.
+        """
+        # Redelivery / already-run guard: never re-import a terminal sync.
+        if sync.status in ("completed", "failed"):
+            logger.info(
+                f"{_LOG_TAG} sync_id={sync.id} already {sync.status}; skipping re-run"
+            )
+            return sync
+
+        sync.status = "processing"
+        self.db.commit()
+        logger.info(f"{_LOG_TAG} sync_id={sync.id} processing")
+
+        # C-3: re-check the directory still exists (not soft-deleted / torn down) before
+        # doing any work. If it was hard-deleted mid-run, abort cleanly without upserting.
+        directory = None
+        if sync.directory_id is not None:
+            directory = (
+                self.query(ContactDirectory)
+                .filter(
+                    ContactDirectory.id == sync.directory_id,
+                    ContactDirectory.deleted_at.is_(None),
+                )
+                .first()
+            )
+        if directory is None:
+            logger.warning(
+                f"{_LOG_TAG} sync_id={sync.id} directory gone mid-run; aborting"
+            )
+            return self._fail(sync, "directory deleted")
+
+        try:
+            datasource, schema_fields, blob = self._load_run_inputs(sync)
+        except HTTPException:
+            raise
+        except Exception as exc:
+            logger.exception(f"{_LOG_TAG} sync_id={sync.id} failed loading inputs")
+            return self._fail(sync, str(exc)[:500])
+
+        created = 0
+        updated = 0
+        skipped = 0
+        failed = 0
+        row_errors: List[Dict[str, Any]] = []
+        imported_contact_ids: List[UUID] = []
+        parsed_any = False
+
+        try:
+            managed, validator = make_contact_metadata_validator(schema_fields)
+            source = get_contact_source(datasource)
+            for i, parsed in enumerate(source.parse(blob)):
+                parsed_any = True
+                if i >= self.MAX_SYNC_ROWS:
+                    row_errors.append(
+                        {"row": i, "field": None, "message": f"Import truncated at {self.MAX_SYNC_ROWS} rows."}
+                    )
+                    logger.warning(
+                        f"{_LOG_TAG} sync_id={sync.id} truncated at {self.MAX_SYNC_ROWS} rows"
+                    )
+                    break
+
+                raw = self._parsed_to_raw(parsed)
+                mapped = map_source_row_to_contact(raw, schema_fields) if schema_fields else self._identity_map(parsed)
+
+                # The schema maps metadata (and MAY override name/phone/external_id); the
+                # base contact identity always comes from the parsed source row. Backfill
+                # anything the schema didn't explicitly map, so a schema that only defines
+                # extra fields (e.g. city) never drops the synthesized external_id/name/phone.
+                mapped["external_id"] = mapped.get("external_id") or parsed.external_id
+                mapped["name"] = mapped.get("name") or parsed.name
+                mapped["phone_number"] = mapped.get("phone_number") or parsed.phone_number
+
+                # The per-row schedule override lives in parsed metadata, but
+                # map_source_row_to_contact keeps only schema-mapped keys — so carry
+                # scheduled_at over explicitly (the outbound dialer reads
+                # contact_metadata["scheduled_at"]). A schema-mapped value wins.
+                parsed_scheduled_at = (parsed.metadata or {}).get("scheduled_at")
+                if parsed_scheduled_at:
+                    meta = mapped.setdefault("contact_metadata", {})
+                    meta.setdefault("scheduled_at", parsed_scheduled_at)
+
+                # Each error entry carries the row's identity (name/phone) so the report
+                # shows WHICH contact failed, not just a row number.
+                def _err(field, message):
+                    return {
+                        "row": i,
+                        "field": field,
+                        "message": message,
+                        "name": mapped.get("name"),
+                        "phone_number": mapped.get("phone_number"),
+                    }
+
+                if not mapped.get("external_id"):
+                    skipped += 1
+                    row_errors.append(_err("external_id", "Row has no resolvable external_id."))
+                    continue
+
+                errors = validate_contact_metadata(mapped.get("contact_metadata"), managed, validator)
+                if errors:
+                    skipped += 1
+                    for msg in errors:
+                        row_errors.append(_err(None, msg))
+                    continue
+
+                contact, action = upsert_contact(
+                    self.db,
+                    sync.directory_id,
+                    mapped,
+                    organization_id=self.org_id,
+                    sync_id=sync.id,
+                    created_by_user_id=sync.created_by_user_id,
+                )
+                self.db.flush()
+                imported_contact_ids.append(contact.id)
+                if action == "created":
+                    created += 1
+                else:
+                    updated += 1
+
+            self.db.commit()
+        except Exception as exc:
+            logger.exception(f"{_LOG_TAG} sync_id={sync.id} parse/upsert failed")
+            self.db.rollback()
+            return self._fail(sync, str(exc)[:500])
+
+        # A file that parsed to zero usable rows (all invalid, or empty) is a hard failure.
+        if created == 0 and updated == 0:
+            reason = (
+                "All rows failed validation." if (parsed_any or row_errors)
+                else "No importable rows found in the file."
+            )
+            failed_sync = self._fail(sync, reason)
+            failed_sync.counts = {"created": 0, "updated": 0, "skipped": skipped, "failed": failed}
+            failed_sync.row_errors = row_errors
+            self.db.commit()
+            logger.info(
+                f"{_LOG_TAG} sync_id={sync.id} failed (no rows imported) failed={failed}"
+            )
+            return failed_sync
+
+        # Optional auto-assign of the imported contacts to an agent (idempotent).
+        if sync.agent_id is not None and imported_contact_ids:
+            try:
+                from core.services.contacts.agent_contact_service import AgentContactService
+
+                AgentContactService(
+                    self.db, user_id=self.user_id, org_id=self.org_id
+                ).assign_contacts_to_agent(sync.agent_id, contact_ids=imported_contact_ids)
+            except Exception:
+                logger.exception(
+                    f"{_LOG_TAG} sync_id={sync.id} auto-assign to agent_id="
+                    f"{sync.agent_id} failed"
+                )
+                # Auto-assign is a best-effort side effect; the import itself succeeded, so
+                # don't roll the whole sync back — surface it and continue to completed.
+
+        sync.status = "completed"
+        sync.counts = {"created": created, "updated": updated, "skipped": skipped, "failed": failed}
+        sync.row_errors = row_errors
+        sync.error = None
+        self.db.commit()
+        self.db.refresh(sync)
+        logger.info(
+            f"{_LOG_TAG} sync_id={sync.id} completed counts={sync.counts} "
+            f"assigned={len(imported_contact_ids) if sync.agent_id else 0}"
+        )
+        return sync
+
+    # ---------------------------------------------------------------- run helpers
+
+    def _load_run_inputs(self, sync: ContactSync):
+        """Resolve the datasource, active schema fields, and downloaded file blob for a
+        sync. Raises on a hard failure so ``run_contact_sync`` can mark it ``failed``."""
+        if sync.datasource_id is None:
+            raise ValueError("Sync has no datasource.")
+        datasource = (
+            self.query(Datasource)
+            .filter(Datasource.id == sync.datasource_id)
+            .first()
+        )
+        if datasource is None:
+            raise ValueError("Datasource not found.")
+
+        schema_fields = (
+            self.query(SchemaField)
+            .filter(
+                SchemaField.schema_id == sync.schema_id,
+                SchemaField.deleted_at.is_(None),
+                SchemaField.is_active.is_(True),
+            )
+            .all()
+        )
+
+        if sync.upload_id is None:
+            raise ValueError("Sync has no uploaded file.")
+        upload = (
+            self.query(Upload).filter(Upload.id == sync.upload_id).first()
+        )
+        if upload is None or not upload.file_path:
+            raise ValueError("Sync upload not found.")
+        blob = R2StorageService().download_file(upload.file_path)
+        return datasource, schema_fields, blob
+
+    @staticmethod
+    def _parsed_to_raw(parsed) -> Dict[str, Any]:
+        """Flatten a ``ParsedContact`` into a raw ``header -> value`` dict for the schema
+        mapper (reserved fields promoted, metadata columns merged)."""
+        raw: Dict[str, Any] = dict(parsed.metadata or {})
+        if parsed.name is not None:
+            raw["name"] = parsed.name
+        if parsed.phone_number is not None:
+            raw["phone_number"] = parsed.phone_number
+        if parsed.external_id is not None:
+            raw["external_id"] = parsed.external_id
+        return raw
+
+    @staticmethod
+    def _identity_map(parsed) -> Dict[str, Any]:
+        """Fallback mapping when the schema has no fields — take the source as-is."""
+        return {
+            "name": parsed.name,
+            "phone_number": parsed.phone_number,
+            "external_id": parsed.external_id,
+            "contact_metadata": dict(parsed.metadata or {}),
+        }
+
+    def _fail(self, sync: ContactSync, error: str) -> ContactSync:
+        """Mark a sync ``failed`` with an error message and commit."""
+        sync.status = "failed"
+        sync.error = error
+        self.db.commit()
+        self.db.refresh(sync)
+        return sync
+
+    # -------------------------------------------------------------------- read
+
+    def get_contact_sync(self, sync_id: UUID) -> ContactSync:
+        """Fetch an org-owned sync or 404."""
+        sync = self.query(ContactSync).filter(ContactSync.id == sync_id).first()
+        if sync is None:
+            raise HTTPException(status_code=404, detail="Contact sync not found.")
+        return sync
+
+    def list_contact_syncs(
+        self,
+        *,
+        directory_id: Optional[UUID] = None,
+        status: Optional[str] = None,
+        page_no: int = 1,
+        page_size: int = 20,
+        sort_by: Optional[str] = None,
+        sort_order: str = "desc",
+    ) -> Dict[str, Any]:
+        """List org syncs (optionally scoped to one directory and/or status), paginated."""
+        query = self.query(ContactSync)
+        if directory_id is not None:
+            query = query.filter(ContactSync.directory_id == directory_id)
+        if status:
+            query = query.filter(ContactSync.status == status)
+        rows, total = apply_search_sort_pagination(
+            query,
+            sort_by=sort_by,
+            sort_order=sort_order,
+            sort_map={
+                "created_at": ContactSync.created_at,
+                "updated_at": ContactSync.updated_at,
+                "status": ContactSync.status,
+            },
+            page_no=page_no,
+            page_size=page_size,
+        )
+        return {
+            "data": [row.to_dict() for row in rows],
+            "total": total,
+            "page_no": page_no,
+            "page_size": page_size,
+        }
+

--- a/core/services/contacts/contact_upsert.py
+++ b/core/services/contacts/contact_upsert.py
@@ -1,0 +1,78 @@
+"""Reusable contact upsert keyed by ``(directory_id, external_id)``.
+
+``upsert_contact`` inserts a new ``Contact`` or updates the existing one for a directory,
+returning ``(contact, action)`` where ``action`` is ``"created"`` or ``"updated"``. It
+is the single write-site for the directory-scoped uniqueness rule and is shared by manual
+create, multi-add, and the sync pipeline — so ``sync_id`` (and the source-of-truth fields)
+are always written the same way.
+
+It does NOT commit; the caller owns the transaction boundary (a sync commits once at the
+end of a batch; a manual create commits per row).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from core.models.contact import Contact
+
+
+def upsert_contact(
+    db: Session,
+    directory_id: UUID,
+    parsed: Dict[str, Any],
+    *,
+    organization_id: Optional[UUID] = None,
+    sync_id: Optional[UUID] = None,
+    created_by_user_id: Optional[UUID] = None,
+) -> Tuple[Contact, str]:
+    """Insert or update a contact in ``directory_id`` keyed by ``external_id``.
+
+    Args:
+        db: the active session (the caller commits).
+        directory_id: the owning directory.
+        parsed: normalized contact dict — ``external_id`` (required), ``name``,
+            ``phone_number``, ``contact_metadata``.
+        organization_id: org to stamp on new rows (required on insert).
+        sync_id: the sync run that produced this write (set when called from a sync).
+        created_by_user_id: stamped on new rows.
+
+    Returns:
+        ``(contact, "created" | "updated")``. A previously soft-deleted match is revived.
+    """
+    external_id = parsed["external_id"]
+    metadata = parsed.get("contact_metadata") or {}
+
+    existing = (
+        db.query(Contact)
+        .filter(Contact.directory_id == directory_id, Contact.external_id == external_id)
+        .first()
+    )
+    if existing is None:
+        contact = Contact(
+            organization_id=organization_id,
+            directory_id=directory_id,
+            external_id=external_id,
+            name=parsed.get("name"),
+            phone_number=parsed.get("phone_number"),
+            contact_metadata=metadata,
+            sync_id=sync_id,
+            created_by_user_id=created_by_user_id,
+            is_active=True,
+        )
+        db.add(contact)
+        return contact, "created"
+
+    existing.name = parsed.get("name")
+    existing.phone_number = parsed.get("phone_number")
+    existing.contact_metadata = metadata
+    if sync_id is not None:
+        existing.sync_id = sync_id
+    if existing.deleted_at is not None:
+        # Re-importing revives a previously soft-deleted contact.
+        existing.deleted_at = None
+        existing.is_active = True
+    return existing, "updated"

--- a/core/services/contacts/directory_delete.py
+++ b/core/services/contacts/directory_delete.py
@@ -1,0 +1,239 @@
+"""Reusable directory hard-delete helpers.
+
+``summarize_directory_deletion`` counts the blast radius for the confirm modal;
+``hard_delete_directory_and_children`` performs the FK-safe teardown in a single
+transaction. Both are org-scoped (callers pass the resolved ``org_id``) and share the
+same underlying counting query so the modal and the delete never disagree.
+
+Delete order (FK-safe):
+ 1. find the directory's contacts;
+ 2. cancel queued dial jobs for their ``scheduled_calls`` (status='scheduled'), mark
+    them 'canceled', then DELETE those scheduled_calls rows;
+ 3. mark the directory's pending/processing ``contact_syncs`` as 'failed' (C-3 race
+    guard) BEFORE detaching;
+ 4. hard-DELETE agent_contacts for those contacts, then the contacts, then the
+    directory's CSV datasource(s);
+ 5. DETACH contact_syncs (SET NULL directory_id + datasource_id) — kept for audit;
+ 6. KEEP org contact_schemas untouched;
+ 7. DELETE the directory.
+
+Completed ``calls`` history is preserved (scheduled_calls.call_id / calls untouched).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict, List
+from uuid import UUID
+
+from fastapi import HTTPException
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from core.models.agent_contact import AgentContact
+from core.models.contact import Contact
+from core.models.contact_directory import ContactDirectory
+from core.models.contact_sync import ContactSync
+from core.models.datasource import Datasource
+from core.models.scheduled_call import ScheduledCall
+
+
+def _get_owned_directory(db: Session, org_id, directory_id: UUID) -> ContactDirectory:
+    directory = (
+        db.query(ContactDirectory)
+        .filter(
+            ContactDirectory.id == directory_id,
+            ContactDirectory.organization_id == org_id,
+            ContactDirectory.deleted_at.is_(None),
+        )
+        .first()
+    )
+    if directory is None:
+        raise HTTPException(status_code=404, detail="Directory not found.")
+    return directory
+
+
+def _contact_ids(db: Session, org_id, directory_id: UUID) -> List[UUID]:
+    rows = (
+        db.query(Contact.id)
+        .filter(
+            Contact.directory_id == directory_id,
+            Contact.organization_id == org_id,
+        )
+        .all()
+    )
+    return [row[0] for row in rows]
+
+
+def summarize_directory_deletion(db: Session, org_id, directory_id: UUID) -> Dict:
+    """Count the impact of hard-deleting ``directory_id`` for the confirm modal.
+
+    Returns counts of rows that will be **deleted** (contacts, agent_contacts,
+    scheduled_calls) and **detached** (syncs). Org contact_schemas are kept, so they are
+    not counted for deletion. Raises 404 if the directory isn't org-owned.
+    """
+    _get_owned_directory(db, org_id, directory_id)
+    contact_ids = _contact_ids(db, org_id, directory_id)
+
+    contacts_count = len(contact_ids)
+    agent_contacts_count = 0
+    scheduled_calls_count = 0
+    if contact_ids:
+        agent_contacts_count = (
+            db.query(AgentContact)
+            .filter(AgentContact.contact_id.in_(contact_ids))
+            .count()
+        )
+        scheduled_calls_count = (
+            db.query(ScheduledCall)
+            .filter(ScheduledCall.contact_id.in_(contact_ids))
+            .count()
+        )
+
+    syncs_to_detach = (
+        db.query(ContactSync)
+        .filter(
+            ContactSync.directory_id == directory_id,
+            ContactSync.organization_id == org_id,
+        )
+        .count()
+    )
+
+    return {
+        "contacts": contacts_count,
+        "agent_contacts": agent_contacts_count,
+        "scheduled_calls": scheduled_calls_count,
+        "syncs_detached": syncs_to_detach,
+        "schemas_kept": True,
+    }
+
+
+def hard_delete_directory_and_children(db: Session, org_id, directory_id: UUID) -> Dict:
+    """FK-safe hard-delete of a directory and its owned children, in one transaction.
+
+    Cancels queued dial jobs, deletes contacts + agent_contacts + their scheduled_calls
+    + the directory's CSV datasource(s), marks in-flight syncs failed then detaches all
+    the directory's syncs (kept for audit), keeps org schemas, and deletes the directory.
+    Returns a summary dict of everything removed/detached. Raises 404 if not org-owned.
+    """
+    from core.services.ingestion_queue import cancel_outbound_job
+
+    _get_owned_directory(db, org_id, directory_id)
+    contact_ids = _contact_ids(db, org_id, directory_id)
+
+    cancelled_jobs = 0
+    scheduled_deleted = 0
+    jobs_to_cancel: List = []
+    if contact_ids:
+        # (2) Mark still-'scheduled' rows canceled and collect their queued dial jobs to
+        # cancel AFTER commit, then delete all the directory's scheduled_calls. Deferring
+        # the Procrastinate cancellation until after the DB commit ensures a later
+        # rollback can't leave jobs cancelled while their rows survive.
+        scheduled_rows = (
+            db.query(ScheduledCall)
+            .filter(ScheduledCall.contact_id.in_(contact_ids))
+            .all()
+        )
+        for sc in scheduled_rows:
+            if sc.status == "scheduled":
+                sc.status = "canceled"
+                if sc.queue_job_id:
+                    jobs_to_cancel.append((sc.queue_job_id, sc.id))
+        db.flush()
+        scheduled_deleted = (
+            db.query(ScheduledCall)
+            .filter(ScheduledCall.contact_id.in_(contact_ids))
+            .delete(synchronize_session=False)
+        )
+
+    # (3) C-3 race guard: mark pending/processing syncs failed BEFORE detaching so a
+    # worker mid-run aborts cleanly instead of upserting into a torn-down directory.
+    syncs_failed = (
+        db.query(ContactSync)
+        .filter(
+            ContactSync.directory_id == directory_id,
+            ContactSync.organization_id == org_id,
+            ContactSync.status.in_(["pending", "processing"]),
+        )
+        .update(
+            {ContactSync.status: "failed", ContactSync.error: "directory deleted"},
+            synchronize_session=False,
+        )
+    )
+
+    # (4) Hard-delete agent_contacts for those contacts, then the contacts.
+    agent_contacts_deleted = 0
+    contacts_deleted = 0
+    if contact_ids:
+        agent_contacts_deleted = (
+            db.query(AgentContact)
+            .filter(AgentContact.contact_id.in_(contact_ids))
+            .delete(synchronize_session=False)
+        )
+        contacts_deleted = (
+            db.query(Contact)
+            .filter(Contact.id.in_(contact_ids))
+            .delete(synchronize_session=False)
+        )
+
+    # (4 cont.) Delete the directory's CSV datasource(s).
+    datasources_deleted = (
+        db.query(Datasource)
+        .filter(
+            Datasource.directory_id == directory_id,
+            Datasource.organization_id == org_id,
+        )
+        .delete(synchronize_session=False)
+    )
+
+    # (5) Detach the directory's syncs (SET NULL) — retained as audit.
+    syncs_detached = (
+        db.query(ContactSync)
+        .filter(
+            ContactSync.directory_id == directory_id,
+            ContactSync.organization_id == org_id,
+        )
+        .update(
+            {ContactSync.directory_id: None, ContactSync.datasource_id: None},
+            synchronize_session=False,
+        )
+    )
+
+    # (6) org contact_schemas untouched. (7) delete the directory.
+    db.query(ContactDirectory).filter(
+        ContactDirectory.id == directory_id,
+        ContactDirectory.organization_id == org_id,
+    ).delete(synchronize_session=False)
+
+    db.commit()
+
+    # Cancel the collected Procrastinate dial jobs AFTER commit so a rollback can never
+    # leave a job cancelled while its scheduled_call row is still alive.
+    for job_id, sc_id in jobs_to_cancel:
+        try:
+            cancel_outbound_job(job_id)
+            cancelled_jobs += 1
+        except Exception:
+            logger.exception(
+                "[contact-directory] failed to cancel dial job job_id={} scheduled_call_id={}",
+                job_id, sc_id,
+            )
+
+    summary = {
+        "directory_id": str(directory_id),
+        "contacts_deleted": contacts_deleted,
+        "agent_contacts_deleted": agent_contacts_deleted,
+        "scheduled_calls_deleted": scheduled_deleted,
+        "dial_jobs_cancelled": cancelled_jobs,
+        "datasources_deleted": datasources_deleted,
+        "syncs_marked_failed": syncs_failed,
+        "syncs_detached": syncs_detached,
+    }
+    logger.info(
+        "[contact-directory] hard-deleted directory id={} contacts={} agent_contacts={} "
+        "scheduled_calls={} dial_jobs_cancelled={} datasources={} syncs_failed={} "
+        "syncs_detached={}",
+        directory_id, contacts_deleted, agent_contacts_deleted, scheduled_deleted,
+        cancelled_jobs, datasources_deleted, syncs_failed, syncs_detached,
+    )
+    return summary

--- a/core/services/ingestion_queue.py
+++ b/core/services/ingestion_queue.py
@@ -24,6 +24,38 @@ def ingest_upload(upload_id: str, org_id: str, delete_existing: bool = False) ->
     DocumentProcessingService().process_upload(UUID(upload_id), UUID(org_id), delete_existing=delete_existing)
 
 
+@app.task(name="run_contact_sync", queue="contact_import")
+def run_contact_sync(sync_id: str, org_id: str) -> None:
+    """Execute one directory sync run: source → map → validate → upsert → auto-assign.
+
+    Idempotent: ``ContactSyncService.run_contact_sync`` upserts by
+    ``(directory_id, external_id)``, so a re-delivered job re-parses the same file to the
+    same result rather than duplicating contacts.
+    """
+    from uuid import UUID as _UUID
+
+    from core.database.session import get_db_context
+    from core.services.contacts.contact_sync_service import ContactSyncService
+
+    logger.info("[contact-sync] worker running sync sync_id={} org={}", sync_id, org_id)
+    with get_db_context() as db:
+        service = ContactSyncService(db, org_id=_UUID(org_id))
+        sync = service.get_contact_sync(_UUID(sync_id))
+        service.run_contact_sync(sync)
+
+
+async def enqueue_contact_sync(sync_id, org_id) -> int:
+    async with app.open_async():
+        return await run_contact_sync.defer_async(sync_id=str(sync_id), org_id=str(org_id))
+
+
+def enqueue_contact_sync_sync(sync_id, org_id) -> int:
+    """Sync counterpart for callers inside a sync route handler (the contact-syncs router
+    runs in the threadpool)."""
+    with app.open():
+        return run_contact_sync.defer(sync_id=str(sync_id), org_id=str(org_id))
+
+
 @app.periodic(cron="* * * * *")
 @app.task(name="sync_pods_and_nodes", queue="pod_sync")
 def sync_pods_and_nodes_task(timestamp: int) -> None:

--- a/core/services/outbound_call_service.py
+++ b/core/services/outbound_call_service.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Session
 
 from core.models.agent import Agent
 from core.models.channel import Channel
+from core.models.contact import Contact
 from core.models.phone_number import PhoneNumber
 from core.models.scheduled_call import ScheduledCall
 from core.services.base import BaseService
@@ -32,25 +33,28 @@ from shared.config import settings
 _E164_RE = re.compile(r"^\+[1-9]\d{6,14}$")
 
 # scheduled_calls lifecycle ranks — status only moves strictly forward.
+# scheduled < processing < dispatched < in_progress < terminal.
 _STATUS_RANK = {
     "scheduled": 0,
     "processing": 1,
     "dispatched": 2,
-    "completed": 3,
-    "busy": 3,
-    "no_answer": 3,
-    "failed": 3,
-    "canceled": 3,
+    "in_progress": 3,
+    "completed": 4,
+    "busy": 4,
+    "no_answer": 4,
+    "failed": 4,
+    "canceled": 4,
 }
 _TERMINAL = {"completed", "busy", "no_answer", "failed", "canceled"}
 
-# Twilio CallStatus -> scheduled_calls status. In-flight states collapse to
-# "dispatched"; the connected call's own log carries the detail.
+# Twilio CallStatus -> scheduled_calls status. Pre-answer in-flight states collapse to
+# "dispatched"; Twilio "in-progress" (the call is connected/live) maps to "in_progress"
+# so the list can show an "In progress" chip. The connected call's own log carries detail.
 _TWILIO_STATUS_MAP = {
     "queued": "dispatched",
     "initiated": "dispatched",
     "ringing": "dispatched",
-    "in-progress": "dispatched",
+    "in-progress": "in_progress",
     "completed": "completed",
     "busy": "busy",
     "no-answer": "no_answer",
@@ -273,12 +277,31 @@ class OutboundCallService(BaseService):
             )
             for num in numbers
         ]
+        self._persist_and_enqueue_rows(rows)
+        logger.info(
+            "[outbound] queued batch agent={} count={} invalid={} scheduled_at={}",
+            agent.id, len(rows), len(invalid), scheduled_at,
+        )
+        return {
+            "mode": "bulk" if len(numbers) > 1 else "scheduled",
+            "count": len(rows),
+            "invalid": invalid,
+            "data": [self._to_response(sc) for sc in rows],
+        }
+
+    def _persist_and_enqueue_rows(self, rows: List[ScheduledCall]) -> None:
+        """Persist ``scheduled_calls`` rows then defer one Procrastinate job per row at
+        that row's own ``scheduled_at`` (so a batch can carry per-contact times). Enqueue
+        failures are isolated per row (marked ``failed``) so one bad defer doesn't drop
+        the rest of the batch."""
+        if not rows:
+            return
         self.db.add_all(rows)
         # flush() assigns PKs while the instances' attributes are still live; reading
-        # sc.id here (all rows share `when`) avoids the per-row reload that a post-commit
-        # access would trigger under expire_on_commit.
+        # sc.id / sc.scheduled_at here avoids the per-row reload a post-commit access
+        # would trigger under expire_on_commit.
         self.db.flush()
-        batch = [(sc.id, self.org_id, when) for sc in rows]
+        batch = [(sc.id, self.org_id, sc.scheduled_at) for sc in rows]
         self.db.commit()
 
         from core.services.ingestion_queue import enqueue_outbound_calls_batch
@@ -294,15 +317,112 @@ class OutboundCallService(BaseService):
                 sc.queue_job_id = job_id
         self.db.commit()
 
-        logger.info(
-            "[outbound] queued batch agent={} count={} invalid={} scheduled_at={}",
-            agent.id, len(rows), len(invalid), scheduled_at,
+    # --------------------------------------------------- schedule for contacts
+
+    @staticmethod
+    def _resolve_contact_when(contact: Contact, request_when: Optional[datetime]) -> datetime:
+        """Per-row effective schedule time. A contact's own ``scheduled_at`` metadata wins
+        only when it is still in the FUTURE; a stale/past metadata time is ignored so it
+        can neither override the (already future-validated) request time nor force an
+        immediate dial. Falls back to the request-level time, then to ASAP (now)."""
+        now = datetime.now(timezone.utc)
+        meta_when: Optional[datetime] = None
+        raw = (contact.contact_metadata or {}).get("scheduled_at")
+        if raw:
+            try:
+                parsed = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+                meta_when = parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+            except (ValueError, TypeError):
+                logger.debug("[outbound] contact {} has unparseable scheduled_at {!r}", contact.id, raw)
+        # Contact metadata time wins only when still in the future; otherwise fall back to
+        # the (already future-validated) request time, else ASAP.
+        if meta_when is not None and meta_when > now:
+            return meta_when
+        if request_when is not None:
+            return request_when
+        return now
+
+    def schedule_calls_for_contacts(
+        self,
+        agent_id,
+        from_number: str,
+        contact_ids: List,
+        scheduled_at: Optional[datetime] = None,
+        created_by_user_id=None,
+    ) -> Dict[str, Any]:
+        """Schedule outbound calls to the given org-owned contacts.
+
+        Reuses ``_validate_agent_and_from`` (gates outbound/both agent + Twilio
+        from-number) and the ``scheduled_calls`` pipeline. Each row carries its
+        ``contact_id`` and a per-contact effective time (CSV ``scheduled_at`` overrides
+        the request time). Contacts with no/invalid phone are collected into ``invalid``
+        rather than failing the whole batch."""
+        if not contact_ids:
+            raise HTTPException(status_code=400, detail="Provide at least one contact.")
+        if len(contact_ids) > self.MAX_BULK:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Too many contacts in one request (max {self.MAX_BULK}).",
+            )
+
+        agent, channel_id, from_number = self._validate_agent_and_from(agent_id, from_number)
+
+        if scheduled_at is not None and scheduled_at.tzinfo is None:
+            scheduled_at = scheduled_at.replace(tzinfo=timezone.utc)
+        if scheduled_at is not None and scheduled_at <= datetime.now(timezone.utc) - timedelta(seconds=60):
+            raise HTTPException(status_code=400, detail="scheduled_at must be in the future.")
+
+        # Org-scoped load; a spoofed id from another org simply won't be found.
+        contacts = (
+            self.query(Contact)
+            .filter(Contact.id.in_(contact_ids), Contact.deleted_at.is_(None))
+            .all()
         )
+        found = {c.id for c in contacts}
+        invalid: List[Dict[str, str]] = [
+            {"contact_id": str(cid), "error": "Contact not found."}
+            for cid in contact_ids if cid not in found
+        ]
+
+        rows: List[ScheduledCall] = []
+        for contact in contacts:
+            try:
+                to_number = self._normalize_e164(contact.phone_number or "", "phone_number")
+            except HTTPException:
+                invalid.append({
+                    "contact_id": str(contact.id),
+                    "error": "Contact has no valid E.164 phone number.",
+                })
+                continue
+            rows.append(ScheduledCall(
+                agent_id=agent.id,
+                organization_id=self.org_id,
+                channel_id=channel_id,
+                contact_id=contact.id,
+                from_number=from_number,
+                to_number=to_number,
+                scheduled_at=self._resolve_contact_when(contact, scheduled_at),
+                status="scheduled",
+                created_by_user_id=created_by_user_id,
+                metadata_={},
+            ))
+
+        if not rows:
+            raise HTTPException(
+                status_code=400,
+                detail="No contacts with a valid phone number were provided.",
+            )
+
+        self._persist_and_enqueue_rows(rows)
+        logger.info(
+            "[outbound] scheduled {} call(s) for contacts agent={} invalid={}",
+            len(rows), agent.id, len(invalid),
+        )
+        contact_by_id = {c.id: c for c in contacts}
         return {
-            "mode": "bulk" if len(numbers) > 1 else "scheduled",
             "count": len(rows),
             "invalid": invalid,
-            "data": [self._to_response(sc) for sc in rows],
+            "data": [self._to_response(sc, contact=contact_by_id.get(sc.contact_id)) for sc in rows],
         }
 
     # ---------------------------------------------------------------- dispatch
@@ -465,9 +585,9 @@ class OutboundCallService(BaseService):
         if sc is None:
             return
         sc.call_id = call_id
-        # A connected scheduled call is 'completed' from the scheduler's POV; guard so a
-        # later terminal callback (busy/no-answer can't happen post-connect) can't regress.
-        self._apply_status(sc, "completed")
+        # A connected call is 'in_progress'; the terminal Twilio status callback
+        # (completed/busy/no_answer/failed) advances it to its final state.
+        self._apply_status(sc, "in_progress")
         self.db.commit()
         logger.info("[outbound] linked scheduled call {} -> call {}", scheduled_call_id, call_id)
 
@@ -521,7 +641,12 @@ class OutboundCallService(BaseService):
         return sc
 
     def get_scheduled_call(self, scheduled_call_id) -> Dict[str, Any]:
-        return self._to_response(self._get_owned(scheduled_call_id))
+        sc = self._get_owned(scheduled_call_id)
+        agent = self.db.query(Agent).filter(Agent.id == sc.agent_id).first()
+        contact = None
+        if sc.contact_id:
+            contact = self.query(Contact).filter(Contact.id == sc.contact_id).first()
+        return self._to_response(sc, agent_name=agent.name if agent else None, contact=contact)
 
     def list_scheduled_calls(
         self,
@@ -565,19 +690,33 @@ class OutboundCallService(BaseService):
         names = {}
         if agent_ids:
             names = {a.id: a.name for a in self.db.query(Agent).filter(Agent.id.in_(agent_ids)).all()}
+
+        # Resolve the linked contact (FK) so the list can show contact name/phone.
+        contact_ids = {r.contact_id for r in rows if r.contact_id}
+        contacts_by_id = {}
+        if contact_ids:
+            contacts_by_id = {
+                c.id: c for c in self.query(Contact).filter(Contact.id.in_(contact_ids)).all()
+            }
         return {
-            "data": [self._to_response(r, agent_name=names.get(r.agent_id)) for r in rows],
+            "data": [
+                self._to_response(r, agent_name=names.get(r.agent_id), contact=contacts_by_id.get(r.contact_id))
+                for r in rows
+            ],
             "total": total,
             "page_no": page_no,
             "page_size": page_size,
         }
 
     @staticmethod
-    def _to_response(sc: ScheduledCall, agent_name: Optional[str] = None) -> Dict[str, Any]:
+    def _to_response(sc: ScheduledCall, agent_name: Optional[str] = None, contact: Optional[Contact] = None) -> Dict[str, Any]:
         return {
             "id": str(sc.id),
             "agent_id": str(sc.agent_id),
             "agent_name": agent_name,
+            "contact_id": str(sc.contact_id) if sc.contact_id else None,
+            "contact_name": contact.name if contact else None,
+            "contact_phone_number": contact.phone_number if contact else None,
             "status": sc.status,
             "from_number": sc.from_number,
             "to_number": sc.to_number,

--- a/core/services/pipeline/mistral_self_hosted_llm_service.py
+++ b/core/services/pipeline/mistral_self_hosted_llm_service.py
@@ -69,7 +69,7 @@ class MistralSelfHostedLLMService(BaseOpenAILLMService):
         params = super().build_chat_completion_params(params_from_context)
         trace_id = get_trace_id()
         if trace_id and trace_id != "none":
-            params["extra_headers"] = {"X-Request-Id": trace_id}
+            params.setdefault("extra_headers", {})["X-Request-Id"] = trace_id
         messages = params.get("messages")
         if not messages:
             return params

--- a/docs/code-review/README.md
+++ b/docs/code-review/README.md
@@ -78,6 +78,17 @@ spend review cycles on style a tool can fix.**
 
 Reuse is a review priority in this repo, but **premature abstraction is a defect too.**
 
+- **Single source of truth (blocker-class).** A given piece of functionality has exactly
+  one implementation, and every call site — another router, a worker, a CLI, a test, a
+  second page — goes through it. If a PR re-implements or copy-pastes behavior that an
+  existing service/helper/hook already provides, that's a `[blocker]`/`[should]`: the fix
+  is "call the shared function," not "duplicate it here." Before approving new logic, ask
+  "does this already exist, and will it be needed elsewhere?" — if yes, it belongs in a
+  shared service (`BaseService`) / `core/services/common` / `core/utils` (BE) or
+  `@/components/shared` / `@/hooks` / `@/lib` / `@/utils` / `@/services` (FE).
+- **Logic goes through the service layer, always.** Routers/controllers and components stay
+  thin; domain logic lives in a service so it is reusable and testable from anywhere. Flag
+  any business logic, raw query, or multi-model rule that sits in a router or component.
 - **Rule of three.** Two occurrences → leave it. Three → extract a shared helper/component/service.
 - **Extract by responsibility, not by shape.** Two blocks that *look* similar but change for
   *different reasons* should stay separate. Coupling them creates a helper with five boolean

--- a/docs/code-review/backend-python-fastapi.md
+++ b/docs/code-review/backend-python-fastapi.md
@@ -161,6 +161,14 @@ Formatting is tool-enforced (Ruff/formatter). **Review the substance below, not 
 
 ## 11. Structure, naming & reuse
 
+- `[blocker]` **Single source of truth.** The same functionality has one implementation and every
+  caller (router, worker, CLI, test) invokes it. A PR that re-implements or copy-pastes logic an
+  existing service/helper already provides must call the shared function instead — flag the
+  duplication and point to the canonical one. New logic that will be needed from more than one place
+  is written as a shared service method / `core/services/common` / `core/utils` helper from the start.
+- `[blocker]` **All business logic runs through the service layer.** Routers stay thin (parse →
+  authorize → call service → shape response); domain rules, multi-model operations, and queries live
+  in a `BaseService`, callable from anywhere. (Reinforces §1.)
 - `[should]` Shared logic → a service method or `core/utils` helper, reused across routers — not
   copy-pasted between endpoints (rule of three).
 - `[should]` Functions do one thing; a service method spanning fetch + transform + external call +
@@ -171,6 +179,7 @@ Formatting is tool-enforced (Ruff/formatter). **Review the substance below, not 
 ## Quick reviewer checklist (BE)
 
 - [ ] Router is thin; logic in a `BaseService`; models stay data-only.
+- [ ] **No duplicated logic — same functionality is one shared service/helper, called everywhere (not re-implemented per endpoint).**
 - [ ] Every route has the right auth guard; **every query is org/tenant-scoped**.
 - [ ] AuthZ checks the specific object (no IDOR), not just the role.
 - [ ] No raw/interpolated SQL; no N+1; queries paginated; transactions atomic.

--- a/frontend/.claude/rules.md
+++ b/frontend/.claude/rules.md
@@ -332,3 +332,37 @@ Use a **55% / 40%** left-right split with a gap between label and control:
 | Form row description | `text-[13px] leading-relaxed text-muted-foreground` |
 | Page heading         | `text-lg font-semibold text-foreground`             |
 | Banner/alert text    | `text-[13px]`                                       |
+
+---
+
+## 13. Reuse & the service layer — single source of truth (mandatory)
+
+The same functionality must have **exactly one implementation** that every caller uses. If a behavior is (or will be) invoked from more than one place — another page, component, hook, atom, or test — it MUST be a shared function, not copy-pasted. Before writing new logic, search for an existing shared piece and extend it; when a second call site appears, extract rather than duplicate.
+
+### Where shared logic lives
+
+| Kind of logic                                        | Put it in                                     | Never do this                                              |
+| ---------------------------------------------------- | --------------------------------------------- | --------------------------------------------------------- |
+| Reusable UI element                                  | `src/components/shared/` (barrel-exported)    | Re-implement a shared component inline per page            |
+| Cross-page domain UI                                 | `src/components/<domain>/shared/`             | Copy a table/modal/form into a second feature             |
+| Stateful reusable behavior                           | `src/hooks/`                                  | Duplicate the same `useState`/`useEffect` block per page  |
+| Pure helpers (format/validate/transform)             | `src/lib/` or `src/utils/`                    | Inline the same date/string/number logic in many files    |
+| **All HTTP / server calls**                          | `src/services/` or `src/lib/api/` hooks       | Call `axios`/`fetch` directly from a component             |
+| Client state + side effects                          | Jotai atoms (`src/atoms/`)                    | Fire service calls from render or duplicate write logic    |
+
+### Rules
+
+1. **API/service layer is mandatory.** Every backend call goes through a service function (`src/services/`) or a `src/lib/api` query/mutation hook — never a raw `axios`/`fetch` in a component or page. One client wrapper per endpoint; every caller reuses it (see the Contacts `lib/api/*` clients and `usePaginatedList` for the pattern).
+2. **Components stay thin.** Components render + wire events; side effects go through Jotai write atoms; data-shaping/validation lives in a hook/util/schema. No business logic embedded in a component that a second component would need to copy.
+3. **Factor out on the 2nd–3rd occurrence.** Extract by **responsibility**, not by superficial shape. If two spots do the same job, they call one function; if they merely look similar but mean different things, keep them separate.
+4. **Extend, don't fork.** Need a variant? Add a prop/param to the shared function. Do not clone-and-tweak it into a near-duplicate.
+5. **Register new shared pieces** so they get reused: barrel-export shared components from `@/components/shared`, document shared UI in `docs/shared-components.md`, and list reusable domain hooks/clients in the "Contacts Directories — reusable components/hooks" section of `CLAUDE.md`.
+
+### Code review must flag (blocker)
+
+- Any **raw `fetch`/`axios`** in a component/page instead of a service or `lib/api` hook.
+- **Duplicated logic** — the same functionality re-implemented in a second call site instead of calling the existing shared function/hook/service/component.
+- A new component/hook/util that **rebuilds something a shared piece already provides** — the fix is "call the shared one", not "copy it here".
+- Business logic living **inside a component** that belongs in a hook/util/service/atom.
+
+The fix for all of the above is always *reuse the single implementation*, never *duplicate it*.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -197,10 +197,23 @@ try {
 
 ---
 
+## Contacts Directories — reusable components/hooks (reuse, don't re-implement)
+
+Import targets (all under `src/`):
+- **`usePaginatedList`** (`lib/api/usePaginatedList.ts`) — generic TanStack Query hook for `POST /…/list` (search/sort/paginate). **`queryKeys`** (`lib/api/queryKeys.ts`) — typed query-key factory for all contacts queries/invalidations.
+- **`buildContactFormSchema`** (`components/contacts/shared/buildContactFormSchema.ts`) — `schema_fields` → Zod schema at runtime. **`SchemaDrivenContactForm`** (same dir) — renders inputs from `schema_fields` (RHF+Zod). Used by Add + Edit contact.
+- **`ContactsTable`** (`components/contacts/shared/ContactsTable.tsx`) — wraps `CustomTable` (search/filter/sort/paginate). Directory General + Agent Contacts + Assign picker.
+- **`SchemaFieldsEditor`** (`components/contacts/shared/SchemaFieldsEditor.tsx`) — field CRUD editor.
+- **`SyncContactsModal`** + **`useSyncStatusPolling`** + **`SyncStatusChip`** (`components/contacts/shared/`) — sync stepper + poll to terminal; optional `agentId` auto-assign.
+- **`AssignContactsModal`** + **`DirectoryContactTree`** + **`useDirectoryContactTreeSelection`** (`components/contacts/shared/`) — tri-state directory→contacts multi-select; emits `{directory_ids, contact_ids}`.
+- **`ConfirmDeleteModal`** (`components/contacts/shared/ConfirmDeleteModal.tsx`) — impact-summary + confirm wrapper over `CustomModal`.
+- API clients: `lib/api/{contactDirectories,contactDatasources,contactSchemas,contactSyncs,agentContacts,contacts}.ts`.
+
 ## Project Rules
 
 Project-wide rules are defined in `.claude/rules.md`. This includes:
 
+- **Reuse & the service layer (single source of truth)** — one shared implementation per behavior; all HTTP through `src/services` / `src/lib/api` hooks (never raw `fetch`/`axios` in a component); components stay thin; code review flags duplication (rule §13)
 - **Skill error tracking** — How skills log errors, categories, severity levels, and the log format
 - **Error resolution workflow** — How to diagnose, fix, and update the error log
 - **Skill execution rules** — Pre-execution checks, error handling, output standards
@@ -290,8 +303,9 @@ Every `/code-review` run works through all nine sections below. No section is sk
 
 Applies **solid-checklist.md** in full — SRP, OCP, LSP, ISP, DIP, code smells, hook design, component design.
 
+- **Single source of truth (reuse first):** the same functionality has ONE implementation that every caller uses — a shared component (`src/components/shared`), hook (`src/hooks`), util (`src/lib`/`src/utils`), service (`src/services` / `src/lib/api`), or Jotai atom. Flag any PR that re-implements or copy-pastes behavior a shared piece already provides — call the shared function, don't duplicate it. When new logic will be needed from more than one place, factor it out from the start (extract by responsibility, not shape; rule of three).
 - **This project**: Service functions in `src/services/` must not import Jotai atoms directly (DIP). Atoms call services; services do not know about atoms.
-- Components must not call `src/services/` directly — all side effects go through Jotai write atoms.
+- Components must not call `src/services/` directly — all side effects go through Jotai write atoms; all HTTP goes through the service / `src/lib/api` layer (never raw `fetch`/`axios` in a component).
 - `agentFormUtils.ts` owns `AgentFormState` shape, `defaultFormState`, and serialisation — do not duplicate this logic in components.
 
 #### 5. Security
@@ -414,6 +428,8 @@ Write-only atoms (e.g., `atom(null, async (_get, set, payload) => {...})`) are t
 **UI**: shadcn/ui primitives in `src/components/ui/` styled with Tailwind v4 and theme tokens from `src/app/globals.css` (CSS variables for color, radius, etc.). The root font is **Geist Sans** (loaded via `next/font` in `src/app/layout.tsx`, exposed as `--font-geist-sans` and bound to Tailwind's `font-sans`); `font-mono` resolves to Geist Mono. Dark mode is handled by `next-themes`. Use **lucide-react** for icons (or `src/components/icons/` for brand marks). The codebase is MUI-free — do not introduce `@mui/*` or `@emotion/*` packages.
 
 **Shared components**: `src/components/shared/` holds reusable form/UI pieces (TextInput, CustomButton, Form, CheckboxField, RadioGroupField, SelectInput, TextAreaField, CustomLink). Each form component is **unified** — passing a `control` prop activates RHF `Controller` integration automatically (no separate `Form*` wrapper needed). Component prop types are defined in `src/types/components.ts`. To understand or use them without reading each file, read **`docs/shared-components.md`** (single reference, lower token usage). When adding or changing a shared component, update that doc.
+
+**Date/time input (mandatory)**: Use the shared `DateTimePicker` (a single instant → emits a UTC ISO string) or `DateRangePicker` (a range) for ALL date/time selection. Both are timezone-aware and share the `combineToIso`/`splitFromIso`/`getBrowserTimeZone` helpers in `@/utils/date`. Do NOT use native `<input type="date">` / `<input type="datetime-local">` or introduce another calendar library in app/feature code.
 
 **Form validation**: Two patterns are used for form validation:
 

--- a/frontend/docs/shared-components.md
+++ b/frontend/docs/shared-components.md
@@ -295,6 +295,35 @@ Wraps shadcn `Button` with semantic `type` and loading/icon support.
 
 ---
 
+## CollapsibleSection
+
+Reusable disclosure ("expand / collapse") primitive: a bordered section with an always-visible header (title + optional leading icon + optional sub-line) and a body that animates in/out (height + fade, `prefers-reduced-motion`-safe). When open it gains a primary-tinted accent. Uncontrolled by default; controllable via `expanded` + `onExpandedChange`. Use it for any optional/advanced form section or "show more" panel instead of re-wiring `useState` + chevron + framer-motion.
+
+| Prop             | Type                                                | Default | Description                                                         |
+| ---------------- | --------------------------------------------------- | ------- | ------------------------------------------------------------------ |
+| title            | string                                              | —       | Header heading.                                                    |
+| description      | `ReactNode \| (expanded: boolean) => ReactNode`     | —       | Sub-line under the title; pass a fn to vary copy by open state.    |
+| icon             | ReactNode                                           | —       | Leading icon; its tile tints to the primary colour when open.      |
+| defaultExpanded  | boolean                                             | `false` | Initial open state (uncontrolled).                                 |
+| expanded         | boolean                                             | —       | Controlled open state (pair with `onExpandedChange`).             |
+| onExpandedChange | `(expanded: boolean) => void`                       | —       | Fired on every header toggle.                                      |
+| children         | ReactNode                                           | —       | Body revealed when expanded.                                       |
+| className        | string                                              | —       | Extra classes on the outer container.                              |
+
+**Example:**
+
+```tsx
+<CollapsibleSection
+  title="Advanced configuration"
+  icon={<SlidersHorizontal className="size-4" aria-hidden />}
+  description={(open) => (open ? 'Choose a directory.' : 'Defaults to Global')}
+>
+  <SelectInput name="directory" label="Directory" options={options} value={id} onValueChange={setId} />
+</CollapsibleSection>
+```
+
+---
+
 ## CustomLink
 
 `next/link` styled like CustomButton `type="link"` (primary text, underline on hover). No navigation logic—just styling.
@@ -1030,6 +1059,40 @@ const params = {
 
 ---
 
+## DateTimePicker
+
+Timezone-aware **single-instant** picker — the sibling of `DateRangePicker`, styled identically (popover trigger → single calendar + `HH:mm` time + IANA timezone + Apply/Clear). No range, no relative presets. Emits `{ value, timeZone }` where `value` is a **UTC ISO** instant. Shares the `combineToIso`/`splitFromIso`/`getBrowserTimeZone` helpers in `@/utils/date` with `DateRangePicker`.
+
+### Props
+
+| Prop             | Type                               | Default                | Description                                       |
+| ---------------- | ---------------------------------- | ---------------------- | ------------------------------------------------- |
+| value            | `DateTimeValue`                    | —                      | Applied value `{ value, timeZone }` (`value` UTC ISO). |
+| onChange         | `(value: DateTimeValue) => void`   | —                      | Fired on Apply / Clear with the new value.        |
+| placeholder      | string                             | `'Select date & time'` | Trigger text when no instant is set.              |
+| align            | `'start' \| 'center' \| 'end'`     | `'start'`              | Popover alignment.                                |
+| triggerClassName | string                             | —                      | Extra classes for the trigger button.             |
+| disabled         | boolean                            | `false`                | Disables the trigger.                             |
+
+**DateTimeValue:** `{ value: string \| null; timeZone: string }`
+
+### Example
+
+```tsx
+const [when, setWhen] = useState<DateTimeValue>({ value: null, timeZone: getBrowserTimeZone() });
+
+<DateTimePicker value={when} onChange={setWhen} />;
+
+// Send to an API expecting a single ISO instant:
+const payload = { scheduled_at: when.value ?? undefined };
+```
+
+### Mandate
+
+Use **`DateTimePicker`** (single instant) or **`DateRangePicker`** (range) for ALL date/time selection across the app. Do **not** use native `<input type="date">` / `<input type="datetime-local">` or introduce another calendar library in app/feature code.
+
+---
+
 ## TokenSearchBar
 
 Tokenized `field:value` search bar with autocomplete chips (Vercel-style). Typing shows a field list; selecting a field loads its values (for `enum` fields, via `fetchValues`, cached after first load) and shows a value list; confirmed filters render as removable chips. Typing `status:` directly auto-activates that field. Emits a normalized `SearchToken[]`.
@@ -1083,7 +1146,7 @@ const filters = tokens.map((t) => ({ field: t.field, operator: 'in', value: [t.v
 
 ## Exports from `@/components/shared`
 
-- **Components:** `ActionMenu`, `CheckboxField`, `CustomButton`, `CustomLink`, `CustomModal`, `CustomTab`, `CustomTable`, `CustomTooltip`, `DateRangePicker`, `Divider`, `Form`, `Logo`, `MultiSelectField`, `RadioGroupField`, `SearchableSelect`, `SelectInput`, `SliderField`, `TextAreaField`, `TextInput`, `TokenSearchBar`
+- **Components:** `ActionMenu`, `CheckboxField`, `CustomButton`, `CustomLink`, `CustomModal`, `CustomTab`, `CustomTable`, `CustomTooltip`, `DateRangePicker`, `DateTimePicker`, `Divider`, `Form`, `Logo`, `MultiSelectField`, `RadioGroupField`, `SearchableSelect`, `SelectInput`, `SliderField`, `TextAreaField`, `TextInput`, `TokenSearchBar`
 - **Types:** `ActionMenuProps`, `CheckboxFieldBaseProps`, `CustomModalProps`, `CustomTableColumn`, `CustomTablePagination`, `CustomTableProps`, `FormCheckboxFieldProps`, `FormMultiSelectFieldProps`, `FormRadioGroupFieldProps`, `FormSelectInputProps`, `FormSliderFieldProps`, `FormTextAreaFieldProps`, `FormTextInputProps`, `MultiSelectFieldBaseProps`, `MultiSelectOption`, `RadioGroupOption`, `SearchableSelectOption`, `SelectInputBaseProps`, `SelectOption`, `SliderFieldBaseProps`, `TabItem`, `TextAreaFieldBaseProps`, `TextInputBaseProps`
 
 ---

--- a/frontend/public/samples/contacts-sample.csv
+++ b/frontend/public/samples/contacts-sample.csv
@@ -1,0 +1,4 @@
+name,phone_number,external_id,scheduled_at,company,notes
+Jane Doe,+14155550123,cust-001,2026-08-01T15:30:00Z,Acme Inc,Prefers afternoon calls
+John Smith,+14155550124,cust-002,,Globex,Follow up on demo
+Maria Garcia,+442071838750,cust-003,2026-08-02T09:00:00+00:00,Initech,VIP account

--- a/frontend/src/app/(dashboard)/contacts/datasource/page.tsx
+++ b/frontend/src/app/(dashboard)/contacts/datasource/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import ContactSchemaSection from '@/components/contacts/schema/ContactSchemaSection';
+
+/**
+ * `/contacts/datasource` — the org-level reusable contact-schema library,
+ * independent of any directory. Schemas defined here are shared across
+ * directories (a directory picks one as its default via the directory form).
+ * Lives inside the focused Contacts section rail under "Datasource".
+ */
+export default function ContactsDatasourcePage() {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex shrink-0 flex-col gap-1 border-b border-border px-6 py-5">
+        <h1 className="text-xl font-semibold text-foreground">Datasource Schemas</h1>
+        <p className="text-sm text-muted-foreground">
+          Reusable contact schemas — define fields once and share them across directories.
+        </p>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col p-6">
+        <ContactSchemaSection />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/contacts/directories/[directoryId]/page.tsx
+++ b/frontend/src/app/(dashboard)/contacts/directories/[directoryId]/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+
+import DirectoryDetailHeader from '@/components/contacts/DirectoryDetailHeader';
+// PIN: built by another agent — prop `{ directoryId: string }`. If missing at
+// build time, that's an integration gap, not an error in this file.
+import DirectoryContactsSection from '@/components/contacts/general/DirectoryContactsSection';
+
+/**
+ * General pane host for a directory: the detail header (General tab active) plus
+ * the contacts section (table + add + sync).
+ */
+export default function DirectoryGeneralPage() {
+  const params = useParams<{ directoryId: string }>();
+  const directoryId = params.directoryId;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <DirectoryDetailHeader directoryId={directoryId} />
+      <div className="flex min-h-0 flex-1 flex-col p-6">
+        <DirectoryContactsSection directoryId={directoryId} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/contacts/directories/layout.tsx
+++ b/frontend/src/app/(dashboard)/contacts/directories/layout.tsx
@@ -1,0 +1,14 @@
+import ContactsMasterDetail from '@/components/contacts/ContactsMasterDetail';
+
+/**
+ * Master-detail shell for the Contact Directories (General) view.
+ *
+ * Wraps every `/contacts/directories/*` route with the persistent left rail
+ * (directory list) and a right-pane slot (`children`). The rail stays mounted
+ * across detail navigation so its scroll position and selection are preserved.
+ * This shell lives one level down under the focused Contacts section rail
+ * (contacts/layout.tsx).
+ */
+export default function ContactsDirectoriesLayout({ children }: { children: React.ReactNode }) {
+  return <ContactsMasterDetail>{children}</ContactsMasterDetail>;
+}

--- a/frontend/src/app/(dashboard)/contacts/directories/page.tsx
+++ b/frontend/src/app/(dashboard)/contacts/directories/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { FolderOpen } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+import { useDirectoriesList } from '@/lib/api/contactDirectories';
+
+/**
+ * `/contacts/directories` index (right-pane host when no directory is selected).
+ *
+ * With no directory in the route, auto-select the first directory by redirecting
+ * to `/contacts/directories/[firstId]`. If the org has no directories yet, show a
+ * "Select a directory" placeholder (the rail owns the empty/create state).
+ */
+export default function ContactsDirectoriesIndexPage() {
+  const router = useRouter();
+  const { data, isLoading } = useDirectoriesList({
+    page_size: 1,
+    sort_by: 'name',
+    sort_order: 'asc',
+  });
+
+  const firstDirectoryId = data?.data?.[0]?.id ?? null;
+
+  useEffect(() => {
+    if (firstDirectoryId) router.replace(`/contacts/directories/${firstDirectoryId}`);
+  }, [firstDirectoryId, router]);
+
+  if (isLoading || firstDirectoryId) {
+    // While loading, or briefly before the redirect lands, render nothing
+    // heavy — the rail already shows its own loading state.
+    return null;
+  }
+
+  return (
+    <div className="flex h-full w-full min-w-0 flex-col items-center justify-center gap-3 p-8 text-center">
+      <div className="flex size-14 items-center justify-center rounded-full bg-muted/60">
+        <FolderOpen className="size-7 text-muted-foreground/60" strokeWidth={1.5} />
+      </div>
+      <p className="text-base font-semibold text-foreground">Select a directory</p>
+      <p className="max-w-xs text-balance break-words text-sm text-muted-foreground">
+        Choose a directory from the list, or create one to start adding contacts.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/contacts/layout.tsx
+++ b/frontend/src/app/(dashboard)/contacts/layout.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import { CONTACTS_NAV_GROUPS, CONTACTS_NAV_ITEMS } from '@/components/contacts/contactsNav';
+import { AccountMenu } from '@/components/layout/AccountMenu';
+import { SidebarShell, isSidebarItemActive } from '@/components/layout/SidebarShell';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/primitives';
+import { useNavigation } from '@/contexts/navigation';
+import { cn } from '@/lib/utils';
+
+/** Primary slot — return to the main app. */
+function BackToApp({ collapsed }: { collapsed: boolean }) {
+  if (collapsed) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Link
+            href="/agents"
+            aria-label="Back to app"
+            className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/10 transition-colors hover:bg-primary/15"
+          >
+            <ArrowLeft className="h-4 w-4 text-primary" strokeWidth={1.75} />
+          </Link>
+        </TooltipTrigger>
+        <TooltipContent side="right" sideOffset={12}>
+          Back to app
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Link
+      href="/agents"
+      className="flex w-full items-center gap-3 rounded-lg px-2 py-2 text-left transition-colors hover:bg-sidebar-accent/60"
+    >
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 ring-1 ring-primary/10">
+        <ArrowLeft className="h-[18px] w-[18px] text-primary" strokeWidth={1.75} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-[14px] font-semibold leading-tight tracking-tight">Contacts</p>
+        <p className="mt-0.5 truncate text-[11.5px] leading-tight text-muted-foreground">
+          Back to app
+        </p>
+      </div>
+    </Link>
+  );
+}
+
+export default function ContactsLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  // Share the collapse state (and therefore width) with the main app sidebar so
+  // switching between the app and contacts never changes the rail width.
+  const { sidebarCollapsed, toggleSidebar } = useNavigation();
+
+  return (
+    <div className="flex h-full w-full min-w-0 bg-background">
+      {/* ── Contacts rail (desktop) — shares SidebarShell with the app sidebar ── */}
+      <SidebarShell
+        groups={CONTACTS_NAV_GROUPS}
+        collapsed={sidebarCollapsed}
+        onToggle={toggleSidebar}
+        activeLayoutId="contacts-rail"
+        className="hidden lg:flex"
+        primary={(c) => <BackToApp collapsed={c} />}
+        footer={(c) => <AccountMenu collapsed={c} />}
+      />
+
+      {/* ── Content column ────────────────────────────────────────── */}
+      <div className="flex h-full min-h-0 w-full min-w-0 flex-col">
+        {/* Mobile top bar */}
+        <div className="flex shrink-0 flex-col gap-2 border-b border-border/60 bg-sidebar/60 px-4 pb-2 pt-2.5 backdrop-blur lg:hidden">
+          <div className="flex items-center gap-3">
+            <Link
+              href="/agents"
+              aria-label="Back to app"
+              className="inline-flex size-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-foreground"
+            >
+              <ArrowLeft className="size-4" />
+            </Link>
+            <span className="text-[15px] font-semibold tracking-tight">Contacts</span>
+          </div>
+          <nav
+            aria-label="Contacts sections (mobile)"
+            className="-mx-1 flex items-center gap-1 overflow-x-auto px-1 pb-0.5"
+          >
+            {CONTACTS_NAV_ITEMS.map((item) => {
+              const Icon = item.icon;
+              const active = isSidebarItemActive(pathname, item);
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  aria-current={active ? 'page' : undefined}
+                  className={cn(
+                    'inline-flex shrink-0 items-center gap-1.5 rounded-full px-3 py-1.5 text-[12px] font-medium transition-colors',
+                    active
+                      ? 'bg-sidebar-accent text-foreground'
+                      : 'text-muted-foreground hover:bg-sidebar-accent/60 hover:text-foreground',
+                  )}
+                >
+                  <Icon className="size-3.5" />
+                  {item.label}
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/contacts/page.tsx
+++ b/frontend/src/app/(dashboard)/contacts/page.tsx
@@ -1,0 +1,9 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * `/contacts` index — the Contacts section opens on its General (directories)
+ * view. Redirect to `/contacts/directories`, the first rail destination.
+ */
+export default function ContactsIndexPage() {
+  redirect('/contacts/directories');
+}

--- a/frontend/src/app/(dashboard)/contacts/sync-history/page.tsx
+++ b/frontend/src/app/(dashboard)/contacts/sync-history/page.tsx
@@ -1,0 +1,352 @@
+'use client';
+
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { ChevronDown, History } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { useDirectoriesList } from '@/lib/api/contactDirectories';
+import { useContactSyncsList } from '@/lib/api/contactSyncs';
+import { CustomButton, SelectInput } from '@/components/shared';
+import SyncErrorTable from '@/components/contacts/shared/SyncErrorTable';
+import SyncStatusChip from '@/components/contacts/shared/SyncStatusChip';
+import type { ContactSync, ContactSyncStatus } from '@/types/contactSync';
+import { cn } from '@/utils/cn';
+import { formatTimestamp } from '@/utils/date';
+
+/**
+ * `/contacts/sync-history` — an org-wide log of every CSV import across all directories.
+ *
+ * WHAT: lists past `ContactSync` runs (newest first, paginated) so a user can reopen a
+ * finished sync after closing the sync modal — each row shows the directory it targeted,
+ * its status + counts, and an expandable per-row error report (`SyncErrorTable`) with a
+ * re-downloadable CSV.
+ *
+ * WHEN: the third item in the focused Contacts section rail, after "Datasource".
+ */
+const PAGE_SIZE = 10;
+
+// `all` is a sentinel — Radix Select can't use an empty-string item value.
+const STATUS_OPTIONS = [
+  { value: 'all', label: 'All statuses' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'processing', label: 'Processing' },
+  { value: 'pending', label: 'Pending' },
+];
+
+export default function ContactsSyncHistoryPage() {
+  const [page, setPage] = useState(1);
+  const [directoryFilter, setDirectoryFilter] = useState('all');
+  const [statusFilter, setStatusFilter] = useState('all');
+
+  const { data: syncsPage, isLoading } = useContactSyncsList({
+    page_no: page,
+    page_size: PAGE_SIZE,
+    sort_by: 'created_at',
+    sort_order: 'desc',
+    directory_id: directoryFilter === 'all' ? undefined : directoryFilter,
+    status: statusFilter === 'all' ? undefined : (statusFilter as ContactSyncStatus),
+  });
+
+  // Resolve directory ids → names so each sync shows which directory it imported into.
+  const { data: directoriesPage } = useDirectoriesList({ page_size: 100 });
+  const directoryNames = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const d of directoriesPage?.data ?? []) map.set(d.id, d.name);
+    return map;
+  }, [directoriesPage]);
+
+  const directoryOptions = useMemo(
+    () => [
+      { value: 'all', label: 'All directories' },
+      ...(directoriesPage?.data ?? []).map((d) => ({ value: d.id, label: d.name })),
+    ],
+    [directoriesPage],
+  );
+
+  const hasFilters = directoryFilter !== 'all' || statusFilter !== 'all';
+  const handleDirectoryFilter = (id: string) => {
+    setDirectoryFilter(id);
+    setPage(1);
+  };
+  const handleStatusFilter = (s: string) => {
+    setStatusFilter(s);
+    setPage(1);
+  };
+  const clearFilters = () => {
+    setDirectoryFilter('all');
+    setStatusFilter('all');
+    setPage(1);
+  };
+
+  const syncs = syncsPage?.data ?? [];
+  const total = syncsPage?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div className="animate-page flex h-full min-h-0 flex-col">
+      <div className="flex shrink-0 flex-col gap-1 border-b border-border px-6 py-5">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground">Sync History</h1>
+        <p className="text-sm text-muted-foreground">
+          Past CSV imports across your directories — review skipped rows and re-download error
+          reports.
+        </p>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-6">
+        <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col">
+          <div className="mb-4 flex flex-wrap items-center gap-2">
+            <div className="w-56">
+              <SelectInput
+                name="filter-directory"
+                options={directoryOptions}
+                value={directoryFilter}
+                onValueChange={handleDirectoryFilter}
+                placeholder="All directories"
+              />
+            </div>
+            <div className="w-44">
+              <SelectInput
+                name="filter-status"
+                options={STATUS_OPTIONS}
+                value={statusFilter}
+                onValueChange={handleStatusFilter}
+                placeholder="All statuses"
+              />
+            </div>
+            {hasFilters && (
+              <CustomButton type="text" size="sm" onClick={clearFilters}>
+                Clear filters
+              </CustomButton>
+            )}
+          </div>
+
+          {isLoading ? (
+            <SyncHistorySkeleton />
+          ) : syncs.length === 0 ? (
+            <div className="flex flex-1 flex-col items-center justify-center gap-4 py-16 text-center">
+              <span className="flex size-14 items-center justify-center rounded-full bg-muted/60 ring-1 ring-border">
+                <History className="size-6 text-muted-foreground" aria-hidden />
+              </span>
+              <div className="space-y-1">
+                <p className="text-sm font-semibold text-foreground">
+                  {hasFilters ? 'No syncs match these filters' : 'No syncs yet'}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {hasFilters
+                    ? 'Try a different directory or status.'
+                    : 'Import a CSV into a directory and its run will show up here.'}
+                </p>
+              </div>
+              {hasFilters && (
+                <CustomButton type="default" size="sm" onClick={clearFilters}>
+                  Clear filters
+                </CustomButton>
+              )}
+            </div>
+          ) : (
+            <>
+              <ul className="flex flex-col gap-3">
+                {syncs.map((sync) => (
+                  <li key={sync.id}>
+                    <SyncHistoryCard sync={sync} directoryNames={directoryNames} />
+                  </li>
+                ))}
+              </ul>
+
+              <div className="mt-auto flex items-center justify-between gap-3 pt-6">
+                <span className="text-xs tabular-nums text-muted-foreground">
+                  Page {page} of {totalPages}
+                </span>
+                <div className="flex items-center gap-2">
+                  <CustomButton
+                    type="default"
+                    size="sm"
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    disabled={page <= 1}
+                  >
+                    Previous
+                  </CustomButton>
+                  <CustomButton
+                    type="default"
+                    size="sm"
+                    onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                    disabled={page >= totalPages}
+                  >
+                    Next
+                  </CustomButton>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** 2–3 shimmering placeholder cards while the first page loads. */
+function SyncHistorySkeleton() {
+  return (
+    <ul className="flex flex-col gap-3" aria-busy="true" aria-label="Loading syncs">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <li key={i} className="rounded-lg border border-border border-l-2 border-l-border p-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex flex-col gap-2">
+              <div className="h-4 w-40 animate-pulse rounded bg-muted" />
+              <div className="h-3 w-28 animate-pulse rounded bg-muted/70" />
+            </div>
+            <div className="h-6 w-24 animate-pulse rounded-full bg-muted" />
+          </div>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {Array.from({ length: 4 }).map((_, j) => (
+              <div key={j} className="h-6 w-20 animate-pulse rounded-md bg-muted/70" />
+            ))}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/** completed w/ 0 failed → success · completed w/ some failed but progress → warning · failed → error. */
+type SyncOutcome = 'success' | 'warning' | 'error' | 'neutral';
+
+function getSyncOutcome(sync: ContactSync): SyncOutcome {
+  if (sync.status === 'failed') return 'error';
+  if (sync.status === 'completed') {
+    const { created = 0, updated = 0, failed = 0 } = sync.counts ?? {};
+    if (failed > 0) return created > 0 || updated > 0 ? 'warning' : 'error';
+    return 'success';
+  }
+  return 'neutral';
+}
+
+/** Left accent keyed to outcome — soft token tints, not loud fills. */
+const OUTCOME_ACCENT: Record<SyncOutcome, string> = {
+  success: 'border-l-emerald-400',
+  warning: 'border-l-amber-400',
+  error: 'border-l-red-400',
+  neutral: 'border-l-border',
+};
+
+/** One sync run: directory + date + status + counts, with an expandable error report. */
+function SyncHistoryCard({
+  sync,
+  directoryNames,
+}: {
+  sync: ContactSync;
+  directoryNames: Map<string, string>;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const reduceMotion = useReducedMotion();
+  const hasErrors = sync.row_errors.length > 0;
+  const directoryName =
+    (sync.directory_id && directoryNames.get(sync.directory_id)) || 'Deleted directory';
+  const counts = sync.counts ?? {};
+  const outcome = getSyncOutcome(sync);
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-border border-l-2 bg-card transition-colors',
+        OUTCOME_ACCENT[outcome],
+      )}
+    >
+      <div className="p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <span className="truncate text-base font-semibold text-foreground">
+              {directoryName}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {formatTimestamp(sync.created_at)}
+            </span>
+          </div>
+          <SyncStatusChip status={sync.status} />
+        </div>
+
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <StatChip label="Created" value={counts.created ?? 0} tone="created" />
+          <StatChip label="Updated" value={counts.updated ?? 0} tone="updated" />
+          <StatChip label="Skipped" value={counts.skipped ?? 0} tone="skipped" />
+          <StatChip label="Failed" value={counts.failed ?? 0} tone="failed" />
+        </div>
+
+        {sync.error && (
+          <div
+            role="alert"
+            className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-800 ring-1 ring-inset ring-red-200"
+          >
+            {sync.error}
+          </div>
+        )}
+      </div>
+
+      {hasErrors && (
+        <div className="border-t border-border px-4 py-2">
+          <CustomButton
+            type="text"
+            size="xs"
+            aria-expanded={expanded}
+            onClick={() => setExpanded((v) => !v)}
+            icon={
+              <ChevronDown
+                className={cn(
+                  'size-3.5 transition-transform',
+                  expanded ? 'rotate-0' : '-rotate-90',
+                )}
+              />
+            }
+          >
+            View errors ({sync.row_errors.length})
+          </CustomButton>
+
+          <AnimatePresence initial={false}>
+            {expanded && (
+              <motion.div
+                key="errors"
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: 'auto', opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: reduceMotion ? 0 : 0.2, ease: 'easeOut' }}
+                className="overflow-hidden"
+              >
+                <div className="pt-2">
+                  <SyncErrorTable rowErrors={sync.row_errors} syncId={sync.id} />
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      )}
+    </div>
+  );
+}
+
+type StatTone = 'created' | 'updated' | 'skipped' | 'failed';
+
+/** Quiet color coding; non-zero values are emphasized, zero values recede to muted. */
+const STAT_TONE: Record<StatTone, string> = {
+  created: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+  updated: 'bg-sky-50 text-sky-700 ring-sky-200',
+  skipped: 'bg-amber-50 text-amber-700 ring-amber-200',
+  failed: 'bg-red-50 text-red-700 ring-red-200',
+};
+
+function StatChip({ label, value, tone }: { label: string; value: number; tone: StatTone }) {
+  const active = value > 0;
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium ring-1 ring-inset',
+        active ? STAT_TONE[tone] : 'bg-muted/50 text-muted-foreground ring-transparent',
+      )}
+    >
+      <span className="tabular-nums">{value}</span>
+      <span className={cn('font-normal', active ? undefined : 'text-muted-foreground')}>
+        {label}
+      </span>
+    </span>
+  );
+}

--- a/frontend/src/app/(dashboard)/layout.tsx
+++ b/frontend/src/app/(dashboard)/layout.tsx
@@ -95,6 +95,7 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
   // sidebar/chrome while inside them.
   const isFocused =
     pathname.startsWith('/settings') ||
+    pathname.startsWith('/contacts') ||
     pathname.startsWith('/agents/create') ||
     pathname.startsWith('/agents/edit') ||
     /^\/workflows\/[^/]+/.test(pathname) ||

--- a/frontend/src/components/agents/AgentEditorShell.tsx
+++ b/frontend/src/components/agents/AgentEditorShell.tsx
@@ -193,7 +193,14 @@ export default function AgentEditorShell({ agentType, agentId, children }: Agent
     [guardedAction, isInternalNav, router],
   );
   const navContextValue = useMemo(() => ({ safeNavigate }), [safeNavigate]);
-  const navGroups = useMemo(() => buildAgentNav(basePath, mode), [basePath, mode]);
+  // Gate call-mode-specific sections (e.g. Contacts) on the LIVE form value so
+  // the rail updates the moment the user toggles outbound in Basics; fall back
+  // to the URL-derived direction before the form has hydrated.
+  const callMode = (watchedValues.agent_type as AgentDirection | undefined) ?? agentType;
+  const navGroups = useMemo(
+    () => buildAgentNav(basePath, mode, callMode),
+    [basePath, mode, callMode],
+  );
   const flatItems = useMemo(() => navGroups.flatMap((g) => g.items), [navGroups]);
 
   /** Push a freshly-loaded AgentDetail into local state + the RHF form.
@@ -803,10 +810,10 @@ export default function AgentEditorShell({ agentType, agentId, children }: Agent
   // providers mounted so the agent's unsaved state survives the round-trip and
   // returning to a section counts as internal navigation (no discard prompt).
   const isBuilderRoute = /\/workflow\/[^/]+$/.test(pathname);
-  // Call History hosts the full call-log table + filter toolbar — it needs the
+  // Call History and Contacts host full-width tables + toolbars — they need the
   // entire content width. The form sections (Basics, Prompt, …) stay in the
   // narrow, centered max-w-3xl column that reads better for forms.
-  const isWideSection = /\/call-history$/.test(pathname);
+  const isWideSection = /\/(call-history|contacts)$/.test(pathname);
   if (isBuilderRoute) {
     return (
       <FormProvider {...methods}>

--- a/frontend/src/components/agents/AgentSectionBody.tsx
+++ b/frontend/src/components/agents/AgentSectionBody.tsx
@@ -11,6 +11,7 @@ import PromptStep from '@/components/agents/agent-form/steps/PromptStep';
 import ToolsMcpStep from '@/components/agents/agent-form/steps/ToolsMcpStep';
 import VoiceStep from '@/components/agents/agent-form/steps/VoiceStep';
 import ChannelsStep from '@/components/agents/agent-form/steps/ChannelsStep';
+import ContactsStep from '@/components/agents/agent-form/steps/ContactsStep';
 import CallHistoryStep from '@/components/agents/agent-form/steps/CallHistoryStep';
 
 // Maps a URL section segment to its body. Shared by the edit and create
@@ -35,8 +36,11 @@ export default function AgentSectionBody({
     section === 'tools' ||
     section === 'knowledge' ||
     section === 'channels';
-  // Overview and Call History only exist for a saved agent (edit mode).
-  const known = isStep || ((section === 'overview' || section === 'call-history') && !!agentId);
+  // Overview, Call History, and Contacts only exist for a saved agent (edit
+  // mode) — Contacts (C-5) needs a persisted agent_id to assign against.
+  const known =
+    isStep ||
+    ((section === 'overview' || section === 'call-history' || section === 'contacts') && !!agentId);
 
   // Bad/unknown section in the URL → bounce to a sensible default.
   useEffect(() => {
@@ -64,6 +68,8 @@ export default function AgentSectionBody({
       return <KnowledgePhoneStep agentId={agentId} />;
     case 'channels':
       return <ChannelsStep />;
+    case 'contacts':
+      return <ContactsStep agentId={agentId} />;
     case 'call-history':
       return <CallHistoryStep agentId={agentId} />;
     default:

--- a/frontend/src/components/agents/agent-form/sectionNav.ts
+++ b/frontend/src/components/agents/agent-form/sectionNav.ts
@@ -6,11 +6,13 @@ import {
   LayoutGrid,
   MessageSquare,
   Radio,
+  Users,
   Volume2,
   Wrench,
 } from 'lucide-react';
 
 import type { SidebarNavGroup } from '@/components/layout/SidebarShell';
+import type { AgentDirection } from '@/types/agent';
 
 // Single source of truth for the agent editor's configuration sections. The
 // editor rail (AgentEditorShell) and the routed section pages both derive from
@@ -35,11 +37,28 @@ export const AGENT_SECTIONS: AgentSection[] = [
   { key: 'tools', label: 'Tools & MCP', icon: Wrench },
   { key: 'knowledge', label: 'Knowledge', icon: Book },
   { key: 'channels', label: 'Channels', icon: Radio },
+  { key: 'contacts', label: 'Contacts', icon: Users },
   { key: 'call-history', label: 'Call History', icon: Clock },
 ];
 
-/** Sections shown only for a saved agent (edit mode) — omitted while creating. */
-const EDIT_ONLY_SECTION_KEYS = new Set<string>(['call-history']);
+/**
+ * Sections shown only for a saved agent (edit mode) — omitted while creating.
+ * `contacts` (C-5): assigning contacts needs a persisted `agent_id`, which only
+ * exists after the agent is saved, so the tab must not render in create mode.
+ */
+const EDIT_ONLY_SECTION_KEYS = new Set<string>(['call-history', 'contacts']);
+
+/**
+ * Sections gated on the agent's call mode. `contacts` only makes sense for agents
+ * that place outbound calls (`outbound` or `both`) — an inbound-only agent never
+ * dials a contact, so the tab is hidden for it.
+ */
+const OUTBOUND_ONLY_SECTION_KEYS = new Set<string>(['contacts']);
+
+/** True when the agent handles outbound calls (`outbound` or `both`). */
+function handlesOutbound(callMode: AgentDirection): boolean {
+  return callMode === 'outbound' || callMode === 'both';
+}
 
 export const AGENT_SECTION_KEYS = AGENT_SECTIONS.map((s) => s.key);
 
@@ -49,14 +68,23 @@ export const DEFAULT_SECTION = { edit: 'overview', create: 'basics' } as const;
 /**
  * Build the rail nav for the agent editor. `edit` mode prepends an "Overview"
  * entry (a saved agent has something to summarise); `create` mode omits it.
+ *
+ * `callMode` is the agent's current call direction (live form value in the
+ * editor). Sections in `OUTBOUND_ONLY_SECTION_KEYS` (e.g. `contacts`) are shown
+ * only when the agent handles outbound calls (`outbound`/`both`).
  */
-export function buildAgentNav(basePath: string, mode: 'edit' | 'create'): SidebarNavGroup[] {
+export function buildAgentNav(
+  basePath: string,
+  mode: 'edit' | 'create',
+  callMode: AgentDirection,
+): SidebarNavGroup[] {
   const items = [];
   if (mode === 'edit') {
     items.push({ label: 'Overview', href: `${basePath}/overview`, icon: LayoutGrid });
   }
   for (const s of AGENT_SECTIONS) {
     if (mode === 'create' && EDIT_ONLY_SECTION_KEYS.has(s.key)) continue;
+    if (OUTBOUND_ONLY_SECTION_KEYS.has(s.key) && !handlesOutbound(callMode)) continue;
     items.push({ label: s.label, href: `${basePath}/${s.key}`, icon: s.icon });
   }
   return [{ heading: null, items }];

--- a/frontend/src/components/agents/agent-form/steps/BasicsStep.tsx
+++ b/frontend/src/components/agents/agent-form/steps/BasicsStep.tsx
@@ -1,13 +1,22 @@
 'use client';
 
-import { MessageCircle, Power, User2 } from 'lucide-react';
+import { MessageCircle, PhoneCall, Power, User2 } from 'lucide-react';
 import { Controller, useFormContext } from 'react-hook-form';
 
 import SectionCard, { ACCENTS } from '@/components/agents/agent-form/SectionCard';
-import { TextAreaField, TextInput } from '@/components/shared';
+import { CheckboxField, TextAreaField, TextInput } from '@/components/shared';
 import { Switch } from '@/components/ui/switch';
-import type { AgentFormState } from '@/types/agent';
+import type { AgentDirection, AgentFormState } from '@/types/agent';
 import { cn } from '@/utils/cn';
+
+/** Two booleans → the persisted agent_type. Returns null when neither is set, so the
+ *  caller can block clearing both (at least one call mode is required). */
+function deriveAgentType(inbound: boolean, outbound: boolean): AgentDirection | null {
+  if (inbound && outbound) return 'both';
+  if (inbound) return 'inbound';
+  if (outbound) return 'outbound';
+  return null;
+}
 
 export default function BasicsStep() {
   const { control } = useFormContext<AgentFormState>();
@@ -63,6 +72,46 @@ export default function BasicsStep() {
           helperText="Message sent at the end of a conversation."
         />
       </SectionCard>
+
+      <Controller
+        name="agent_type"
+        control={control}
+        render={({ field }) => {
+          const value = (field.value as AgentDirection) ?? 'inbound';
+          const inbound = value === 'inbound' || value === 'both';
+          const outbound = value === 'outbound' || value === 'both';
+          return (
+            <SectionCard
+              icon={<PhoneCall className="size-3.5" strokeWidth={2.25} />}
+              iconClassName={ACCENTS.indigo}
+              title="Call mode"
+              description="Which call directions this agent handles. Outbound (or Both) unlocks scheduling calls to contacts."
+            >
+              <div className="flex flex-col gap-3">
+                <CheckboxField
+                  id="agent-mode-inbound"
+                  label="Inbound — answers incoming calls"
+                  checked={inbound}
+                  onCheckedChange={(v) => {
+                    const next = deriveAgentType(!!v, outbound);
+                    if (next) field.onChange(next);
+                  }}
+                />
+                <CheckboxField
+                  id="agent-mode-outbound"
+                  label="Outbound — places calls to contacts"
+                  checked={outbound}
+                  onCheckedChange={(v) => {
+                    const next = deriveAgentType(inbound, !!v);
+                    if (next) field.onChange(next);
+                  }}
+                />
+                <p className="text-xs text-muted-foreground">At least one call mode is required.</p>
+              </div>
+            </SectionCard>
+          );
+        }}
+      />
 
       <Controller
         name="is_active"

--- a/frontend/src/components/agents/agent-form/steps/ContactsStep.tsx
+++ b/frontend/src/components/agents/agent-form/steps/ContactsStep.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { Plus, Trash2, Upload, UserPlus, Users } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { useAgentContactsList, useUnassignContacts } from '@/lib/api/agentContacts';
+import { CustomButton } from '@/components/shared';
+import AddContactsModal from '@/components/contacts/general/AddContactsModal';
+import AssignContactsModal from '@/components/contacts/shared/AssignContactsModal';
+import ConfirmDeleteModal from '@/components/contacts/shared/ConfirmDeleteModal';
+import ContactsTable from '@/components/contacts/shared/ContactsTable';
+import SyncContactsModal from '@/components/contacts/shared/SyncContactsModal';
+import type { AgentContactRow } from '@/types/agentContact';
+import type { CustomTableColumn } from '@/types/components';
+import type { PaginatedListParams } from '@/types/contactList';
+import { handleApiError } from '@/utils/helpers';
+import { showToast } from '@/utils/toast';
+
+export default function ContactsStep({ agentId }: { agentId: string | null }) {
+  const [params, setParams] = useState<PaginatedListParams>({ page_no: 1, page_size: 10 });
+  const [assignOpen, setAssignOpen] = useState(false);
+  const [addContactOpen, setAddContactOpen] = useState(false);
+  const [syncOpen, setSyncOpen] = useState(false);
+  const [unassignTarget, setUnassignTarget] = useState<AgentContactRow | null>(null);
+
+  const { data, isLoading, refetch } = useAgentContactsList(agentId, params);
+  const unassign = useUnassignContacts(agentId ?? '');
+
+  const columns = useMemo<CustomTableColumn<AgentContactRow>[]>(
+    () => [
+      {
+        key: 'name',
+        title: 'Name',
+        dataIndex: 'name',
+        render: (_v, row) => row.name ?? <span className="text-muted-foreground">—</span>,
+      },
+      {
+        key: 'phone_number',
+        title: 'Phone',
+        dataIndex: 'phone_number',
+        render: (_v, row) => row.phone_number ?? <span className="text-muted-foreground">—</span>,
+      },
+      {
+        key: 'actions',
+        title: '',
+        align: 'right',
+        render: (_v, row) => (
+          <CustomButton
+            type="text"
+            size="icon-sm"
+            aria-label={`Unassign ${row.name ?? row.phone_number ?? 'contact'}`}
+            onClick={() => setUnassignTarget(row)}
+            icon={<Trash2 className="size-4 text-muted-foreground" />}
+          />
+        ),
+      },
+    ],
+    [],
+  );
+
+  if (!agentId) return null;
+
+  const rows = data?.data ?? [];
+  const total = data?.total ?? 0;
+
+  const confirmUnassign = async () => {
+    if (!unassignTarget) return;
+    try {
+      await unassign.mutateAsync([unassignTarget.id]);
+      showToast.success('Contact unassigned.');
+      setUnassignTarget(null);
+      refetch();
+    } catch (err) {
+      handleApiError(err);
+    }
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-4">
+      <ContactsTable<AgentContactRow>
+        columns={columns}
+        data={rows}
+        rowKey={(row) => row.assignment_id}
+        loading={isLoading}
+        total={total}
+        page={params.page_no ?? 1}
+        pageSize={params.page_size ?? 10}
+        onPageChange={(page, pageSize) =>
+          setParams((p) => ({ ...p, page_no: page, page_size: pageSize }))
+        }
+        searchValue={params.search ?? ''}
+        onSearchChange={(search) => setParams((p) => ({ ...p, search, page_no: 1 }))}
+        searchPlaceholder="Search assigned contacts…"
+        sort={params.sort_by ? { field: params.sort_by, order: params.sort_order ?? 'asc' } : null}
+        onSortChange={(sort) =>
+          setParams((p) => ({
+            ...p,
+            sort_by: sort?.field,
+            sort_order: sort?.order,
+            page_no: 1,
+          }))
+        }
+        emptyState={
+          <div className="flex flex-col items-center gap-2 py-10 text-center">
+            <Users className="size-8 text-muted-foreground" aria-hidden />
+            <p className="text-sm font-medium">No contacts assigned</p>
+            <p className="text-xs text-muted-foreground">
+              Assign contacts from a directory or import a CSV to get started.
+            </p>
+          </div>
+        }
+        toolbar={
+          <div className="flex items-center gap-2">
+            <CustomButton
+              type="default"
+              size="sm"
+              icon={<Plus className="size-4" />}
+              onClick={() => setAddContactOpen(true)}
+            >
+              Add contacts
+            </CustomButton>
+            <CustomButton
+              type="default"
+              size="sm"
+              icon={<Upload className="size-4" />}
+              onClick={() => setSyncOpen(true)}
+            >
+              Sync contacts
+            </CustomButton>
+            <CustomButton
+              type="primary"
+              size="sm"
+              icon={<UserPlus className="size-4" />}
+              onClick={() => setAssignOpen(true)}
+            >
+              Assign contacts
+            </CustomButton>
+          </div>
+        }
+      />
+
+      <AssignContactsModal
+        open={assignOpen}
+        onClose={() => setAssignOpen(false)}
+        agentId={agentId}
+        onAssigned={() => refetch()}
+      />
+
+      <AddContactsModal
+        open={addContactOpen}
+        onClose={() => setAddContactOpen(false)}
+        agentId={agentId}
+        onCompleted={() => refetch()}
+      />
+
+      <SyncContactsModal
+        open={syncOpen}
+        onClose={() => setSyncOpen(false)}
+        agentId={agentId}
+        onCompleted={() => refetch()}
+      />
+
+      <ConfirmDeleteModal
+        open={!!unassignTarget}
+        onClose={() => setUnassignTarget(null)}
+        onConfirm={confirmUnassign}
+        title="Unassign contact"
+        description="This removes the contact from this agent. The contact itself is not deleted."
+        confirmText="Unassign"
+        loading={unassign.isPending}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/call-history/CallHistory.tsx
+++ b/frontend/src/components/call-history/CallHistory.tsx
@@ -85,6 +85,7 @@ const COLUMN_GROUPS: Array<{
       { key: 'duration_seconds', label: 'Duration' },
       { key: 'from_number', label: 'From' },
       { key: 'to_number', label: 'To' },
+      { key: 'provider_call_id', label: 'Call SID' },
       { key: 'started_at', label: 'Started At' },
       { key: 'ended_at', label: 'Ended At' },
     ],
@@ -446,6 +447,15 @@ const CallHistory: React.FC<{ agentId?: string }> = ({ agentId }) => {
       render: (value) => {
         const num = value as string | null;
         return num ? <PhoneNumberDisplay phoneNumber={num} flagSize="sm" /> : '-';
+      },
+    },
+    {
+      key: 'provider_call_id',
+      title: 'Call SID',
+      dataIndex: 'provider_call_id',
+      render: (value) => {
+        const sid = value as string | null;
+        return sid ? <span className="font-mono text-xs text-muted-foreground">{sid}</span> : '-';
       },
     },
     {

--- a/frontend/src/components/contacts/ContactDirectoryRail.tsx
+++ b/frontend/src/components/contacts/ContactDirectoryRail.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { FolderOpen, Plus } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import DirectoryFormModal from '@/components/contacts/DirectoryFormModal';
+import { CustomButton, CustomTooltip, SearchBar } from '@/components/shared';
+import { useDirectoriesList } from '@/lib/api/contactDirectories';
+import { cn } from '@/lib/utils';
+import { useAuthStore } from '@/stores/auth';
+import type { ContactDirectory, ContactDirectoryListItem } from '@/types/contactDirectory';
+
+/**
+ * Left rail of the Contacts master-detail shell (~300px).
+ *
+ * WHAT: a searchable, selectable list of the org's contact directories. Each row
+ * shows the directory name (truncated + tooltip on overflow) and a live
+ * contact-count badge; the active directory is highlighted with the same
+ * treatment the app sidebar uses for its active item. Admins/owners get a
+ * "New Directory" button; on create the new directory is selected. Empty and
+ * loading (skeleton) states are handled inline.
+ *
+ * WHEN: rendered once by `ContactsMasterDetail` and kept mounted across detail
+ * navigation so its scroll position + selection survive back-navigation.
+ */
+export interface ContactDirectoryRailProps {
+  /** The directory id currently open in the detail pane (null on the placeholder). */
+  activeDirectoryId: string | null;
+  /** Navigate to a directory's detail pane. */
+  onSelect: (directoryId: string) => void;
+}
+
+const ROW_BASE =
+  'group flex w-full cursor-pointer items-center gap-2 rounded-lg px-2.5 py-2 text-left text-sm transition-colors';
+
+export default function ContactDirectoryRail({
+  activeDirectoryId,
+  onSelect,
+}: ContactDirectoryRailProps) {
+  const user = useAuthStore((s) => s.user);
+  const isAdminOrOwner = user?.role === 'admin' || user?.role === 'owner';
+
+  const [search, setSearch] = useState('');
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const { data, isLoading, isError } = useDirectoriesList({
+    // Backend caps page_size at 100 (ListDirectoriesRequest: le=100); 200 → 422.
+    search: search || undefined,
+    page_size: 100,
+    sort_by: 'name',
+    sort_order: 'asc',
+  });
+
+  const directories = useMemo<ContactDirectoryListItem[]>(() => data?.data ?? [], [data]);
+
+  const handleCreated = (directory: ContactDirectory) => {
+    onSelect(directory.id);
+  };
+
+  return (
+    <div className="flex h-full min-h-0 w-full flex-col">
+      <div className="flex shrink-0 flex-col gap-3 border-b border-border px-4 py-3.5">
+        <div className="flex items-center justify-between gap-2">
+          <h2 className="text-[15px] font-semibold tracking-tight text-foreground">Directories</h2>
+          {isAdminOrOwner && (
+            <CustomButton
+              type="primary"
+              size="sm"
+              icon={<Plus className="size-4" />}
+              onClick={() => setCreateOpen(true)}
+            >
+              New
+            </CustomButton>
+          )}
+        </div>
+        <SearchBar
+          value={search}
+          onSearch={setSearch}
+          placeholder="Search directories..."
+          containerClassName="max-w-none"
+        />
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {isLoading ? (
+          <RailSkeleton />
+        ) : isError ? (
+          <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+            Couldn&apos;t load directories.
+          </p>
+        ) : directories.length === 0 ? (
+          <EmptyState
+            searching={!!search}
+            canCreate={isAdminOrOwner}
+            onCreate={() => setCreateOpen(true)}
+          />
+        ) : (
+          <ul className="flex flex-col gap-0.5">
+            {directories.map((directory) => (
+              <li key={directory.id}>
+                <DirectoryRow
+                  directory={directory}
+                  active={directory.id === activeDirectoryId}
+                  onSelect={() => onSelect(directory.id)}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <DirectoryFormModal
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onSaved={handleCreated}
+      />
+    </div>
+  );
+}
+
+function DirectoryRow({
+  directory,
+  active,
+  onSelect,
+}: {
+  directory: ContactDirectoryListItem;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-current={active ? 'true' : undefined}
+      className={cn(
+        ROW_BASE,
+        active
+          ? 'bg-sidebar-accent font-medium text-foreground'
+          : 'text-foreground/85 hover:bg-sidebar-accent/60',
+      )}
+    >
+      <FolderOpen
+        className={cn('size-4 shrink-0', active ? 'text-primary' : 'text-muted-foreground')}
+        strokeWidth={1.75}
+      />
+      <CustomTooltip content={directory.name}>
+        <span className="min-w-0 flex-1 truncate">{directory.name}</span>
+      </CustomTooltip>
+      <span
+        className={cn(
+          'shrink-0 rounded-full px-1.5 py-0.5 text-[11px] font-medium tabular-nums',
+          active ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground',
+        )}
+      >
+        {directory.contact_count}
+      </span>
+    </button>
+  );
+}
+
+function EmptyState({
+  searching,
+  canCreate,
+  onCreate,
+}: {
+  searching: boolean;
+  canCreate: boolean;
+  onCreate: () => void;
+}) {
+  if (searching) {
+    return (
+      <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+        No directories match your search.
+      </p>
+    );
+  }
+  return (
+    <div className="flex flex-col items-center gap-3 px-4 py-10 text-center">
+      <div className="flex size-12 items-center justify-center rounded-full bg-muted/60">
+        <FolderOpen className="size-6 text-muted-foreground/60" strokeWidth={1.5} />
+      </div>
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-foreground">No directories yet</p>
+        <p className="text-xs text-muted-foreground">Create one to start organizing contacts.</p>
+      </div>
+      {canCreate && (
+        <CustomButton
+          type="primary"
+          size="sm"
+          icon={<Plus className="size-4" />}
+          onClick={onCreate}
+        >
+          Create directory
+        </CustomButton>
+      )}
+    </div>
+  );
+}
+
+function RailSkeleton() {
+  return (
+    <ul className="flex flex-col gap-0.5" aria-hidden>
+      {Array.from({ length: 6 }).map((_, i) => (
+        <li key={i} className="flex items-center gap-2 px-2.5 py-2">
+          <div className="size-4 shrink-0 animate-pulse rounded bg-muted" />
+          <div className="h-3.5 flex-1 animate-pulse rounded bg-muted" />
+          <div className="h-4 w-6 shrink-0 animate-pulse rounded-full bg-muted" />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/components/contacts/ContactsMasterDetail.tsx
+++ b/frontend/src/components/contacts/ContactsMasterDetail.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+import { useParams, useRouter } from 'next/navigation';
+
+import ContactDirectoryRail from '@/components/contacts/ContactDirectoryRail';
+import { CustomButton } from '@/components/shared';
+import { cn } from '@/lib/utils';
+
+/**
+ * Two-pane responsive shell for the Contacts master-detail experience.
+ *
+ * WHAT: renders the persistent `ContactDirectoryRail` alongside a right-pane
+ * slot (`children` — the detail route or the "select a directory" placeholder).
+ * At ≥1024px both panes are visible side-by-side. Below 1024px it collapses to
+ * a single pane: the rail shows when no directory is selected, and the detail
+ * (with a "Back to directories" control) shows when one is. Selecting a rail
+ * item navigates to `/contacts/directories/[id]`, which is the single source of
+ * truth for the active directory — the rail stays mounted so its scroll +
+ * selection survive back-navigation.
+ *
+ * WHEN: rendered by `contacts/directories/layout.tsx` to wrap every
+ * `/contacts/directories/*` route.
+ */
+export interface ContactsMasterDetailProps {
+  children: React.ReactNode;
+}
+
+export default function ContactsMasterDetail({ children }: ContactsMasterDetailProps) {
+  const router = useRouter();
+  const params = useParams<{ directoryId?: string }>();
+  const activeDirectoryId = params?.directoryId ?? null;
+
+  const handleSelect = (directoryId: string) => {
+    router.push(`/contacts/directories/${directoryId}`);
+  };
+
+  return (
+    <div className="flex h-full min-h-0 w-full min-w-0 overflow-hidden bg-card">
+      {/* Left rail — full width on mobile until a directory is selected. */}
+      <aside
+        className={cn(
+          'min-h-0 shrink-0 border-border lg:flex lg:w-[300px] lg:border-r',
+          activeDirectoryId ? 'hidden lg:flex' : 'flex w-full',
+        )}
+      >
+        <ContactDirectoryRail activeDirectoryId={activeDirectoryId} onSelect={handleSelect} />
+      </aside>
+
+      {/* Right pane — hidden on mobile until a directory is selected. */}
+      <section
+        className={cn(
+          'min-h-0 min-w-0 flex-1 flex-col',
+          activeDirectoryId ? 'flex' : 'hidden lg:flex',
+        )}
+      >
+        {activeDirectoryId && (
+          <div className="shrink-0 border-b border-border px-4 py-2 lg:hidden">
+            <CustomButton
+              type="text"
+              size="sm"
+              icon={<ArrowLeft className="size-4" />}
+              onClick={() => router.push('/contacts/directories')}
+            >
+              Directories
+            </CustomButton>
+          </div>
+        )}
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">{children}</div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/contacts/DirectoryDetailHeader.tsx
+++ b/frontend/src/components/contacts/DirectoryDetailHeader.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { ChevronRight, Pencil, Trash2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import ConfirmDeleteModal from '@/components/contacts/shared/ConfirmDeleteModal';
+import DirectoryFormModal from '@/components/contacts/DirectoryFormModal';
+import { CustomButton } from '@/components/shared';
+import {
+  useDeleteDirectory,
+  useDirectory,
+  useDirectoryDeleteImpact,
+} from '@/lib/api/contactDirectories';
+import { useAuthStore } from '@/stores/auth';
+import type { DirectoryDeleteImpact } from '@/types/contactDirectory';
+import { handleApiError } from '@/utils/helpers';
+import { showToast } from '@/utils/toast';
+
+/**
+ * Right-pane header for a single directory.
+ *
+ * WHAT: shows the directory name, a `Directories › {name}` breadcrumb, and edit +
+ * delete actions (admin/owner only). Delete opens `ConfirmDeleteModal` with the
+ * `delete-impact` blast radius (permanent-deletion warning) before calling the
+ * hard-delete endpoint, then navigates back to `/contacts/directories`. Datasource
+ * schemas are now a section inside Contacts (`/contacts/datasource`), so this header no
+ * longer carries a General/Schema tab — a directory detail shows only its contacts.
+ *
+ * WHEN: rendered by the directory-detail (General) route page.
+ */
+export interface DirectoryDetailHeaderProps {
+  directoryId: string;
+}
+
+export default function DirectoryDetailHeader({ directoryId }: DirectoryDetailHeaderProps) {
+  const router = useRouter();
+  const user = useAuthStore((s) => s.user);
+  const isAdminOrOwner = user?.role === 'admin' || user?.role === 'owner';
+
+  const { data: directory } = useDirectory(directoryId);
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const deleteDirectory = useDeleteDirectory();
+  // Fetched lazily only while the confirm modal is open.
+  const { data: impact, isLoading: impactLoading } = useDirectoryDeleteImpact(
+    deleteOpen ? directoryId : null,
+  );
+
+  const name = directory?.name ?? '';
+
+  const handleDelete = async () => {
+    try {
+      await deleteDirectory.mutateAsync(directoryId);
+      showToast.success(
+        'Directory deleted',
+        name ? `"${name}" was permanently deleted.` : undefined,
+      );
+      setDeleteOpen(false);
+      router.replace('/contacts/directories');
+    } catch (error) {
+      handleApiError(error);
+    }
+  };
+
+  return (
+    <div className="flex shrink-0 flex-col gap-3 border-b border-border px-6 py-5">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <nav
+            aria-label="Breadcrumb"
+            className="flex items-center gap-1 text-xs text-muted-foreground"
+          >
+            <span>Directories</span>
+            <ChevronRight className="size-3.5" />
+            <span className="truncate text-foreground/80">{name || '…'}</span>
+          </nav>
+          <h1 className="mt-1 truncate text-xl font-semibold text-foreground">{name || '…'}</h1>
+        </div>
+
+        {isAdminOrOwner && (
+          <div className="flex shrink-0 items-center gap-2">
+            <CustomButton
+              type="default"
+              size="sm"
+              icon={<Pencil className="size-3.5" />}
+              onClick={() => setEditOpen(true)}
+            >
+              Edit
+            </CustomButton>
+            <CustomButton
+              type="danger"
+              size="sm"
+              icon={<Trash2 className="size-3.5" />}
+              onClick={() => setDeleteOpen(true)}
+            >
+              Delete
+            </CustomButton>
+          </div>
+        )}
+      </div>
+
+      <DirectoryFormModal
+        open={editOpen}
+        onClose={() => setEditOpen(false)}
+        directory={directory ?? null}
+      />
+
+      <ConfirmDeleteModal
+        open={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={handleDelete}
+        title="Delete directory"
+        description="This directory and its data will be permanently deleted. This cannot be undone."
+        confirmText="Permanently delete"
+        loading={deleteDirectory.isPending}
+        confirmDisabled={impactLoading}
+        impact={<DeleteImpactSummary impact={impact} loading={impactLoading} />}
+      />
+    </div>
+  );
+}
+
+function DeleteImpactSummary({
+  impact,
+  loading,
+}: {
+  impact: DirectoryDeleteImpact | undefined;
+  loading: boolean;
+}) {
+  if (loading || !impact) {
+    return <p className="text-sm text-muted-foreground">Calculating impact…</p>;
+  }
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-sm font-medium text-foreground">
+        The following will be permanently deleted:
+      </p>
+      <ul className="list-disc space-y-1 pl-5 text-sm text-muted-foreground">
+        <li>
+          <span className="font-medium text-foreground">{impact.contacts}</span> contacts
+        </li>
+        <li>
+          <span className="font-medium text-foreground">{impact.agent_contacts}</span> agent
+          assignments
+        </li>
+        <li>
+          <span className="font-medium text-foreground">{impact.scheduled_calls}</span> scheduled
+          calls
+        </li>
+      </ul>
+      <p className="text-sm text-muted-foreground">
+        <span className="font-medium text-foreground">{impact.syncs_detached}</span> sync
+        {impact.syncs_detached === 1 ? '' : 's'} will be detached (kept for audit). Reusable schemas
+        are kept.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/contacts/DirectoryFormModal.tsx
+++ b/frontend/src/components/contacts/DirectoryFormModal.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import { CustomModal, SelectInput, TextAreaField, TextInput } from '@/components/shared';
+import { useCreateDirectory, useUpdateDirectory } from '@/lib/api/contactDirectories';
+import { useSchemasList } from '@/lib/api/contactSchemas';
+import type { SelectOption } from '@/types/components';
+import type { ContactDirectory, UpdateDirectoryPayload } from '@/types/contactDirectory';
+import { handleApiError } from '@/utils/helpers';
+import { showToast } from '@/utils/toast';
+
+/**
+ * Create/edit form for a contact directory (name + description).
+ *
+ * WHAT: RHF + Zod modal that creates a new directory (from the rail's "New
+ * Directory" button) or edits an existing one (from the detail header's edit
+ * action). On success it invalidates the directory list/detail via the shared
+ * mutation hooks and fires a toast; the parent decides what to do next
+ * (`onSaved` receives the persisted directory — e.g. to navigate to a new one).
+ *
+ * WHEN: use for every directory create/edit surface so the validation + copy +
+ * toast handling stays in one place.
+ */
+const directoryFormSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, 'Name is required')
+    .max(120, 'Name must be 120 characters or fewer'),
+  description: z.string().trim().max(500, 'Description must be 500 characters or fewer').optional(),
+  // Optional org schema to use as this directory's default shape. No schema is
+  // auto-created per directory, so leaving this empty is fine (the directory just
+  // has no default until one is assigned).
+  default_schema_id: z.string().optional(),
+});
+
+type DirectoryFormValues = z.infer<typeof directoryFormSchema>;
+
+export interface DirectoryFormModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** When set, the modal is in edit mode and pre-fills from this directory. */
+  directory?: ContactDirectory | null;
+  /** Called after a successful create/update with the persisted directory. */
+  onSaved?: (directory: ContactDirectory) => void;
+}
+
+export default function DirectoryFormModal({
+  open,
+  onClose,
+  directory,
+  onSaved,
+}: DirectoryFormModalProps) {
+  const isEdit = !!directory;
+  const createDirectory = useCreateDirectory();
+  const updateDirectory = useUpdateDirectory();
+  const saving = createDirectory.isPending || updateDirectory.isPending;
+
+  // Org-level schemas the directory can pick as its default shape.
+  const schemasQuery = useSchemasList({ page_size: 100 });
+  const schemaOptions: SelectOption[] = (schemasQuery.data?.data ?? []).map((s) => ({
+    value: s.id,
+    label: s.name,
+  }));
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { isValid },
+  } = useForm<DirectoryFormValues>({
+    resolver: zodResolver(directoryFormSchema),
+    mode: 'onBlur',
+    defaultValues: { name: '', description: '', default_schema_id: '' },
+  });
+
+  // Re-seed the form each time the modal opens (or the target directory
+  // changes) so edit mode pre-fills and create mode starts clean.
+  useEffect(() => {
+    if (!open) return;
+    reset({
+      name: directory?.name ?? '',
+      description: directory?.description ?? '',
+      default_schema_id: directory?.default_schema_id ?? '',
+    });
+  }, [open, directory, reset]);
+
+  const onSubmit = handleSubmit(async (values) => {
+    const name = values.name.trim();
+    const description = values.description?.trim() ? values.description.trim() : null;
+    // Only send default_schema_id when the user picked one — on create the backend
+    // auto-provisions a default if omitted; on edit an empty value means "leave as-is".
+    const defaultSchemaId = values.default_schema_id?.trim() || null;
+    try {
+      let saved: ContactDirectory;
+      if (isEdit) {
+        const payload: UpdateDirectoryPayload = { name, description };
+        if (defaultSchemaId) payload.default_schema_id = defaultSchemaId;
+        saved = await updateDirectory.mutateAsync({ id: directory!.id, payload });
+      } else {
+        // No schema is auto-created; the user's optional pick is sent on create.
+        saved = await createDirectory.mutateAsync({
+          name,
+          description,
+          default_schema_id: defaultSchemaId,
+        });
+      }
+      showToast.success(
+        isEdit ? 'Directory updated' : 'Directory created',
+        `"${saved.name}" was ${isEdit ? 'updated' : 'created'}.`,
+      );
+      onSaved?.(saved);
+      onClose();
+    } catch (error) {
+      handleApiError(error);
+    }
+  });
+
+  return (
+    <CustomModal
+      open={open}
+      onClose={onClose}
+      title={isEdit ? 'Edit directory' : 'New directory'}
+      description={
+        isEdit
+          ? 'Update the name or description of this directory.'
+          : 'Create a directory to organize contacts and their datasource schema.'
+      }
+      confirmText={isEdit ? 'Save changes' : 'Create directory'}
+      confirmLoading={saving}
+      confirmDisabled={!isValid}
+      onConfirm={onSubmit}
+      width="sm:max-w-md"
+    >
+      <form onSubmit={onSubmit} className="flex flex-col gap-4">
+        <TextInput
+          control={control}
+          name="name"
+          label="Name"
+          placeholder="e.g. Q3 Leads"
+          autoFocus
+        />
+        <TextAreaField
+          control={control}
+          name="description"
+          label="Description"
+          placeholder="Optional — what this directory is for"
+          rows={3}
+        />
+        <SelectInput
+          control={control}
+          name="default_schema_id"
+          label="Default schema (optional)"
+          placeholder={schemasQuery.isLoading ? 'Loading schemas…' : 'None — assign a schema later'}
+          options={schemaOptions}
+          loading={schemasQuery.isLoading}
+        />
+      </form>
+    </CustomModal>
+  );
+}

--- a/frontend/src/components/contacts/contactsNav.ts
+++ b/frontend/src/components/contacts/contactsNav.ts
@@ -1,0 +1,27 @@
+import { History, Table2, Users } from 'lucide-react';
+
+import type { SidebarNavGroup, SidebarNavItem } from '@/components/layout/SidebarShell';
+
+// Single source of truth for the Contacts focused-section rail. Both the
+// contacts rail (contacts/layout.tsx desktop) and its mobile top bar derive
+// their navigation from this list so the two can never drift. Mirrors the
+// settings navConfig.ts shape.
+//
+// Distinct leading segments (`directories` vs `datasource`) mean
+// `isSidebarItemActive` highlights each item without collision — no `exact`
+// needed. `General` stays active across `/contacts/directories` and
+// `/contacts/directories/[id]`.
+
+export const CONTACTS_NAV_GROUPS: SidebarNavGroup[] = [
+  {
+    heading: null,
+    items: [
+      { label: 'General', href: '/contacts/directories', icon: Users },
+      { label: 'Datasource', href: '/contacts/datasource', icon: Table2 },
+      { label: 'Sync History', href: '/contacts/sync-history', icon: History },
+    ],
+  },
+];
+
+// Flat list of every contacts destination — used by the mobile nav.
+export const CONTACTS_NAV_ITEMS: SidebarNavItem[] = CONTACTS_NAV_GROUPS.flatMap((g) => g.items);

--- a/frontend/src/components/contacts/general/AddContactsModal.tsx
+++ b/frontend/src/components/contacts/general/AddContactsModal.tsx
@@ -1,0 +1,293 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useFieldArray, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Plus, Trash2 } from 'lucide-react';
+import { z } from 'zod';
+
+import { useCreateContacts } from '@/lib/api/contacts';
+import { useDirectoriesList } from '@/lib/api/contactDirectories';
+import { useSchema, useSchemasList } from '@/lib/api/contactSchemas';
+import { CustomButton, CustomModal, SelectInput } from '@/components/shared';
+import AdvancedDirectoryConfig from '@/components/contacts/shared/AdvancedDirectoryConfig';
+import SchemaDrivenContactForm from '@/components/contacts/shared/SchemaDrivenContactForm';
+import { buildContactFormSchema } from '@/components/contacts/shared/buildContactFormSchema';
+import type { ContactRowPayload, CreateContactFailure } from '@/types/contact';
+import { handleApiError } from '@/utils/helpers';
+import { showToast } from '@/utils/toast';
+
+/**
+ * Multi-row "Add contact(s)" modal — shared by BOTH the directory General view and the
+ * agent Contacts tab (one modal, one create endpoint).
+ *
+ * WHAT: renders N repeatable rows of `SchemaDrivenContactForm` (driven by the directory's
+ * default-schema fields) and submits them as a bulk create. Handles the C-7 partial
+ * response `{ created, failed }`: on any failures it toasts the created count and KEEPS
+ * the modal open, highlighting the failed rows with their inline `errors`; it only closes
+ * (and reports success) once every submitted row was created.
+ *
+ * TWO CONTEXTS:
+ * - Directory General: pass `directoryId` (+ `defaultSchemaId`). Behaves as before — no
+ *   directory picker, the schema selector stays.
+ * - Agent Contacts tab: pass `agentId` and NO `directoryId`. A directory picker appears so
+ *   the user chooses which directory to create the contact in; the create request carries
+ *   `agent_id`, so the backend also ASSIGNS the created contacts to that agent.
+ */
+export interface AddContactsModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Directory to create into (General view). Omit in the agent-tab context. */
+  directoryId?: string;
+  /** When set (and `directoryId` omitted), created contacts are assigned to this agent. */
+  agentId?: string;
+  /** The directory's default schema id — preselected in the schema picker. */
+  defaultSchemaId?: string | null;
+  /** Called after every submitted row lands, so the parent can refresh its list. */
+  onCompleted?: () => void;
+}
+
+/** A single blank row seed (name + phone + an empty metadata bag). */
+function emptyRow(): { name: string; phone_number: string; metadata: Record<string, unknown> } {
+  return { name: '', phone_number: '', metadata: {} };
+}
+
+export default function AddContactsModal({
+  open,
+  onClose,
+  directoryId,
+  agentId,
+  defaultSchemaId,
+  onCompleted,
+}: AddContactsModalProps) {
+  // Agent-tab context: no fixed directory, but an agent to assign the created contacts to.
+  const isAgentContext = !directoryId && !!agentId;
+
+  // Directory picker (agent context only) — fetch a wide page so all directories are
+  // selectable; the query is cheap and shared via TanStack Query.
+  const directoriesQuery = useDirectoriesList({ page_size: 100 });
+  const directoryOptions = (directoriesQuery.data?.data ?? []).map((d) => ({
+    value: d.id,
+    label: d.name,
+  }));
+
+  // The org's seeded "Global" directory is the default target in the agent context —
+  // resolved BY NAME from the normal directories list (there is no /global endpoint).
+  const globalDirectory = directoriesQuery.data?.data?.find((d) => d.name === 'Global');
+
+  const [pickedDirectoryId, setPickedDirectoryId] = useState<string>('');
+  // The directory we actually create into: the fixed prop, or the user's pick.
+  const effectiveDirectoryId = directoryId ?? pickedDirectoryId;
+
+  const createContacts = useCreateContacts(effectiveDirectoryId);
+
+  const schemasQuery = useSchemasList({ page_size: 100 });
+  const schemaOptions = (schemasQuery.data?.data ?? []).map((s) => ({
+    value: s.id,
+    label: s.name,
+  }));
+
+  const [schemaId, setSchemaId] = useState<string>(defaultSchemaId ?? '');
+  const { data: schemaDetail } = useSchema(schemaId || null);
+  const fields = useMemo(() => schemaDetail?.fields ?? [], [schemaDetail]);
+
+  const formSchema = useMemo(
+    () => z.object({ rows: z.array(buildContactFormSchema(fields)) }),
+    [fields],
+  );
+  type FormValues = z.infer<typeof formSchema>;
+
+  const { control, handleSubmit, reset } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { rows: [emptyRow()] },
+  });
+  const { fields: rowFields, append, remove } = useFieldArray({ control, name: 'rows' });
+
+  const [rowErrors, setRowErrors] = useState<Record<number, string[]>>({});
+
+  useEffect(() => {
+    if (open) {
+      setSchemaId(defaultSchemaId ?? '');
+      // The directory is seeded by the dedicated effect below once the directories arrive,
+      // so we don't touch `pickedDirectoryId` here — that would wipe typed rows when the
+      // directories query resolves late.
+      reset({ rows: [emptyRow()] });
+      setRowErrors({});
+    }
+  }, [open, defaultSchemaId, reset]);
+
+  // Once the directories list arrives (agent context), default the pick to "Global" if the
+  // user hasn't chosen one yet. If no "Global" exists, the pick stays empty and the user
+  // expands Advanced configuration to choose a directory.
+  useEffect(() => {
+    if (open && isAgentContext && !pickedDirectoryId && globalDirectory) {
+      setPickedDirectoryId(globalDirectory.id);
+    }
+  }, [open, isAgentContext, pickedDirectoryId, globalDirectory]);
+
+  // Changing the schema swaps the metadata field set but PRESERVES what the user already
+  // typed — name/phone always apply, and any metadata for fields not in the new schema is
+  // simply ignored on submit (Zod strips unknown keys), while new fields render empty.
+  const handleSchemaChange = (id: string) => {
+    setSchemaId(id);
+    setRowErrors({});
+  };
+
+  // Agent context: picking a directory selects it and defaults the schema to that
+  // directory's default schema (the user can still change it below). Entered rows are kept.
+  const handleDirectoryChange = (id: string) => {
+    setPickedDirectoryId(id);
+    const dir = directoriesQuery.data?.data?.find((d) => d.id === id);
+    setSchemaId(dir?.default_schema_id ?? '');
+    setRowErrors({});
+  };
+
+  const onSubmit = async (values: FormValues) => {
+    // Agent context requires a directory pick before we can create anywhere.
+    if (!effectiveDirectoryId) {
+      showToast.warning('Select a directory first.');
+      return;
+    }
+
+    const contacts: ContactRowPayload[] = values.rows.map((row) => ({
+      name: row.name || null,
+      phone_number: row.phone_number || null,
+      contact_metadata: row.metadata,
+    }));
+
+    try {
+      // `agent_id` (when set) tells the backend to also assign the created contacts.
+      const result = await createContacts.mutateAsync({ contacts, agent_id: agentId });
+      const failedByIndex: Record<number, string[]> = {};
+      for (const f of result.failed as CreateContactFailure[]) {
+        failedByIndex[f.index] = f.errors;
+      }
+
+      if (result.created.length > 0) {
+        const count = result.created.length;
+        const noun = `contact${count === 1 ? '' : 's'}`;
+        showToast.success(agentId ? `${count} ${noun} added & assigned` : `${count} ${noun} added`);
+        onCompleted?.();
+      }
+
+      if (result.failed.length === 0) {
+        onClose();
+        return;
+      }
+
+      // Partial: keep the modal open, drop the created rows, keep only the failed ones so
+      // the user can fix them in place, and surface each row's inline errors.
+      const failedRows = values.rows
+        .map((row, index) => ({ row, index }))
+        .filter(({ index }) => failedByIndex[index] != null);
+      reset({ rows: failedRows.map(({ row }) => row) });
+      setRowErrors(
+        failedRows.reduce<Record<number, string[]>>((acc, { index }, newIndex) => {
+          acc[newIndex] = failedByIndex[index];
+          return acc;
+        }, {}),
+      );
+      showToast.warning(
+        `${result.failed.length} row${result.failed.length === 1 ? '' : 's'} could not be added`,
+      );
+    } catch (err) {
+      handleApiError(err);
+    }
+  };
+
+  return (
+    <CustomModal open={open} onClose={onClose} title="Add contacts" hideFooter width="sm:max-w-2xl">
+      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
+        <SelectInput
+          name="add-contacts-schema"
+          label="Schema"
+          options={schemaOptions}
+          value={schemaId}
+          onValueChange={handleSchemaChange}
+          loading={schemasQuery.isLoading}
+          placeholder="No schema — name & phone only"
+        />
+
+        <div className="flex max-h-[60vh] flex-col gap-4 overflow-y-auto pr-1">
+          {rowFields.map((row, index) => (
+            <div key={row.id} className="rounded-lg border border-border p-4">
+              <div className="mb-2 flex items-center justify-between">
+                <span className="text-sm font-medium text-muted-foreground">
+                  Contact {index + 1}
+                </span>
+                {rowFields.length > 1 && (
+                  <CustomButton
+                    type="text"
+                    size="icon-xs"
+                    onClick={() => {
+                      remove(index);
+                      setRowErrors((prev) => {
+                        const next: Record<number, string[]> = {};
+                        for (const [k, v] of Object.entries(prev)) {
+                          const i = Number(k);
+                          if (i < index) next[i] = v;
+                          else if (i > index) next[i - 1] = v;
+                        }
+                        return next;
+                      });
+                    }}
+                    aria-label={`Remove contact ${index + 1}`}
+                  >
+                    <Trash2 className="size-4" aria-hidden />
+                  </CustomButton>
+                )}
+              </div>
+
+              <SchemaDrivenContactForm
+                control={control}
+                fields={fields}
+                namePrefix={`rows.${index}`}
+              />
+
+              {rowErrors[index]?.length ? (
+                <ul
+                  role="alert"
+                  className="mt-2 list-inside list-disc rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 ring-1 ring-inset ring-red-200"
+                >
+                  {rowErrors[index].map((message, i) => (
+                    <li key={`${index}-${i}`}>{message}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+          ))}
+        </div>
+
+        <div>
+          <CustomButton type="default" onClick={() => append(emptyRow())}>
+            <Plus className="size-4" aria-hidden />
+            Add another
+          </CustomButton>
+        </div>
+
+        {isAgentContext && (
+          <AdvancedDirectoryConfig
+            options={directoryOptions}
+            value={pickedDirectoryId}
+            onChange={handleDirectoryChange}
+            loading={directoriesQuery.isLoading}
+          />
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <CustomButton type="default" onClick={onClose}>
+            Cancel
+          </CustomButton>
+          <CustomButton
+            type="primary"
+            htmlType="submit"
+            loading={createContacts.isPending}
+            disabled={!effectiveDirectoryId}
+          >
+            Save contacts
+          </CustomButton>
+        </div>
+      </form>
+    </CustomModal>
+  );
+}

--- a/frontend/src/components/contacts/general/DirectoryContactsSection.tsx
+++ b/frontend/src/components/contacts/general/DirectoryContactsSection.tsx
@@ -1,0 +1,482 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Pencil, Plus, Trash2, Upload, Users } from 'lucide-react';
+import { z } from 'zod';
+
+import { useDirectory } from '@/lib/api/contactDirectories';
+import { useSchema } from '@/lib/api/contactSchemas';
+import {
+  useBulkDeleteContacts,
+  useContactsList,
+  useDeleteContact,
+  useUpdateContact,
+} from '@/lib/api/contacts';
+import { CustomButton, CustomModal } from '@/components/shared';
+import { PhoneNumberDisplay } from '@/components/shared/PhoneNumberDisplay';
+import ContactsTable from '@/components/contacts/shared/ContactsTable';
+import ConfirmDeleteModal from '@/components/contacts/shared/ConfirmDeleteModal';
+import SchemaDrivenContactForm from '@/components/contacts/shared/SchemaDrivenContactForm';
+import SyncContactsModal from '@/components/contacts/shared/SyncContactsModal';
+import { useSyncStatusPolling } from '@/components/contacts/shared/useSyncStatusPolling';
+import { buildContactFormSchema } from '@/components/contacts/shared/buildContactFormSchema';
+import type { Contact, ListContactsParams } from '@/types/contact';
+import type { SchemaField } from '@/types/contactSchema';
+import type { CustomTableColumn, CustomTableSortState } from '@/types/components';
+import { handleApiError } from '@/utils/helpers';
+import { showToast } from '@/utils/toast';
+
+import AddContactsModal from './AddContactsModal';
+
+/**
+ * The "General" pane of a Contact Directory.
+ *
+ * WHAT: lists a directory's contacts (server search / sort / paginate via
+ * `useContactsList`) with per-row edit + delete and bulk-delete; hosts the multi-row
+ * "Add Contacts" modal and the shared "Sync Contacts" CSV modal. It drives the
+ * directory's default-schema fields (fetched via the directory → schema hooks) into the
+ * add / edit forms so metadata inputs match the schema. After a sync completes it shows a
+ * completed-with-warnings banner (linking the error report) and refreshes the list.
+ *
+ * WHEN: rendered by the directory detail shell for the "General" tab.
+ */
+export interface DirectoryContactsSectionProps {
+  directoryId: string;
+}
+
+const PAGE_SIZE = 20;
+
+export default function DirectoryContactsSection({ directoryId }: DirectoryContactsSectionProps) {
+  // Resolve the directory's default schema → its fields (drives the add / edit forms).
+  const { data: directory } = useDirectory(directoryId);
+  const defaultSchemaId = directory?.default_schema_id ?? null;
+  const { data: schema } = useSchema(defaultSchemaId);
+  const fields: SchemaField[] = useMemo(() => schema?.fields ?? [], [schema]);
+
+  // Server-driven list params (search / sort / page).
+  const [search, setSearch] = useState('');
+  const [sort, setSort] = useState<CustomTableSortState | null>(null);
+  const [page, setPage] = useState(1);
+
+  const listParams: ListContactsParams = {
+    page_no: page,
+    page_size: PAGE_SIZE,
+    search: search || undefined,
+    sort_by: sort?.field,
+    sort_order: sort?.order,
+  };
+  const { data: contactsPage, isLoading, refetch } = useContactsList(directoryId, listParams);
+
+  const contacts = contactsPage?.data ?? [];
+  const total = contactsPage?.total ?? 0;
+
+  // Selection for bulk-delete.
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  // Modals / dialogs.
+  const [addOpen, setAddOpen] = useState(false);
+  const [syncOpen, setSyncOpen] = useState(false);
+  const [editContact, setEditContact] = useState<Contact | null>(null);
+  const [deleteContact, setDeleteContact] = useState<Contact | null>(null);
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+
+  // Post-sync banner: once a sync completes we pull the directory's most recent sync so we
+  // can poll it (for the completed-with-warnings banner) and link its error report.
+  const [lastSyncId, setLastSyncId] = useState<string | null>(null);
+  const [bannerDismissed, setBannerDismissed] = useState(false);
+  const syncPoll = useSyncStatusPolling(lastSyncId);
+
+  const deleteContactMutation = useDeleteContact(directoryId);
+  const bulkDeleteMutation = useBulkDeleteContacts(directoryId);
+
+  const isSelected = (id: string) => selectedIds.includes(id);
+  const toggleSelected = (id: string) =>
+    setSelectedIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
+  const allOnPageSelected = contacts.length > 0 && contacts.every((c) => isSelected(c.id));
+  const toggleSelectAll = () =>
+    setSelectedIds((prev) =>
+      allOnPageSelected
+        ? prev.filter((id) => !contacts.some((c) => c.id === id))
+        : Array.from(new Set([...prev, ...contacts.map((c) => c.id)])),
+    );
+
+  const columns: CustomTableColumn<Contact>[] = useMemo(
+    () => [
+      {
+        key: 'select',
+        title: (
+          <input
+            type="checkbox"
+            aria-label="Select all contacts on this page"
+            checked={allOnPageSelected}
+            onChange={toggleSelectAll}
+            className="size-4 cursor-pointer accent-primary"
+          />
+        ),
+        width: '44px',
+        render: (_v, record) => (
+          <input
+            type="checkbox"
+            aria-label={`Select contact ${record.name ?? record.phone_number ?? record.id}`}
+            checked={isSelected(record.id)}
+            onChange={(e) => {
+              e.stopPropagation();
+              toggleSelected(record.id);
+            }}
+            onClick={(e) => e.stopPropagation()}
+            className="size-4 cursor-pointer accent-primary"
+          />
+        ),
+      },
+      {
+        key: 'name',
+        title: 'Name',
+        dataIndex: 'name',
+        sorter: true,
+        render: (_v, record) =>
+          record.name ? (
+            <span className="font-medium text-foreground">{record.name}</span>
+          ) : (
+            <span className="text-muted-foreground">—</span>
+          ),
+      },
+      {
+        key: 'phone_number',
+        title: 'Phone',
+        dataIndex: 'phone_number',
+        sorter: true,
+        className: 'tabular-nums',
+        render: (_v, record) =>
+          record.phone_number ? (
+            <PhoneNumberDisplay phoneNumber={record.phone_number} flagSize="sm" />
+          ) : (
+            <span className="text-muted-foreground">—</span>
+          ),
+      },
+      {
+        key: 'actions',
+        title: '',
+        align: 'right',
+        width: '96px',
+        render: (_v, record) => (
+          // Hover/focus-reveal on pointer devices; stays visible where hover is
+          // unavailable (touch) so actions remain reachable. Keyboard focus reveals via
+          // `focus-within`, and the buttons keep their default focus rings.
+          <div className="flex items-center justify-end gap-1 opacity-100 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 [@media(hover:hover)]:opacity-0">
+            <CustomButton
+              type="text"
+              size="icon-xs"
+              onClick={(e) => {
+                e.stopPropagation();
+                setEditContact(record);
+              }}
+              aria-label="Edit contact"
+            >
+              <Pencil className="size-4" aria-hidden />
+            </CustomButton>
+            <CustomButton
+              type="text"
+              size="icon-xs"
+              onClick={(e) => {
+                e.stopPropagation();
+                setDeleteContact(record);
+              }}
+              aria-label="Delete contact"
+            >
+              <Trash2 className="size-4 text-red-600" aria-hidden />
+            </CustomButton>
+          </div>
+        ),
+      },
+    ],
+    // Re-derive when the current page's selection changes so the checkboxes reflect state.
+    [contacts, selectedIds],
+  );
+
+  const handleSortChange = (next: CustomTableSortState | null) => {
+    setSort(next);
+    setPage(1);
+  };
+
+  const handleSearchChange = (value: string) => {
+    setSearch(value);
+    setPage(1);
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteContact) return;
+    try {
+      await deleteContactMutation.mutateAsync(deleteContact.id);
+      showToast.success('Contact deleted');
+      setSelectedIds((prev) => prev.filter((id) => id !== deleteContact.id));
+      setDeleteContact(null);
+    } catch (err) {
+      handleApiError(err);
+    }
+  };
+
+  const confirmBulkDelete = async () => {
+    try {
+      const res = await bulkDeleteMutation.mutateAsync(selectedIds);
+      showToast.success(`${res.deleted} contact${res.deleted === 1 ? '' : 's'} deleted`);
+      setSelectedIds([]);
+      setBulkDeleteOpen(false);
+    } catch (err) {
+      handleApiError(err);
+    }
+  };
+
+  const showBanner = !bannerDismissed && syncPoll.isTerminal && !!lastSyncId;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-4">
+      {showBanner && (
+        <SyncCompletedBanner
+          warnings={syncPoll.completedWithWarnings}
+          failed={syncPoll.isFailed}
+          error={syncPoll.sync?.error ?? null}
+          onDismiss={() => setBannerDismissed(true)}
+        />
+      )}
+
+      <ContactsTable<Contact>
+        columns={columns}
+        data={contacts}
+        rowKey="id"
+        loading={isLoading}
+        total={total}
+        page={page}
+        pageSize={PAGE_SIZE}
+        onPageChange={(nextPage) => setPage(nextPage)}
+        searchValue={search}
+        onSearchChange={handleSearchChange}
+        searchPlaceholder="Search contacts..."
+        sort={sort}
+        onSortChange={handleSortChange}
+        fillHeight
+        groupRows
+        emptyState={
+          <div className="flex flex-col items-center gap-3 py-10 text-center">
+            <span className="flex size-12 items-center justify-center rounded-full bg-muted/60">
+              <Users className="size-6 text-muted-foreground" aria-hidden />
+            </span>
+            <div className="flex flex-col gap-1">
+              <p className="text-sm font-medium text-foreground">No contacts yet</p>
+              <p className="text-xs text-muted-foreground">
+                Add contacts manually or sync them from a CSV to get started.
+              </p>
+            </div>
+            <div className="mt-1 flex items-center gap-2">
+              <CustomButton type="default" size="sm" onClick={() => setSyncOpen(true)}>
+                <Upload className="size-4" aria-hidden />
+                Sync Contacts
+              </CustomButton>
+              <CustomButton type="primary" size="sm" onClick={() => setAddOpen(true)}>
+                <Plus className="size-4" aria-hidden />
+                Add Contacts
+              </CustomButton>
+            </div>
+          </div>
+        }
+        toolbar={
+          <div className="flex items-center gap-2">
+            {selectedIds.length > 0 && (
+              <CustomButton type="default" onClick={() => setBulkDeleteOpen(true)}>
+                <Trash2 className="size-4" aria-hidden />
+                Delete ({selectedIds.length})
+              </CustomButton>
+            )}
+            <CustomButton type="default" onClick={() => setSyncOpen(true)}>
+              <Upload className="size-4" aria-hidden />
+              Sync Contacts
+            </CustomButton>
+            <CustomButton type="primary" onClick={() => setAddOpen(true)}>
+              <Plus className="size-4" aria-hidden />
+              Add Contacts
+            </CustomButton>
+          </div>
+        }
+      />
+
+      <AddContactsModal
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+        directoryId={directoryId}
+        defaultSchemaId={defaultSchemaId}
+        onCompleted={() => refetch()}
+      />
+
+      <SyncContactsModal
+        open={syncOpen}
+        onClose={() => setSyncOpen(false)}
+        directoryId={directoryId}
+        defaultSchemaId={defaultSchemaId}
+        onCompleted={(syncId) => {
+          // The modal reports the finished sync's id directly, so the banner can poll it +
+          // link its report without re-deriving it from a possibly-stale "recent sync" query.
+          refetch();
+          if (syncId) setLastSyncId(syncId);
+          setBannerDismissed(false);
+        }}
+      />
+
+      {editContact && (
+        <EditContactModal
+          open={!!editContact}
+          contact={editContact}
+          directoryId={directoryId}
+          fields={fields}
+          onClose={() => setEditContact(null)}
+          onSaved={() => {
+            setEditContact(null);
+            refetch();
+          }}
+        />
+      )}
+
+      <ConfirmDeleteModal
+        open={!!deleteContact}
+        onClose={() => setDeleteContact(null)}
+        onConfirm={confirmDelete}
+        title="Delete contact"
+        description="This contact will be permanently removed from the directory."
+        loading={deleteContactMutation.isPending}
+      />
+
+      <ConfirmDeleteModal
+        open={bulkDeleteOpen}
+        onClose={() => setBulkDeleteOpen(false)}
+        onConfirm={confirmBulkDelete}
+        title="Delete contacts"
+        description={`${selectedIds.length} contact${
+          selectedIds.length === 1 ? '' : 's'
+        } will be permanently removed from the directory.`}
+        loading={bulkDeleteMutation.isPending}
+      />
+    </div>
+  );
+}
+
+/** The post-sync banner: warnings (link the error report) or a hard-failure notice. */
+function SyncCompletedBanner({
+  warnings,
+  failed,
+  error,
+  onDismiss,
+}: {
+  warnings: boolean;
+  failed: boolean;
+  error: string | null;
+  onDismiss: () => void;
+}) {
+  if (failed) {
+    return (
+      <div
+        role="alert"
+        className="flex items-start justify-between gap-3 rounded-lg bg-red-50 px-4 py-3 text-sm text-red-800 ring-1 ring-inset ring-red-200"
+      >
+        <span>{error ?? 'The last sync failed. Please check the file and try again.'}</span>
+        <CustomButton type="text" size="sm" onClick={onDismiss}>
+          Dismiss
+        </CustomButton>
+      </div>
+    );
+  }
+
+  if (!warnings) {
+    return (
+      <div
+        role="status"
+        className="flex items-start justify-between gap-3 rounded-lg bg-emerald-50 px-4 py-3 text-sm text-emerald-800 ring-1 ring-inset ring-emerald-200"
+      >
+        <span>Sync completed. Contacts are up to date.</span>
+        <CustomButton type="text" size="sm" onClick={onDismiss}>
+          Dismiss
+        </CustomButton>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="alert"
+      className="flex items-start justify-between gap-3 rounded-lg bg-orange-50 px-4 py-3 text-sm text-orange-800 ring-1 ring-inset ring-orange-200"
+    >
+      <span>
+        Sync completed with warnings — some rows were skipped.{' '}
+        <Link href="/contacts/sync-history" className="font-medium underline">
+          View error report
+        </Link>
+      </span>
+      <CustomButton type="text" size="sm" onClick={onDismiss}>
+        Dismiss
+      </CustomButton>
+    </div>
+  );
+}
+
+/** Inline single-contact edit modal (reuses the schema-driven form). */
+function EditContactModal({
+  open,
+  contact,
+  directoryId,
+  fields,
+  onClose,
+  onSaved,
+}: {
+  open: boolean;
+  contact: Contact;
+  directoryId: string;
+  fields: SchemaField[];
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const updateContact = useUpdateContact(directoryId);
+  const formSchema = useMemo(() => buildContactFormSchema(fields), [fields]);
+  type FormValues = z.infer<typeof formSchema>;
+
+  const { control, handleSubmit } = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: contact.name ?? '',
+      phone_number: contact.phone_number ?? '',
+      metadata: (contact.contact_metadata ?? {}) as Record<string, unknown>,
+    },
+  });
+
+  const onSubmit = async (values: FormValues) => {
+    try {
+      await updateContact.mutateAsync({
+        id: contact.id,
+        payload: {
+          name: values.name || null,
+          phone_number: values.phone_number || null,
+          contact_metadata: values.metadata,
+        },
+      });
+      showToast.success('Contact updated');
+      onSaved();
+    } catch (err) {
+      handleApiError(err);
+    }
+  };
+
+  return (
+    <CustomModal open={open} onClose={onClose} title="Edit contact" hideFooter width="sm:max-w-lg">
+      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
+        <SchemaDrivenContactForm control={control} fields={fields} />
+        <div className="flex justify-end gap-2 pt-2">
+          <CustomButton type="default" onClick={onClose}>
+            Cancel
+          </CustomButton>
+          <CustomButton type="primary" htmlType="submit" loading={updateContact.isPending}>
+            Save
+          </CustomButton>
+        </div>
+      </form>
+    </CustomModal>
+  );
+}

--- a/frontend/src/components/contacts/schema/ContactSchemaSection.tsx
+++ b/frontend/src/components/contacts/schema/ContactSchemaSection.tsx
@@ -1,0 +1,474 @@
+'use client';
+
+import { useAtom, useSetAtom } from 'jotai';
+import { AlertTriangle, Check, Pencil, Plus, Rows3, Star, Trash2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+import { authAtom, getCurrentUserAtom } from '@/atoms/AuthAtom';
+import { useDirectory, useUpdateDirectory } from '@/lib/api/contactDirectories';
+import {
+  useCreateSchema,
+  useDeleteSchema,
+  useSchema,
+  useSchemasList,
+  useUpdateSchema,
+} from '@/lib/api/contactSchemas';
+import {
+  AppLoader,
+  CustomButton,
+  CustomModal,
+  SearchBar,
+  TextAreaField,
+  TextInput,
+} from '@/components/shared';
+import type {
+  ContactSchema,
+  CreateSchemaPayload,
+  SchemaReferencedBy,
+  UpdateSchemaPayload,
+} from '@/types/contactSchema';
+import { handleApiError } from '@/utils/helpers';
+import { showToast } from '@/utils/toast';
+
+import SchemaFieldsEditor from '../shared/SchemaFieldsEditor';
+import ConfirmDeleteModal from '../shared/ConfirmDeleteModal';
+
+/**
+ * Datasource Schema library — the shared ORG-LEVEL contact-schema manager.
+ *
+ * WHAT: lists every reusable org schema (create / rename / delete) and opens the shared
+ * {@link SchemaFieldsEditor} for the selected schema's fields. Because schemas are
+ * org-level and reusable, edits/deletes surface a "referenced by N directories / M syncs"
+ * warning (from the schema detail's `referenced_by`), and deleting a schema that is some
+ * directory's default is blocked by the backend (409) — surfaced via toast.
+ *
+ * WHEN: rendered standalone on the `/contacts/datasource` page (no `directoryId`)
+ * as a pure org-level library. When a `directoryId` is passed, it additionally exposes a
+ * "set as this directory's default" control writing to that directory's `default_schema_id`.
+ * Members see everything read-only; create/edit/delete + set-default are admin/owner only.
+ */
+export interface ContactSchemaSectionProps {
+  /**
+   * Optional. When set, the section also renders a "set as this directory's default"
+   * control that writes to the directory's `default_schema_id`. Omit for the pure
+   * org-level library (`/contacts/datasource` page).
+   */
+  directoryId?: string;
+}
+
+type SchemaFormMode = { kind: 'create' } | { kind: 'edit'; schema: ContactSchema };
+
+interface SchemaFormValues {
+  name: string;
+  description: string;
+}
+
+const EMPTY_FORM: SchemaFormValues = { name: '', description: '' };
+
+/** Human summary of how many directories/syncs point at a schema (empty when none). */
+function referencedBySummary(ref: SchemaReferencedBy | undefined): string | null {
+  if (!ref) return null;
+  const parts: string[] = [];
+  if (ref.directories > 0) {
+    parts.push(`${ref.directories} director${ref.directories === 1 ? 'y' : 'ies'}`);
+  }
+  if (ref.syncs > 0) parts.push(`${ref.syncs} sync${ref.syncs === 1 ? '' : 's'}`);
+  if (parts.length === 0) return null;
+  return `Referenced by ${parts.join(' and ')} — edits affect all of them.`;
+}
+
+export default function ContactSchemaSection({ directoryId }: ContactSchemaSectionProps) {
+  // --- current-user role (admin/owner gate) — same pattern as userMenu.tsx ---
+  const [authState] = useAtom(authAtom);
+  const getCurrentUser = useSetAtom(getCurrentUserAtom);
+  useEffect(() => {
+    if (!authState.user && !authState.isLoading) getCurrentUser();
+  }, [authState.user, authState.isLoading, getCurrentUser]);
+  const role = authState.user?.role;
+  const canEdit = role === 'admin' || role === 'owner';
+
+  // --- data ---
+  const [search, setSearch] = useState('');
+  const schemasQuery = useSchemasList({ search: search || undefined, page_size: 100 });
+  const schemas = useMemo(() => schemasQuery.data?.data ?? [], [schemasQuery.data]);
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  // Keep a valid selection: auto-select the first schema, clear if it disappears.
+  useEffect(() => {
+    if (schemas.length === 0) {
+      if (selectedId !== null) setSelectedId(null);
+      return;
+    }
+    if (!selectedId || !schemas.some((s) => s.id === selectedId)) {
+      setSelectedId(schemas[0].id);
+    }
+  }, [schemas, selectedId]);
+
+  const schemaDetailQuery = useSchema(selectedId);
+  const schemaDetail = schemaDetailQuery.data;
+
+  // Only fetch the directory when one is provided (the per-directory set-default control).
+  const directoryQuery = useDirectory(directoryId ?? null);
+  const defaultSchemaId = directoryQuery.data?.default_schema_id ?? null;
+
+  // --- mutations ---
+  const createSchema = useCreateSchema();
+  const updateSchema = useUpdateSchema();
+  const deleteSchema = useDeleteSchema();
+  const updateDirectory = useUpdateDirectory();
+
+  const [formMode, setFormMode] = useState<SchemaFormMode | null>(null);
+  const [formValues, setFormValues] = useState<SchemaFormValues>(EMPTY_FORM);
+  const [deleteTarget, setDeleteTarget] = useState<ContactSchema | null>(null);
+
+  const openCreate = () => {
+    setFormMode({ kind: 'create' });
+    setFormValues(EMPTY_FORM);
+  };
+
+  const openEdit = (schema: ContactSchema) => {
+    setFormMode({ kind: 'edit', schema });
+    setFormValues({ name: schema.name, description: schema.description ?? '' });
+  };
+
+  const closeForm = () => {
+    setFormMode(null);
+    setFormValues(EMPTY_FORM);
+  };
+
+  const saveForm = async () => {
+    const name = formValues.name.trim();
+    if (!name) {
+      showToast.error('Schema name is required.');
+      return;
+    }
+    try {
+      if (formMode?.kind === 'edit') {
+        const payload: UpdateSchemaPayload = {
+          name,
+          description: formValues.description.trim() || null,
+        };
+        await updateSchema.mutateAsync({ id: formMode.schema.id, payload });
+        showToast.success('Schema updated');
+      } else {
+        const payload: CreateSchemaPayload = {
+          name,
+          description: formValues.description.trim() || null,
+        };
+        const created = await createSchema.mutateAsync(payload);
+        setSelectedId(created.id);
+        showToast.success('Schema created');
+      }
+      closeForm();
+    } catch (err) {
+      handleApiError(err);
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteSchema.mutateAsync(deleteTarget.id);
+      showToast.success('Schema deleted');
+      if (selectedId === deleteTarget.id) setSelectedId(null);
+      setDeleteTarget(null);
+    } catch (err) {
+      // Deleting a schema that is a directory's default is blocked by the backend (409);
+      // handleApiError surfaces the backend's `detail` message via toast.
+      handleApiError(err);
+    }
+  };
+
+  const setAsDefault = async (schemaId: string) => {
+    if (!directoryId) return;
+    try {
+      await updateDirectory.mutateAsync({
+        id: directoryId,
+        payload: { default_schema_id: schemaId },
+      });
+      showToast.success('Set as this directory’s default schema');
+    } catch (err) {
+      handleApiError(err);
+    }
+  };
+
+  // Reference counts for the currently-open detail — drives the shared-edit warning
+  // and the delete-confirm impact copy.
+  const detailReferencedBy =
+    schemaDetail && selectedId === schemaDetail.id ? schemaDetail.referenced_by : undefined;
+  const sharedWarning = referencedBySummary(detailReferencedBy);
+
+  // --- render states for the schema library ---
+  const renderLibrary = () => {
+    if (schemasQuery.isLoading) {
+      return (
+        <div className="flex justify-center py-10">
+          <AppLoader />
+        </div>
+      );
+    }
+    if (schemasQuery.isError) {
+      return (
+        <div className="flex flex-col items-center gap-3 py-10 text-center">
+          <p className="text-sm text-muted-foreground">Could not load schemas.</p>
+          <CustomButton type="default" size="sm" onClick={() => schemasQuery.refetch()}>
+            Retry
+          </CustomButton>
+        </div>
+      );
+    }
+    if (schemas.length === 0) {
+      return (
+        <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed border-border px-6 py-10 text-center">
+          <span className="flex size-12 items-center justify-center rounded-full bg-muted/60">
+            <Rows3 className="size-6 text-muted-foreground" aria-hidden />
+          </span>
+          <div className="flex flex-col gap-1">
+            <p className="text-sm font-medium text-foreground">
+              {search ? 'No matching schemas' : 'No schemas yet'}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {search
+                ? 'Try a different search term.'
+                : 'Create a reusable schema to define contact fields once and share it.'}
+            </p>
+          </div>
+          {canEdit && !search && (
+            <CustomButton type="primary" size="sm" onClick={openCreate}>
+              <Plus className="size-4" /> New schema
+            </CustomButton>
+          )}
+        </div>
+      );
+    }
+    return (
+      <ul className="flex flex-col gap-1.5">
+        {schemas.map((schema) => {
+          const isSelected = schema.id === selectedId;
+          const isDefault = schema.id === defaultSchemaId;
+          return (
+            <li key={schema.id}>
+              {/* A div (not a button) so the Edit/Delete CustomButtons below aren't
+                  nested buttons (invalid DOM / hydration mismatch). */}
+              <div
+                role="button"
+                tabIndex={0}
+                onClick={() => setSelectedId(schema.id)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    setSelectedId(schema.id);
+                  }
+                }}
+                aria-current={isSelected}
+                className={`group flex w-full cursor-pointer items-center gap-2 rounded-lg border px-3 py-2.5 text-left transition-colors ${
+                  isSelected
+                    ? 'border-primary bg-primary/5 ring-1 ring-primary/40'
+                    : 'border-border hover:border-border hover:bg-muted/40'
+                }`}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-sm font-medium">{schema.name}</span>
+                    {isDefault && (
+                      <span className="inline-flex shrink-0 items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5 text-[11px] font-medium text-primary">
+                        <Star className="size-3" /> Default
+                      </span>
+                    )}
+                  </div>
+                  {schema.description && (
+                    <p className="truncate text-xs text-muted-foreground">{schema.description}</p>
+                  )}
+                </div>
+                {canEdit && (
+                  <span className="flex shrink-0 items-center gap-1">
+                    <CustomButton
+                      type="text"
+                      size="icon-xs"
+                      aria-label={`Edit ${schema.name}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        openEdit(schema);
+                      }}
+                    >
+                      <Pencil className="size-4" />
+                    </CustomButton>
+                    <CustomButton
+                      type="text"
+                      size="icon-xs"
+                      aria-label={`Delete ${schema.name}`}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setDeleteTarget(schema);
+                      }}
+                    >
+                      <Trash2 className="size-4 text-red-600" />
+                    </CustomButton>
+                  </span>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    );
+  };
+
+  // --- render the fields editor for the selected schema ---
+  const renderDetail = () => {
+    if (!selectedId) {
+      return (
+        <div className="flex h-full items-center justify-center py-10 text-center text-sm text-muted-foreground">
+          Select a schema to view its fields.
+        </div>
+      );
+    }
+    if (schemaDetailQuery.isLoading) {
+      return (
+        <div className="flex justify-center py-10">
+          <AppLoader />
+        </div>
+      );
+    }
+    if (schemaDetailQuery.isError || !schemaDetail) {
+      return (
+        <div className="flex flex-col items-center gap-3 py-10 text-center">
+          <p className="text-sm text-muted-foreground">Could not load this schema.</p>
+          <CustomButton type="default" size="sm" onClick={() => schemaDetailQuery.refetch()}>
+            Retry
+          </CustomButton>
+        </div>
+      );
+    }
+
+    const isDefault = schemaDetail.id === defaultSchemaId;
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0">
+            <h3 className="truncate text-base font-semibold">{schemaDetail.name}</h3>
+            {schemaDetail.description && (
+              <p className="text-sm text-muted-foreground">{schemaDetail.description}</p>
+            )}
+          </div>
+          {canEdit &&
+            directoryId &&
+            (isDefault ? (
+              <span className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2.5 py-1.5 text-xs font-medium text-primary">
+                <Check className="size-4" /> This directory&rsquo;s default
+              </span>
+            ) : (
+              <CustomButton
+                type="default"
+                size="sm"
+                onClick={() => setAsDefault(schemaDetail.id)}
+                loading={updateDirectory.isPending}
+              >
+                <Star className="size-4" /> Set as this directory&rsquo;s default
+              </CustomButton>
+            ))}
+        </div>
+
+        {sharedWarning && (
+          <div className="flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2.5 text-sm text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+            <span>{sharedWarning} Existing contacts are not re-validated.</span>
+          </div>
+        )}
+
+        <SchemaFieldsEditor
+          schemaId={schemaDetail.id}
+          fields={schemaDetail.fields}
+          canEdit={canEdit}
+        />
+      </div>
+    );
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-4">
+      <div className="flex min-h-0 flex-1 flex-col gap-4 lg:flex-row lg:items-stretch lg:gap-6">
+        {/* Left: org schema library */}
+        <div className="flex w-full shrink-0 flex-col gap-3 lg:w-80">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold">Schemas</h2>
+            {canEdit && (
+              <CustomButton type="primary" size="sm" onClick={openCreate}>
+                <Plus className="size-4" /> New
+              </CustomButton>
+            )}
+          </div>
+          <SearchBar
+            value={search}
+            onSearch={setSearch}
+            placeholder="Search schemas"
+            aria-label="Search schemas"
+          />
+          <div className="min-h-0 flex-1 overflow-y-auto">{renderLibrary()}</div>
+        </div>
+
+        {/* Right: selected schema's fields */}
+        <div className="min-h-0 min-w-0 flex-1 overflow-y-auto rounded-lg border border-border bg-card p-4">
+          {renderDetail()}
+        </div>
+      </div>
+
+      {/* Create / edit schema modal */}
+      <CustomModal
+        open={formMode !== null}
+        onClose={closeForm}
+        title={formMode?.kind === 'edit' ? 'Edit schema' : 'New schema'}
+        confirmText={formMode?.kind === 'edit' ? 'Save' : 'Create'}
+        confirmLoading={createSchema.isPending || updateSchema.isPending}
+        onConfirm={saveForm}
+        width="sm:max-w-md"
+      >
+        <div className="flex flex-col gap-4">
+          {formMode?.kind === 'edit' && referencedBySummary(detailReferencedBy) && (
+            <div className="flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2.5 text-sm text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200">
+              <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+              <span>{referencedBySummary(detailReferencedBy)}</span>
+            </div>
+          )}
+          <TextInput
+            name="schema-name"
+            label="Name *"
+            value={formValues.name}
+            onChange={(e) => setFormValues((v) => ({ ...v, name: e.target.value }))}
+            placeholder="e.g. Sales leads"
+          />
+          <TextAreaField
+            name="schema-description"
+            label="Description"
+            value={formValues.description}
+            onChange={(e) => setFormValues((v) => ({ ...v, description: e.target.value }))}
+            placeholder="What this schema is for (optional)"
+          />
+        </div>
+      </CustomModal>
+
+      {/* Delete schema confirm */}
+      <ConfirmDeleteModal
+        open={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={confirmDelete}
+        title="Delete schema"
+        description="This removes the reusable schema from your organization."
+        impact={
+          deleteTarget &&
+          deleteTarget.id === selectedId &&
+          referencedBySummary(detailReferencedBy) ? (
+            <span>
+              {referencedBySummary(detailReferencedBy)} A schema that is a directory&rsquo;s default
+              cannot be deleted until another default is set.
+            </span>
+          ) : (
+            'A schema that is a directory’s default cannot be deleted until another default is set.'
+          )
+        }
+        confirmText="Delete"
+        loading={deleteSchema.isPending}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/contacts/shared/AdvancedDirectoryConfig.tsx
+++ b/frontend/src/components/contacts/shared/AdvancedDirectoryConfig.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { SlidersHorizontal } from 'lucide-react';
+
+import { CollapsibleSection, SelectInput } from '@/components/shared';
+import type { SelectOption } from '@/types/components';
+
+/**
+ * The agent-context "Advanced configuration" panel: a directory override tucked behind the
+ * shared {@link CollapsibleSection} disclosure.
+ *
+ * WHY: in the agent context the target directory defaults to the org's seeded "Global"
+ * directory (resolved by name upstream), so the picker is hidden by default. Power users
+ * expand it to send contacts to a different directory. The collapsed sub-line summarises the
+ * current target so the choice stays legible without opening.
+ *
+ * Shared by BOTH the Add-contacts and Sync-contacts modals.
+ */
+export interface AdvancedDirectoryConfigProps {
+  /** Selectable directories (id → name), typically from `useDirectoriesList`. */
+  options: SelectOption[];
+  /** The currently selected directory id. */
+  value: string;
+  /** Called with the new directory id when the user picks one. */
+  onChange: (id: string) => void;
+  /** Whether the directory list is still loading. */
+  loading?: boolean;
+}
+
+export default function AdvancedDirectoryConfig({
+  options,
+  value,
+  onChange,
+  loading,
+}: AdvancedDirectoryConfigProps) {
+  const selectedLabel = options.find((o) => o.value === value)?.label;
+
+  return (
+    <CollapsibleSection
+      title="Advanced configuration"
+      icon={<SlidersHorizontal className="size-4" aria-hidden />}
+      description={(expanded) =>
+        expanded
+          ? 'Choose which directory these contacts import into.'
+          : selectedLabel
+            ? `Target directory · ${selectedLabel}`
+            : 'Set the target directory'
+      }
+    >
+      <SelectInput
+        name="advanced-directory"
+        label="Directory"
+        options={options}
+        value={value}
+        onValueChange={onChange}
+        loading={loading}
+        placeholder="Select a directory"
+      />
+      <p className="mt-1.5 text-xs text-muted-foreground">
+        Contacts import into this directory. Defaults to your Global directory.
+      </p>
+    </CollapsibleSection>
+  );
+}

--- a/frontend/src/components/contacts/shared/AssignContactsModal.tsx
+++ b/frontend/src/components/contacts/shared/AssignContactsModal.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { useAssignContacts } from '@/lib/api/agentContacts';
+import { useDirectoriesList } from '@/lib/api/contactDirectories';
+import { CustomButton, CustomModal } from '@/components/shared';
+import { handleApiError } from '@/utils/helpers';
+import { showToast } from '@/utils/toast';
+
+import DirectoryContactTree from './DirectoryContactTree';
+import SyncContactsModal from './SyncContactsModal';
+import {
+  useDirectoryContactTreeSelection,
+  type DirectorySelectionMeta,
+} from './useDirectoryContactTreeSelection';
+
+/**
+ * Assign contacts to an agent. Two paths:
+ *  - Option 1 — `DirectoryContactTree` tri-state tree-select → confirm sends
+ *    `{ directory_ids, contact_ids }` to the assign endpoint (directories expanded to
+ *    their active contacts server-side).
+ *  - Option 2 — the shared `SyncContactsModal` with this `agentId`, so a fresh CSV import
+ *    auto-assigns its imported contacts to the agent on completion.
+ *
+ * WHEN: opened from the agent editor's Contacts tab (`ContactsStep`).
+ */
+export interface AssignContactsModalProps {
+  open: boolean;
+  onClose: () => void;
+  agentId: string;
+  /** Called after a successful assign / sync completion so the parent can refetch. */
+  onAssigned?: () => void;
+}
+
+export default function AssignContactsModal({
+  open,
+  onClose,
+  agentId,
+  onAssigned,
+}: AssignContactsModalProps) {
+  const treeSelection = useDirectoryContactTreeSelection();
+  const assign = useAssignContacts(agentId);
+  const [syncOpen, setSyncOpen] = useState(false);
+
+  // Directory counts for the "N selected" summary (whole-directory picks contribute their
+  // live contact_count). One list fetch; the tree does its own paginated/search fetches.
+  const { data: directoriesData } = useDirectoriesList({ page_size: 100 });
+  const metaByDirectory = useMemo(() => {
+    const map = new Map<string, DirectorySelectionMeta>();
+    for (const dir of directoriesData?.data ?? []) {
+      map.set(dir.id, { contactCount: dir.contact_count });
+    }
+    return map;
+  }, [directoriesData]);
+
+  const selectedCount = treeSelection.countSelected(metaByDirectory);
+
+  const handleClose = () => {
+    treeSelection.clear();
+    onClose();
+  };
+
+  const handleAssign = async () => {
+    if (!treeSelection.hasSelection) {
+      showToast.error('Select at least one directory or contact.');
+      return;
+    }
+    try {
+      const result = await assign.mutateAsync(treeSelection.selection);
+      showToast.success(
+        `Assigned ${result.assigned} contact${result.assigned === 1 ? '' : 's'}${
+          result.skipped ? ` (${result.skipped} already assigned)` : ''
+        }`,
+      );
+      treeSelection.clear();
+      onAssigned?.();
+      onClose();
+    } catch (err) {
+      handleApiError(err);
+    }
+  };
+
+  return (
+    <>
+      <CustomModal
+        open={open && !syncOpen}
+        onClose={handleClose}
+        title="Assign contacts"
+        hideFooter
+        width="sm:max-w-xl"
+      >
+        <div className="flex flex-col gap-4">
+          <p className="text-sm text-muted-foreground">
+            Pick whole directories or individual contacts to assign to this agent, or import a new
+            CSV that auto-assigns as it lands.
+          </p>
+
+          <DirectoryContactTree selection={treeSelection} />
+
+          <div className="flex items-center justify-between gap-3 border-t border-border pt-3">
+            <div className="flex items-center gap-3">
+              <span className="text-sm text-muted-foreground" aria-live="polite">
+                {selectedCount} selected
+              </span>
+              <CustomButton type="link" size="sm" onClick={() => setSyncOpen(true)}>
+                Import from CSV instead
+              </CustomButton>
+            </div>
+            <div className="flex gap-2">
+              <CustomButton type="default" onClick={handleClose}>
+                Cancel
+              </CustomButton>
+              <CustomButton
+                type="primary"
+                onClick={handleAssign}
+                loading={assign.isPending}
+                disabled={!treeSelection.hasSelection}
+              >
+                Assign
+              </CustomButton>
+            </div>
+          </div>
+        </div>
+      </CustomModal>
+
+      {/*
+        Option 2 — CSV import with auto-assign. We pass ONLY `agentId` (no `directoryId`), so
+        `SyncContactsModal` enters its agent context (`isAgentContext = !directoryId && !!agentId`)
+        and shows its own directory picker — defaulting to the org's "Global" directory. Passing
+        a concrete `directoryId` here would disable that picker.
+      */}
+      {syncOpen && (
+        <SyncContactsModal
+          open={syncOpen}
+          onClose={() => setSyncOpen(false)}
+          agentId={agentId}
+          defaultSchemaId={null}
+          onCompleted={() => {
+            onAssigned?.();
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/contacts/shared/ConfirmDeleteModal.tsx
+++ b/frontend/src/components/contacts/shared/ConfirmDeleteModal.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { CustomModal } from '@/components/shared';
+
+/**
+ * A thin, destructive-action wrapper over `CustomModal` for the contacts feature.
+ *
+ * WHAT: renders a confirm dialog with a red confirm button, an optional impact-summary
+ * body (e.g. "3 contacts, 2 scheduled calls will be permanently deleted"), and a
+ * loading state on confirm. Radix (via CustomModal) provides focus trap + ARIA.
+ *
+ * WHEN: use for every destructive confirm in the feature — directory delete (with the
+ * `DirectoryDeleteImpact` counts), contact delete/bulk-delete, schema delete, and
+ * unassign. Callers pass their own summary node; this component owns the dialog chrome.
+ */
+export interface ConfirmDeleteModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  /** Dialog title, e.g. "Delete directory". */
+  title: string;
+  /** Optional short prompt under the title, e.g. "This cannot be undone." */
+  description?: string;
+  /**
+   * Optional impact summary rendered in the body — a list of what will be deleted /
+   * detached. Pass the `DirectoryDeleteImpact` breakdown here for a directory delete.
+   */
+  impact?: React.ReactNode;
+  confirmText?: string;
+  cancelText?: string;
+  /** Show a spinner + disable buttons while the delete request is in flight. */
+  loading?: boolean;
+  /** Disable confirm (e.g. while the impact counts are still loading). */
+  confirmDisabled?: boolean;
+}
+
+export default function ConfirmDeleteModal({
+  open,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  impact,
+  confirmText = 'Delete',
+  cancelText = 'Cancel',
+  loading = false,
+  confirmDisabled = false,
+}: ConfirmDeleteModalProps) {
+  return (
+    <CustomModal
+      open={open}
+      onClose={onClose}
+      title={title}
+      description={description}
+      confirmText={confirmText}
+      cancelText={cancelText}
+      confirmType="danger"
+      confirmLoading={loading}
+      confirmDisabled={confirmDisabled}
+      onConfirm={onConfirm}
+      width="sm:max-w-md"
+    >
+      {impact != null && <div className="text-sm text-muted-foreground">{impact}</div>}
+    </CustomModal>
+  );
+}

--- a/frontend/src/components/contacts/shared/ContactsTable.tsx
+++ b/frontend/src/components/contacts/shared/ContactsTable.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { CustomTable } from '@/components/shared';
+import type {
+  CustomTableColumn,
+  CustomTablePagination,
+  CustomTableSortState,
+} from '@/types/components';
+
+/**
+ * A thin wrapper over the shared `CustomTable` preset for contact-style rows, wired for
+ * SERVER-side search / sort / pagination.
+ *
+ * WHAT: forwards a controlled search value, server sort state, and a server-total
+ * pagination config to `CustomTable`, so a paginated contacts endpoint drives it directly.
+ * Callers supply the `columns` (so the directory General view, the Agent Contacts tab,
+ * and the Assign picker can each render their own action/checkbox columns) and the row
+ * data for the current page.
+ *
+ * WHEN: use for every contacts listing that talks to a `POST /…/list` endpoint via
+ * `usePaginatedList` — pass the page's params state + setter down so search/sort/page
+ * changes flow back to the query. Do NOT re-implement CustomTable wiring per screen.
+ */
+export interface ContactsTableProps<TRow> {
+  columns: CustomTableColumn<TRow>[];
+  data: TRow[];
+  rowKey: (keyof TRow & string) | ((record: TRow) => string | number);
+  loading?: boolean;
+  /** Total row count from the server envelope (`total`) — enables server pagination. */
+  total: number;
+  page: number;
+  pageSize: number;
+  onPageChange: (page: number, pageSize: number) => void;
+  /** Controlled search term (server-driven). Omit both to disable the search box. */
+  searchValue?: string;
+  onSearchChange?: (value: string) => void;
+  searchPlaceholder?: string;
+  /** Current server sort, reflected in the header; `onSortChange` sends the new sort up. */
+  sort?: CustomTableSortState | null;
+  onSortChange?: (sort: CustomTableSortState | null) => void;
+  emptyState?: React.ReactNode;
+  onRowClick?: (record: TRow, index: number) => void;
+  /** Extra toolbar content (e.g. Add / Sync / bulk-delete buttons). */
+  toolbar?: React.ReactNode;
+  className?: string;
+  /**
+   * Grow the table card to fill its parent's height (body scrolls internally, pagination
+   * pinned at the card bottom). Parent must be a bounded `flex flex-col`. Optional,
+   * back-compatible — defaults to `false` so existing callers (Agent Contacts tab,
+   * Assign picker) keep their auto-height layout.
+   */
+  fillHeight?: boolean;
+  /** Tag rows with `group` so cells can reveal actions on hover/focus. Optional. */
+  groupRows?: boolean;
+}
+
+export default function ContactsTable<TRow>({
+  columns,
+  data,
+  rowKey,
+  loading = false,
+  total,
+  page,
+  pageSize,
+  onPageChange,
+  searchValue,
+  onSearchChange,
+  searchPlaceholder = 'Search contacts...',
+  sort,
+  onSortChange,
+  emptyState,
+  onRowClick,
+  toolbar,
+  className,
+  fillHeight = false,
+  groupRows = false,
+}: ContactsTableProps<TRow>) {
+  const pagination: CustomTablePagination = {
+    current: page,
+    pageSize,
+    total,
+    onChange: onPageChange,
+  };
+
+  return (
+    <CustomTable<TRow>
+      columns={columns}
+      dataSource={data}
+      rowKey={rowKey}
+      loading={loading}
+      searchable={onSearchChange != null}
+      searchValue={searchValue}
+      onSearchChange={onSearchChange}
+      searchPlaceholder={searchPlaceholder}
+      pagination={pagination}
+      initialSort={sort ?? null}
+      onSortChange={onSortChange}
+      emptyState={emptyState}
+      onRowClick={onRowClick}
+      toolbar={toolbar}
+      className={className}
+      fillHeight={fillHeight}
+      groupRows={groupRows}
+    />
+  );
+}

--- a/frontend/src/components/contacts/shared/DirectoryContactTree.tsx
+++ b/frontend/src/components/contacts/shared/DirectoryContactTree.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { ChevronRight, Folder, Loader2 } from 'lucide-react';
+import { Checkbox as CheckboxPrimitive } from 'radix-ui';
+import { useMemo, useState } from 'react';
+
+import { useContactsList } from '@/lib/api/contacts';
+import { useDirectoriesList } from '@/lib/api/contactDirectories';
+import { CustomButton, SearchBar } from '@/components/shared';
+import type { ContactDirectoryListItem } from '@/types/contactDirectory';
+import { cn } from '@/utils/cn';
+
+import type {
+  DirectorySelectionMeta,
+  TreeCheckState,
+  UseDirectoryContactTreeSelectionResult,
+} from './useDirectoryContactTreeSelection';
+
+/**
+ * Hierarchical tri-state directory → contacts tree-select (the "Assign from directories"
+ * option). Each directory is a collapsible parent row (chevron + tri-state checkbox +
+ * folder icon + name + contact-count badge); expanding it lazy-loads that directory's
+ * contacts as child rows (checkbox + name/phone). Checking a directory selects ALL its
+ * contacts; ticking only some children shows the parent as indeterminate. An empty
+ * directory's parent checkbox is a disabled no-op.
+ *
+ * WHAT: renders the tree UI and delegates all selection bookkeeping to the
+ * `useDirectoryContactTreeSelection` state passed in (so the hosting modal owns the
+ * emitted `{ directory_ids, contact_ids }` and the confirm action).
+ *
+ * WHEN: used by `AssignContactsModal`; reusable for any directory+contact picker.
+ */
+export interface DirectoryContactTreeProps {
+  selection: UseDirectoryContactTreeSelectionResult;
+  className?: string;
+}
+
+/** Page size for the (paginated) directory list + each directory's lazy-loaded children. */
+const PAGE_SIZE = 100;
+
+export default function DirectoryContactTree({ selection, className }: DirectoryContactTreeProps) {
+  const [search, setSearch] = useState('');
+  const { data, isLoading } = useDirectoriesList({ search, page_size: PAGE_SIZE });
+  const directories = data?.data ?? [];
+
+  if (isLoading) {
+    return (
+      <div
+        className={cn('flex items-center justify-center py-10 text-muted-foreground', className)}
+      >
+        <Loader2 className="mr-2 size-4 animate-spin" aria-hidden />
+        Loading directories…
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      <SearchBar
+        value={search}
+        onSearch={setSearch}
+        placeholder="Search directories and contacts…"
+        aria-label="Search directories and contacts"
+      />
+
+      {directories.length === 0 ? (
+        <p className="py-8 text-center text-sm text-muted-foreground">No directories found.</p>
+      ) : (
+        <ul role="tree" aria-label="Directories and contacts" className="flex flex-col gap-1">
+          {directories.map((dir) => (
+            <DirectoryNode key={dir.id} directory={dir} search={search} selection={selection} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/** Radix tri-state checkbox with a dash indicator for the indeterminate state. */
+function TriStateCheckbox({
+  state,
+  disabled,
+  onToggle,
+  label,
+  className,
+}: {
+  state: TreeCheckState;
+  disabled?: boolean;
+  onToggle: () => void;
+  label: string;
+  className?: string;
+}) {
+  const checked = state === 'checked' ? true : state === 'indeterminate' ? 'indeterminate' : false;
+  return (
+    <CheckboxPrimitive.Root
+      checked={checked}
+      disabled={disabled}
+      onCheckedChange={onToggle}
+      aria-label={label}
+      className={cn(
+        'peer size-4 shrink-0 rounded-sm border border-primary shadow-xs outline-none transition-shadow',
+        'data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+        'data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground',
+        'focus-visible:ring-[2px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+    >
+      <CheckboxPrimitive.Indicator className="grid place-content-center text-current">
+        {state === 'indeterminate' ? (
+          <span className="block h-0.5 w-2.5 rounded-full bg-current" aria-hidden />
+        ) : (
+          <svg viewBox="0 0 12 12" className="size-3" aria-hidden>
+            <path
+              d="M2 6l2.5 2.5L10 3"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.75"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        )}
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+/** One directory parent row + its lazily-loaded contact children. */
+function DirectoryNode({
+  directory,
+  search,
+  selection,
+}: {
+  directory: ContactDirectoryListItem;
+  search: string;
+  selection: UseDirectoryContactTreeSelectionResult;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const isEmpty = directory.contact_count <= 0;
+
+  // Lazy-load contacts only once the directory is expanded. Search filters children too.
+  const { data, isLoading } = useContactsList(
+    expanded ? directory.id : undefined,
+    { search, page_size: PAGE_SIZE },
+    undefined,
+  );
+  const contacts = useMemo(() => data?.data ?? [], [data]);
+  const loadedContactIds = useMemo(() => contacts.map((c) => c.id), [contacts]);
+
+  const meta: DirectorySelectionMeta = { contactCount: directory.contact_count };
+  const state = selection.getDirectoryState(directory.id, loadedContactIds);
+
+  // Un-ticking a child of a whole-directory pick "explodes" it into the loaded ids only,
+  // so if not all contacts are loaded (>PAGE_SIZE), the unloaded ones would be silently
+  // dropped. Lock per-child toggling in that case — the user can clear the whole directory
+  // or narrow via search to edit individual contacts.
+  const fullyLoaded = !data || contacts.length >= data.total;
+  const lockChildren = selection.isDirectorySelected(directory.id) && !fullyLoaded;
+
+  return (
+    <li role="treeitem" aria-expanded={expanded} className="list-none">
+      <div className="flex items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-muted/60">
+        <CustomButton
+          type="text"
+          size="icon-xs"
+          onClick={() => setExpanded((v) => !v)}
+          aria-label={expanded ? `Collapse ${directory.name}` : `Expand ${directory.name}`}
+          className="size-5 shrink-0 rounded text-muted-foreground hover:text-foreground"
+        >
+          <ChevronRight
+            className={cn('size-4 transition-transform', expanded && 'rotate-90')}
+            aria-hidden
+          />
+        </CustomButton>
+
+        <TriStateCheckbox
+          state={state}
+          disabled={isEmpty}
+          onToggle={() => selection.toggleDirectory(directory.id, loadedContactIds, meta)}
+          label={`Select all contacts in ${directory.name}`}
+        />
+
+        <Folder className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+
+        <CustomButton
+          type="text"
+          onClick={() => setExpanded((v) => !v)}
+          className="flex h-auto min-w-0 flex-1 items-center justify-start gap-2 p-0 text-left font-normal hover:bg-transparent"
+        >
+          <span className="truncate text-sm font-medium">{directory.name}</span>
+          <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+            {directory.contact_count}
+          </span>
+        </CustomButton>
+      </div>
+
+      {expanded && (
+        <ul role="group" className="ml-8 mt-1 flex max-h-56 flex-col gap-0.5 overflow-y-auto pr-1">
+          {isLoading ? (
+            <li className="flex items-center px-2 py-1.5 text-xs text-muted-foreground">
+              <Loader2 className="mr-2 size-3.5 animate-spin" aria-hidden />
+              Loading contacts…
+            </li>
+          ) : contacts.length === 0 ? (
+            <li className="px-2 py-1.5 text-xs text-muted-foreground">No contacts.</li>
+          ) : (
+            contacts.map((contact) => {
+              const checked =
+                selection.isDirectorySelected(directory.id) ||
+                selection.isContactSelected(contact.id);
+              return (
+                <li
+                  key={contact.id}
+                  role="treeitem"
+                  className="flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted/60"
+                >
+                  <TriStateCheckbox
+                    state={checked ? 'checked' : 'unchecked'}
+                    disabled={lockChildren}
+                    onToggle={() =>
+                      selection.toggleContact(contact.id, directory.id, loadedContactIds)
+                    }
+                    label={`Select ${contact.name ?? contact.phone_number ?? 'contact'}`}
+                  />
+                  <span className="truncate text-sm">
+                    {contact.name ?? 'Unnamed contact'}
+                    {contact.phone_number && (
+                      <span className="ml-2 text-xs text-muted-foreground">
+                        {contact.phone_number}
+                      </span>
+                    )}
+                  </span>
+                </li>
+              );
+            })
+          )}
+          {data && data.total > contacts.length && (
+            <li className="px-2 py-1">
+              <CustomButton type="link" size="xs" disabled>
+                Showing {contacts.length} of {data.total}
+                {lockChildren
+                  ? ' — whole directory selected; clear it or search to edit individual contacts'
+                  : ' — refine your search to narrow'}
+              </CustomButton>
+            </li>
+          )}
+        </ul>
+      )}
+    </li>
+  );
+}

--- a/frontend/src/components/contacts/shared/SchemaDrivenContactForm.tsx
+++ b/frontend/src/components/contacts/shared/SchemaDrivenContactForm.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { Controller, type Control, type FieldValues, type Path } from 'react-hook-form';
+
+import { CheckboxField, SelectInput, TextInput } from '@/components/shared';
+import type { SchemaField } from '@/types/contactSchema';
+
+/**
+ * Renders the inputs for a single contact from a schema's `schema_fields` (RHF-driven).
+ *
+ * WHAT: draws the fixed `name` + `phone_number` inputs plus one input per ACTIVE schema
+ * field (string/number → `TextInput`, `enum` → `SelectInput`, `boolean` → `CheckboxField`),
+ * bound to `contact_metadata.<field_name>`. Extracted verbatim from the old
+ * `ContactFormModal` inline logic so Add + Edit + multi-row add all share it.
+ *
+ * WHEN: mount inside any RHF form whose schema was built with `buildContactFormSchema`.
+ * Pass the form `control` and, for multi-row add, a `namePrefix` (e.g. `rows.0`) so the
+ * field paths nest correctly. Validation errors render inline via the shared inputs.
+ *
+ * The form's Zod schema owns validation — this component only renders inputs.
+ */
+export interface SchemaDrivenContactFormProps<TValues extends FieldValues> {
+  /** The RHF control for the parent form. */
+  control: Control<TValues>;
+  /** The schema fields to render (only `is_active` fields are drawn). */
+  fields: SchemaField[];
+  /**
+   * Optional dotted path prefix for the three field groups when this form is one row of
+   * a multi-row add (e.g. `rows.0` → `rows.0.name`, `rows.0.metadata.<key>`). Defaults to
+   * the top level (`name`, `phone_number`, `metadata.<key>`).
+   */
+  namePrefix?: string;
+  /** Hide the fixed name/phone inputs (e.g. when the parent renders them itself). */
+  hideBaseFields?: boolean;
+}
+
+export default function SchemaDrivenContactForm<TValues extends FieldValues>({
+  control,
+  fields,
+  namePrefix,
+  hideBaseFields = false,
+}: SchemaDrivenContactFormProps<TValues>) {
+  const prefix = namePrefix ? `${namePrefix}.` : '';
+  const path = (segment: string) => `${prefix}${segment}` as Path<TValues>;
+  const activeFields = fields.filter((f) => f.is_active);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {!hideBaseFields && (
+        <>
+          <TextInput name={path('name')} label="Name" control={control} placeholder="Jane Doe" />
+          <TextInput
+            name={path('phone_number')}
+            label="Phone number"
+            control={control}
+            placeholder="+14155550123"
+          />
+        </>
+      )}
+
+      {activeFields.map((f) => {
+        const fieldName = path(`metadata.${f.field_name}`);
+        const fieldLabel = f.label || f.field_name;
+
+        if (f.type === 'boolean') {
+          return (
+            <Controller
+              key={f.id}
+              name={fieldName}
+              control={control}
+              render={({ field }) => (
+                <CheckboxField
+                  id={`cf-${f.id}`}
+                  label={fieldLabel}
+                  isRequired={f.is_mandatory}
+                  checked={!!field.value}
+                  onCheckedChange={(v) => field.onChange(!!v)}
+                />
+              )}
+            />
+          );
+        }
+
+        if (f.type === 'enum') {
+          return (
+            <Controller
+              key={f.id}
+              name={fieldName}
+              control={control}
+              render={({ field, fieldState }) => (
+                <SelectInput
+                  name={f.field_name}
+                  label={fieldLabel}
+                  isRequired={f.is_mandatory}
+                  options={(f.options ?? []).map((o) => ({
+                    value: o.value,
+                    label: o.label || o.value,
+                  }))}
+                  value={(field.value as string) ?? ''}
+                  onValueChange={field.onChange}
+                  error={!!fieldState.error}
+                  helperText={fieldState.error?.message}
+                />
+              )}
+            />
+          );
+        }
+
+        return (
+          <TextInput
+            key={f.id}
+            name={fieldName}
+            label={fieldLabel}
+            isRequired={f.is_mandatory}
+            control={control}
+            type={f.type === 'string' ? 'text' : 'number'}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/contacts/shared/SchemaFieldsEditor.tsx
+++ b/frontend/src/components/contacts/shared/SchemaFieldsEditor.tsx
@@ -1,0 +1,322 @@
+'use client';
+
+import { ListPlus, Pencil, Plus, Trash2, X } from 'lucide-react';
+import { useState } from 'react';
+
+import {
+  useCreateSchemaField,
+  useDeleteSchemaField,
+  useUpdateSchemaField,
+} from '@/lib/api/contactSchemas';
+import { CheckboxField, CustomButton, SelectInput, TextInput } from '@/components/shared';
+import type {
+  CreateSchemaFieldPayload,
+  SchemaField,
+  SchemaFieldOption,
+  SchemaFieldType,
+} from '@/types/contactSchema';
+import { handleApiError } from '@/utils/helpers';
+import { showToast } from '@/utils/toast';
+
+import ConfirmDeleteModal from './ConfirmDeleteModal';
+
+/**
+ * CRUD editor for a schema's `SchemaField` rows (type / format / required / validators /
+ * enum options / source_key).
+ *
+ * WHAT: lists the schema's fields and provides an inline add/edit form plus per-row
+ * delete (confirm). Wired to the schema-field mutation hooks (create/update/delete),
+ * which invalidate the schema detail so the list refreshes. Read-only when `!canEdit`
+ * (member view).
+ *
+ * WHEN: reuse for both a directory's default schema and any datasource schema in the
+ * shared org schema library (F5). It owns only field editing — the parent owns the
+ * schema-level create/rename/delete + set-as-default.
+ */
+const FIELD_TYPES: { value: SchemaFieldType; label: string }[] = [
+  { value: 'string', label: 'Text' },
+  { value: 'number', label: 'Number' },
+  { value: 'integer', label: 'Integer' },
+  { value: 'boolean', label: 'Boolean' },
+  { value: 'enum', label: 'Enum' },
+];
+
+export interface SchemaFieldsEditorProps {
+  schemaId: string;
+  fields: SchemaField[];
+  /** Whether the current user may create/edit/delete fields (admin/owner). */
+  canEdit?: boolean;
+}
+
+interface DraftField {
+  field_name: string;
+  label: string;
+  type: SchemaFieldType;
+  format: string;
+  is_mandatory: boolean;
+  source_key: string;
+  /** Comma-separated enum values (only used when `type === 'enum'`). */
+  optionsText: string;
+}
+
+const EMPTY_DRAFT: DraftField = {
+  field_name: '',
+  label: '',
+  type: 'string',
+  format: '',
+  is_mandatory: false,
+  source_key: '',
+  optionsText: '',
+};
+
+function optionsFromText(text: string): SchemaFieldOption[] {
+  return text
+    .split(',')
+    .map((v) => v.trim())
+    .filter(Boolean)
+    .map((value) => ({ value }));
+}
+
+function draftToPayload(draft: DraftField): CreateSchemaFieldPayload {
+  return {
+    field_name: draft.field_name.trim(),
+    type: draft.type,
+    label: draft.label.trim() || null,
+    format: draft.format.trim() || null,
+    is_mandatory: draft.is_mandatory,
+    source_key: draft.source_key.trim() || null,
+    options: draft.type === 'enum' ? optionsFromText(draft.optionsText) : null,
+  };
+}
+
+export default function SchemaFieldsEditor({
+  schemaId,
+  fields,
+  canEdit = false,
+}: SchemaFieldsEditorProps) {
+  const createField = useCreateSchemaField();
+  const updateField = useUpdateSchemaField();
+  const deleteField = useDeleteSchemaField();
+
+  const [draft, setDraft] = useState<DraftField>(EMPTY_DRAFT);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<SchemaField | null>(null);
+
+  const set = <K extends keyof DraftField>(key: K, value: DraftField[K]) =>
+    setDraft((d) => ({ ...d, [key]: value }));
+
+  const openCreate = () => {
+    setEditingId(null);
+    setDraft(EMPTY_DRAFT);
+    setShowForm(true);
+  };
+
+  const openEdit = (field: SchemaField) => {
+    setEditingId(field.id);
+    setDraft({
+      field_name: field.field_name,
+      label: field.label ?? '',
+      type: field.type,
+      format: field.format ?? '',
+      is_mandatory: field.is_mandatory,
+      source_key: field.source_key ?? '',
+      optionsText: (field.options ?? []).map((o) => o.value).join(', '),
+    });
+    setShowForm(true);
+  };
+
+  const closeForm = () => {
+    setShowForm(false);
+    setEditingId(null);
+    setDraft(EMPTY_DRAFT);
+  };
+
+  const save = async () => {
+    if (!draft.field_name.trim()) {
+      showToast.error('Field name is required.');
+      return;
+    }
+    try {
+      if (editingId) {
+        const { field_name: _fieldName, ...editable } = draftToPayload(draft);
+        await updateField.mutateAsync({ fieldId: editingId, schemaId, payload: editable });
+        showToast.success('Field updated');
+      } else {
+        await createField.mutateAsync({ schemaId, payload: draftToPayload(draft) });
+        showToast.success('Field added');
+      }
+      closeForm();
+    } catch (err) {
+      handleApiError(err);
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteField.mutateAsync({ fieldId: deleteTarget.id, schemaId });
+      showToast.success('Field removed');
+      setDeleteTarget(null);
+    } catch (err) {
+      handleApiError(err);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-semibold">Fields</h4>
+        {canEdit && !showForm && (
+          <CustomButton type="default" size="sm" onClick={openCreate}>
+            <Plus className="size-4" /> Add field
+          </CustomButton>
+        )}
+      </div>
+
+      {fields.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed border-border px-6 py-10 text-center">
+          <span className="flex size-12 items-center justify-center rounded-full bg-muted/60">
+            <ListPlus className="size-6 text-muted-foreground" aria-hidden />
+          </span>
+          <div className="flex flex-col gap-1">
+            <p className="text-sm font-medium text-foreground">No fields yet</p>
+            <p className="text-xs text-muted-foreground">
+              Add fields to define the shape of contacts using this schema.
+            </p>
+          </div>
+          {canEdit && !showForm && (
+            <CustomButton type="primary" size="sm" onClick={openCreate}>
+              <Plus className="size-4" aria-hidden /> Add field
+            </CustomButton>
+          )}
+        </div>
+      ) : (
+        <ul className="flex flex-col divide-y divide-border rounded-lg border border-border">
+          {fields.map((field) => (
+            <li key={field.id} className="flex items-center justify-between gap-3 px-3 py-2.5">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  <span className="truncate">{field.label || field.field_name}</span>
+                  <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                    {field.type}
+                  </span>
+                  {field.is_mandatory && (
+                    <span className="text-[11px] font-medium text-red-600">required</span>
+                  )}
+                </div>
+                <p className="truncate text-xs text-muted-foreground">
+                  {field.field_name}
+                  {field.source_key ? ` ← ${field.source_key}` : ''}
+                </p>
+              </div>
+              {canEdit && (
+                <div className="flex items-center gap-1">
+                  <CustomButton
+                    type="text"
+                    size="icon-xs"
+                    aria-label={`Edit ${field.field_name}`}
+                    onClick={() => openEdit(field)}
+                  >
+                    <Pencil className="size-4" />
+                  </CustomButton>
+                  <CustomButton
+                    type="text"
+                    size="icon-xs"
+                    aria-label={`Delete ${field.field_name}`}
+                    onClick={() => setDeleteTarget(field)}
+                  >
+                    <Trash2 className="size-4 text-red-600" />
+                  </CustomButton>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {canEdit && showForm && (
+        <div className="flex flex-col gap-3 rounded-lg border border-border bg-muted/20 p-4">
+          <div className="flex items-center justify-between">
+            <h5 className="text-sm font-semibold">{editingId ? 'Edit field' : 'New field'}</h5>
+            <CustomButton type="text" size="icon-xs" aria-label="Close" onClick={closeForm}>
+              <X className="size-4" />
+            </CustomButton>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <TextInput
+              name="field_name"
+              label="Field name *"
+              value={draft.field_name}
+              onChange={(e) => set('field_name', e.target.value)}
+              disabled={!!editingId}
+              placeholder="first_name"
+            />
+            <TextInput
+              name="label"
+              label="Label"
+              value={draft.label}
+              onChange={(e) => set('label', e.target.value)}
+              placeholder="First name"
+            />
+            <SelectInput
+              name="type"
+              label="Type"
+              options={FIELD_TYPES}
+              value={draft.type}
+              onValueChange={(v) => set('type', v as SchemaFieldType)}
+            />
+            <TextInput
+              name="source_key"
+              label="Source key (CSV header)"
+              value={draft.source_key}
+              onChange={(e) => set('source_key', e.target.value)}
+              placeholder="identity if blank"
+            />
+            {draft.type === 'enum' && (
+              <TextInput
+                name="options"
+                label="Options (comma-separated)"
+                className="col-span-2"
+                value={draft.optionsText}
+                onChange={(e) => set('optionsText', e.target.value)}
+                placeholder="low, medium, high"
+              />
+            )}
+          </div>
+
+          <CheckboxField
+            id="field-required"
+            label="Required"
+            checked={draft.is_mandatory}
+            onCheckedChange={(v) => set('is_mandatory', !!v)}
+          />
+
+          <div className="flex justify-end gap-2">
+            <CustomButton type="default" onClick={closeForm}>
+              Cancel
+            </CustomButton>
+            <CustomButton
+              type="primary"
+              onClick={save}
+              loading={createField.isPending || updateField.isPending}
+            >
+              {editingId ? 'Save' : 'Add'}
+            </CustomButton>
+          </div>
+        </div>
+      )}
+
+      <ConfirmDeleteModal
+        open={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={confirmDelete}
+        title="Remove field"
+        description="Existing contacts keep their metadata; the field stops being enforced."
+        confirmText="Remove"
+        loading={deleteField.isPending}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/contacts/shared/SyncContactsModal.tsx
+++ b/frontend/src/components/contacts/shared/SyncContactsModal.tsx
@@ -1,0 +1,367 @@
+'use client';
+
+import { Download, FileUp } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import { useCreateContactSync } from '@/lib/api/contactSyncs';
+import { useDirectoriesList } from '@/lib/api/contactDirectories';
+import { useSchema, useSchemasList } from '@/lib/api/contactSchemas';
+import { CustomButton, CustomModal, SelectInput } from '@/components/shared';
+import type { SchemaField } from '@/types/contactSchema';
+import { triggerCsvDownload } from '@/utils/download';
+import { handleApiError } from '@/utils/helpers';
+import { showToast } from '@/utils/toast';
+
+import AdvancedDirectoryConfig from './AdvancedDirectoryConfig';
+import SyncErrorTable from './SyncErrorTable';
+import SyncStatusChip from './SyncStatusChip';
+import { useSyncStatusPolling } from './useSyncStatusPolling';
+
+/**
+ * The contact-sync stepper: pick datasource → mapping schema → (for CSV) upload file →
+ * confirm → progress (polled).
+ *
+ * WHAT: creates a `ContactSync` for a directory from an uploaded CSV mapped through a
+ * chosen org schema, then polls the sync to a terminal status showing live counts and,
+ * on partial success, a completed-with-warnings banner linking the error report. If an
+ * `agentId` is passed, it is sent so the worker auto-assigns imported contacts to that
+ * agent on completion.
+ *
+ * WHEN: reuse for both the directory General view (no `agentId`) and the Agent Contacts
+ * tab's "Sync + auto-assign" option (`agentId` set). This is the single sync-launch UI.
+ */
+export interface SyncContactsModalProps {
+  open: boolean;
+  onClose: () => void;
+  /**
+   * The directory to import into (directory General view). Omit in the agent-tab context —
+   * the modal then defaults to the org's "Global" directory (resolved by name) and lets the
+   * user override it via the Advanced configuration section.
+   */
+  directoryId?: string;
+  /** Optional agent to auto-assign the imported contacts to (Agent Contacts tab). */
+  agentId?: string | null;
+  /** The directory's default schema id — preselected in the schema picker. */
+  defaultSchemaId?: string | null;
+  /**
+   * Called when a sync finishes so the parent can refresh its contacts list. Receives the
+   * finished sync's id (optional) so the parent can poll/link it directly instead of
+   * re-deriving it from a possibly-stale "most recent sync" query.
+   */
+  onCompleted?: (syncId?: string) => void;
+}
+
+/** Datasource types a sync can pull from. CSV is the only type at launch; the picker
+ * is future-proofed for REST/others (which would swap the CSV upload for their own
+ * config). Only `csv` reveals the file-upload control. */
+const DATASOURCE_OPTIONS = [{ value: 'csv', label: 'CSV file' }];
+
+/** Standard dial columns the CSV importer recognizes, always present in the template. */
+const BASE_CSV_COLUMNS = ['name', 'phone_number'];
+
+/**
+ * Build a sample CSV template from a schema's fields so the user uploads a file whose
+ * headers already match the mapping. Headers = the base dial columns + each field's
+ * external `source_key` (or `field_name` when it maps by identity); one example row
+ * illustrates the expected shape.
+ */
+function buildSampleCsv(schemaName: string, fields: SchemaField[]): string {
+  // Each column carries its base (unmarked) key + the header text shown in the file.
+  // Mandatory schema fields are marked with a trailing `*` so the user can see which
+  // columns are required; the importer strips that `*` when mapping, so a filled-in
+  // template still imports correctly.
+  const columns: { key: string; header: string }[] = BASE_CSV_COLUMNS.map((key) => ({
+    key,
+    header: key,
+  }));
+  const seen = new Set(columns.map((c) => c.key));
+  for (const f of fields) {
+    const key = (f.source_key || f.field_name || '').trim();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    columns.push({ key, header: f.is_mandatory ? `${key}*` : key });
+  }
+  const exampleRow = columns.map((c) => {
+    if (c.key === 'name') return 'John Doe';
+    if (c.key === 'phone_number') return '+14155550123';
+    return '';
+  });
+  const headerLine = columns.map((c) => c.header).join(',');
+  return `${headerLine}\n${exampleRow.join(',')}\n`;
+}
+
+export default function SyncContactsModal({
+  open,
+  onClose,
+  directoryId,
+  agentId,
+  defaultSchemaId,
+  onCompleted,
+}: SyncContactsModalProps) {
+  const { data: schemasPage } = useSchemasList({ page_size: 100 });
+  const createSync = useCreateContactSync();
+
+  // Agent-tab context: no fixed directory, but an agent to auto-assign to. Only then do we
+  // need the directories list (to default to "Global" and offer the override).
+  const isAgentContext = !directoryId && !!agentId;
+  const directoriesQuery = useDirectoriesList({ page_size: 100 }, { enabled: isAgentContext });
+  const directoryOptions = (directoriesQuery.data?.data ?? []).map((d) => ({
+    value: d.id,
+    label: d.name,
+  }));
+  // The org's seeded "Global" directory is the default target — resolved BY NAME from the
+  // normal directories list (there is no /global endpoint).
+  const globalDirectory = directoriesQuery.data?.data?.find((d) => d.name === 'Global');
+
+  const [datasourceType, setDatasourceType] = useState<string>('csv');
+  const [schemaId, setSchemaId] = useState<string>(defaultSchemaId ?? '');
+  const [file, setFile] = useState<File | null>(null);
+  const [syncId, setSyncId] = useState<string | null>(null);
+  const [pickedDirectoryId, setPickedDirectoryId] = useState<string>('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // The directory we actually import into: the fixed prop, or the user's pick (defaulting
+  // to "Global" in the agent context).
+  const effectiveDirectoryId = directoryId ?? pickedDirectoryId;
+
+  // The selected schema's fields drive the downloadable sample template.
+  const { data: schemaDetail } = useSchema(schemaId || null);
+
+  const poll = useSyncStatusPolling(syncId);
+  const notifiedSyncId = useRef<string | null>(null);
+
+  const schemaOptions = (schemasPage?.data ?? []).map((s) => ({ value: s.id, label: s.name }));
+  const isCsv = datasourceType === 'csv';
+
+  // Notify the parent exactly once per sync, when it first reaches a terminal state, so
+  // it can refetch its contacts list (a render-time call would loop).
+  useEffect(() => {
+    if (poll.isTerminal && syncId && notifiedSyncId.current !== syncId) {
+      notifiedSyncId.current = syncId;
+      onCompleted?.(syncId);
+    }
+  }, [poll.isTerminal, syncId, onCompleted]);
+
+  // Agent context: default the target to the "Global" directory once the list arrives, if
+  // the user hasn't overridden it. If no "Global" exists, the pick stays empty and the user
+  // expands Advanced configuration to choose a directory.
+  useEffect(() => {
+    if (open && isAgentContext && !pickedDirectoryId && globalDirectory) {
+      setPickedDirectoryId(globalDirectory.id);
+    }
+  }, [open, isAgentContext, pickedDirectoryId, globalDirectory]);
+
+  const reset = () => {
+    setDatasourceType('csv');
+    setSchemaId(defaultSchemaId ?? '');
+    setFile(null);
+    setSyncId(null);
+    notifiedSyncId.current = null;
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const handleDownloadSample = () => {
+    if (!schemaDetail) return;
+    const slug = (schemaDetail.name || 'schema').trim().replace(/\s+/g, '-').toLowerCase();
+    triggerCsvDownload(
+      `sample-${slug}.csv`,
+      buildSampleCsv(schemaDetail.name, schemaDetail.fields ?? []),
+    );
+  };
+
+  const startSync = async () => {
+    if (!effectiveDirectoryId || !schemaId || (isCsv && !file)) {
+      showToast.error('Pick a directory, a schema and a CSV file first.');
+      return;
+    }
+    try {
+      const sync = await createSync.mutateAsync({
+        directory_id: effectiveDirectoryId,
+        schema_id: schemaId,
+        agent_id: agentId ?? undefined,
+        file: file as File,
+      });
+      setSyncId(sync.id);
+    } catch (err) {
+      handleApiError(err);
+    }
+  };
+
+  const counts = poll.sync?.counts ?? {};
+  const canStart = !!effectiveDirectoryId && !!schemaId && (!isCsv || !!file);
+  const rowErrors = poll.sync?.row_errors ?? [];
+
+  return (
+    <CustomModal
+      open={open}
+      onClose={handleClose}
+      title="Sync Contacts"
+      hideFooter
+      width="sm:max-w-lg"
+    >
+      <div className="flex flex-col gap-4">
+        {!syncId && (
+          <>
+            <SelectInput
+              name="sync-datasource"
+              label="Datasource"
+              options={DATASOURCE_OPTIONS}
+              value={datasourceType}
+              onValueChange={setDatasourceType}
+              placeholder="Select a datasource"
+            />
+
+            <SelectInput
+              name="sync-schema"
+              label="Mapping schema"
+              options={schemaOptions}
+              value={schemaId}
+              onValueChange={setSchemaId}
+              placeholder="Select a schema"
+            />
+
+            {isCsv && (
+              <div className="flex flex-col gap-1.5">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-sm font-medium text-foreground">CSV file</span>
+                  {schemaId && (
+                    <CustomButton
+                      type="text"
+                      size="xs"
+                      icon={<Download className="size-3.5" />}
+                      onClick={handleDownloadSample}
+                    >
+                      Download sample
+                    </CustomButton>
+                  )}
+                </div>
+
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".csv,text/csv"
+                  className="hidden"
+                  onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+                />
+                <div className="flex items-center gap-3 rounded-lg border border-input bg-background px-3 py-2">
+                  <CustomButton
+                    type="default"
+                    size="sm"
+                    icon={<FileUp className="size-4" />}
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    Choose file
+                  </CustomButton>
+                  <span
+                    className={`min-w-0 flex-1 truncate text-sm ${
+                      file ? 'text-foreground' : 'text-muted-foreground'
+                    }`}
+                    title={file?.name}
+                  >
+                    {file?.name ?? 'No file chosen'}
+                  </span>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {schemaId
+                    ? 'Upload a CSV whose columns match the selected schema, or download the sample above. Columns marked * are required.'
+                    : 'Select a mapping schema to download a matching sample template.'}
+                </p>
+              </div>
+            )}
+
+            {isAgentContext && (
+              <AdvancedDirectoryConfig
+                options={directoryOptions}
+                value={pickedDirectoryId}
+                onChange={setPickedDirectoryId}
+                loading={directoriesQuery.isLoading}
+              />
+            )}
+
+            <div className="flex justify-end gap-2 pt-2">
+              <CustomButton type="default" onClick={handleClose}>
+                Cancel
+              </CustomButton>
+              <CustomButton
+                type="primary"
+                onClick={startSync}
+                loading={createSync.isPending}
+                disabled={!canStart}
+              >
+                Start sync
+              </CustomButton>
+            </div>
+          </>
+        )}
+
+        {syncId && (
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">Import status</span>
+              {poll.status && <SyncStatusChip status={poll.status} />}
+            </div>
+
+            {poll.isTerminal && (
+              <dl className="grid grid-cols-4 gap-2 text-center text-sm">
+                <div>
+                  <dt className="text-xs text-muted-foreground">Created</dt>
+                  <dd className="font-medium">{counts.created ?? 0}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-muted-foreground">Updated</dt>
+                  <dd className="font-medium">{counts.updated ?? 0}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-muted-foreground">Skipped</dt>
+                  <dd className="font-medium">{counts.skipped ?? 0}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-muted-foreground">Failed</dt>
+                  <dd className="font-medium">{counts.failed ?? 0}</dd>
+                </div>
+              </dl>
+            )}
+
+            {poll.completedWithWarnings && (
+              <div
+                role="alert"
+                className="rounded-lg bg-orange-50 px-3 py-2 text-sm text-orange-800 ring-1 ring-inset ring-orange-200"
+              >
+                Import finished with some skipped rows — review them below.
+              </div>
+            )}
+
+            {poll.isFailed && (
+              <div
+                role="alert"
+                className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-800 ring-1 ring-inset ring-red-200"
+              >
+                {poll.sync?.error ?? 'The import failed. Please check the file and try again.'}
+              </div>
+            )}
+
+            {poll.isTerminal && (
+              <SyncErrorTable rowErrors={rowErrors} syncId={syncId ?? undefined} />
+            )}
+
+            <div className="flex justify-end gap-2 pt-2">
+              {poll.isFailed && (
+                <CustomButton type="default" onClick={reset}>
+                  Retry
+                </CustomButton>
+              )}
+              <CustomButton type="primary" onClick={handleClose} disabled={poll.isPolling}>
+                {poll.isTerminal ? 'Done' : 'Importing…'}
+              </CustomButton>
+            </div>
+          </div>
+        )}
+      </div>
+    </CustomModal>
+  );
+}

--- a/frontend/src/components/contacts/shared/SyncErrorTable.tsx
+++ b/frontend/src/components/contacts/shared/SyncErrorTable.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { Download } from 'lucide-react';
+
+import { CustomButton } from '@/components/shared';
+import type { ContactSyncRowError } from '@/types/contactSync';
+import { triggerCsvDownload } from '@/utils/download';
+
+/**
+ * The shared "Skipped rows" error-report panel for a contact sync.
+ *
+ * WHAT: renders the sync's per-row errors as a scrollable ROW · CONTACT · REASON table
+ * with a header count and a Download button that exports the same rows as a CSV.
+ *
+ * WHEN: reuse anywhere a sync's `row_errors` are shown — the live sync stepper
+ * (`SyncContactsModal`) and the reopenable sync history (`SyncHistoryModal`). Renders
+ * nothing when there are no row errors.
+ */
+export interface SyncErrorTableProps {
+  rowErrors: ContactSyncRowError[];
+  /** The sync id — used to name the downloaded report file. */
+  syncId?: string;
+  /** Panel header text; defaults to "Skipped rows (N)". */
+  title?: string;
+}
+
+/** Turn the sync's per-row errors into a downloadable CSV (row is 1-based data row). */
+export function buildSyncErrorReportCsv(rowErrors: ContactSyncRowError[]): string {
+  const esc = (v: string) => (/[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v);
+  const lines = rowErrors.map((e) =>
+    [
+      String(e.row + 1),
+      esc(e.name ?? ''),
+      esc(e.phone_number ?? ''),
+      esc(e.field ?? ''),
+      esc(e.message),
+    ].join(','),
+  );
+  return `row,name,phone_number,field,message\n${lines.join('\n')}\n`;
+}
+
+export default function SyncErrorTable({ rowErrors, syncId, title }: SyncErrorTableProps) {
+  if (rowErrors.length === 0) return null;
+
+  const handleDownload = () => {
+    triggerCsvDownload(
+      `sync-errors-${syncId?.slice(0, 8) ?? 'report'}.csv`,
+      buildSyncErrorReportCsv(rowErrors),
+    );
+  };
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border">
+      <div className="flex items-center justify-between border-b border-border bg-muted/30 px-3 py-2">
+        <span className="text-sm font-medium text-foreground">
+          {title ?? `Skipped rows (${rowErrors.length})`}
+        </span>
+        <CustomButton
+          type="text"
+          size="xs"
+          icon={<Download className="size-3.5" />}
+          onClick={handleDownload}
+        >
+          Download
+        </CustomButton>
+      </div>
+      <div className="max-h-52 overflow-y-auto">
+        <table className="w-full text-left text-sm">
+          <thead className="sticky top-0 bg-card text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <tr>
+              <th className="px-3 py-1.5">Row</th>
+              <th className="px-3 py-1.5">Contact</th>
+              <th className="px-3 py-1.5">Reason</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rowErrors.map((e, i) => (
+              <tr key={`${e.row}-${i}`} className="border-t border-border/60">
+                <td className="whitespace-nowrap px-3 py-1.5 tabular-nums text-muted-foreground">
+                  {e.row + 1}
+                </td>
+                <td className="px-3 py-1.5">
+                  {e.name || e.phone_number || <span className="text-muted-foreground">—</span>}
+                </td>
+                <td className="px-3 py-1.5 text-muted-foreground">
+                  {e.field ? `${e.field}: ` : ''}
+                  {e.message}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/contacts/shared/SyncStatusChip.tsx
+++ b/frontend/src/components/contacts/shared/SyncStatusChip.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { AlertCircle, CheckCircle2, Clock, Loader2, type LucideIcon } from 'lucide-react';
+
+import type { ContactSyncStatus } from '@/types/contactSync';
+import { cn } from '@/utils/cn';
+
+/**
+ * A small status pill for a `ContactSync` lifecycle status.
+ *
+ * WHAT: maps `pending|processing|completed|failed` to a labelled, coloured chip (mirrors
+ * the `ScheduledCallStatusChip` visual language). `processing` pulses.
+ *
+ * WHEN: use anywhere a sync's status is shown — the sync stepper progress line, a sync
+ * history row, or the Agent Contacts auto-assign flow.
+ */
+interface StatusConfig {
+  label: string;
+  className: string;
+  Icon: LucideIcon;
+  pulse?: boolean;
+}
+
+const STATUS_CONFIG: Record<ContactSyncStatus, StatusConfig> = {
+  pending: {
+    label: 'Pending',
+    className: 'bg-slate-100 text-slate-700 ring-slate-200',
+    Icon: Clock,
+  },
+  processing: {
+    label: 'Processing',
+    className: 'bg-blue-100 text-blue-700 ring-blue-200',
+    Icon: Loader2,
+    pulse: true,
+  },
+  completed: {
+    label: 'Completed',
+    className: 'bg-emerald-100 text-emerald-800 ring-emerald-200',
+    Icon: CheckCircle2,
+  },
+  failed: {
+    label: 'Failed',
+    className: 'bg-red-100 text-red-700 ring-red-200',
+    Icon: AlertCircle,
+  },
+};
+
+export default function SyncStatusChip({ status }: { status: ContactSyncStatus }) {
+  const { label, className, Icon, pulse } = STATUS_CONFIG[status];
+  return (
+    <span
+      aria-label={`Sync status: ${label}`}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ring-1 ring-inset',
+        className,
+      )}
+    >
+      <Icon className={cn('size-3.5', pulse && 'motion-safe:animate-spin')} aria-hidden />
+      {label}
+    </span>
+  );
+}

--- a/frontend/src/components/contacts/shared/buildContactFormSchema.ts
+++ b/frontend/src/components/contacts/shared/buildContactFormSchema.ts
@@ -1,0 +1,86 @@
+import { z } from 'zod';
+
+import type { SchemaField } from '@/types/contactSchema';
+
+/**
+ * Build a runtime Zod object schema from a directory/schema's `schema_fields`.
+ *
+ * WHAT: mirrors the backend field rules (type + `is_mandatory` + validators) so the same
+ * constraints are enforced client-side before the request. Only ACTIVE fields are used;
+ * the returned schema is keyed by `field_name` (matching `contact_metadata`).
+ *
+ * WHEN: use it wherever contact metadata is entered against a schema — the Add and Edit
+ * contact forms both compose it into their form schema (extracted from the old inline
+ * `ContactFormModal.buildMetadataSchema`, now shared per the DRY catalog).
+ */
+/** Treat an empty/blank input as "no value" so `.optional()` and required checks behave. */
+const emptyToUndefined = (v: unknown) => (v === '' || v == null ? undefined : v);
+
+export function buildContactMetadataSchema(fields: SchemaField[]): z.ZodObject<z.ZodRawShape> {
+  const shape: Record<string, z.ZodTypeAny> = {};
+  for (const f of fields.filter((d) => d.is_active)) {
+    let schema: z.ZodTypeAny;
+    if (f.type === 'boolean') {
+      schema = z.boolean().optional();
+    } else if (f.type === 'enum') {
+      const values = (f.options ?? []).map((o) => o.value);
+      let enumSchema: z.ZodTypeAny = values.length
+        ? z.enum(values as [string, ...string[]])
+        : z.string();
+      if (!f.is_mandatory) enumSchema = enumSchema.optional().or(z.literal(''));
+      schema = enumSchema;
+    } else if (f.type === 'number' || f.type === 'integer') {
+      let num = z.coerce.number();
+      if (f.validators.minimum != null) num = num.min(f.validators.minimum);
+      if (f.validators.maximum != null) num = num.max(f.validators.maximum);
+      if (f.type === 'integer') num = num.int();
+      // Number inputs emit '' when cleared; `z.coerce.number('')` is 0, which would
+      // silently pass a required field and store 0 for an optional one. Map empty to
+      // undefined first so required stays required and optional fields are omitted.
+      schema = z.preprocess(emptyToUndefined, f.is_mandatory ? num : num.optional());
+    } else {
+      let str = z.string();
+      if (f.validators.minLength != null) str = str.min(f.validators.minLength);
+      if (f.validators.maxLength != null) str = str.max(f.validators.maxLength);
+      if (f.validators.pattern) str = str.regex(new RegExp(f.validators.pattern));
+      // For optional fields, treat '' as absent so a `minLength` validator doesn't
+      // reject a blank input (`.optional()` only admits undefined, not '').
+      schema = f.is_mandatory
+        ? str.min(1, `${f.label || f.field_name} is required`)
+        : z.preprocess(emptyToUndefined, str.optional());
+    }
+    shape[f.field_name] = schema;
+  }
+  return z.object(shape);
+}
+
+/** E.164 phone validation shared by the contact forms (empty allowed — number optional). */
+export const phoneNumberSchema = z
+  .string()
+  .optional()
+  .refine((v) => !v || /^\+[1-9]\d{6,14}$/.test(v), 'Must be E.164 (e.g. +14155550123)');
+
+/**
+ * The full contact form schema: the fixed `name` + `phone_number` columns plus the
+ * schema-driven `metadata` object. Rebuild it whenever `fields` change (memoise at the
+ * call site).
+ */
+export function buildContactFormSchema(fields: SchemaField[]) {
+  return z
+    .object({
+      name: z.string().optional(),
+      phone_number: phoneNumberSchema,
+      metadata: buildContactMetadataSchema(fields),
+    })
+    .refine((v) => !!(v.name?.trim() || v.phone_number?.trim()), {
+      message: 'Enter a name or phone number',
+      path: ['name'],
+    });
+}
+
+/** Inferred value type of the contact form (name + phone + metadata record). */
+export interface ContactFormValues {
+  name?: string;
+  phone_number?: string;
+  metadata: Record<string, unknown>;
+}

--- a/frontend/src/components/contacts/shared/index.ts
+++ b/frontend/src/components/contacts/shared/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Barrel for the reusable Contact Directories building blocks (F0). Directory pages
+ * (F2–F5, F7) and the Agent Contacts tab (F6) import from here so there is one canonical
+ * path for every shared piece — see the FE reusable-components catalog in the plan.
+ */
+export { default as ContactsTable } from './ContactsTable';
+export type { ContactsTableProps } from './ContactsTable';
+
+export { default as SchemaDrivenContactForm } from './SchemaDrivenContactForm';
+export type { SchemaDrivenContactFormProps } from './SchemaDrivenContactForm';
+
+export {
+  buildContactFormSchema,
+  buildContactMetadataSchema,
+  phoneNumberSchema,
+} from './buildContactFormSchema';
+export type { ContactFormValues } from './buildContactFormSchema';
+
+export { default as SchemaFieldsEditor } from './SchemaFieldsEditor';
+export type { SchemaFieldsEditorProps } from './SchemaFieldsEditor';
+
+export { default as SyncContactsModal } from './SyncContactsModal';
+export type { SyncContactsModalProps } from './SyncContactsModal';
+
+export { default as SyncStatusChip } from './SyncStatusChip';
+
+export { useSyncStatusPolling } from './useSyncStatusPolling';
+export type { UseSyncStatusPollingResult } from './useSyncStatusPolling';
+
+export { default as ConfirmDeleteModal } from './ConfirmDeleteModal';
+export type { ConfirmDeleteModalProps } from './ConfirmDeleteModal';
+
+export { default as AssignContactsModal } from './AssignContactsModal';
+export type { AssignContactsModalProps } from './AssignContactsModal';
+
+export { default as DirectoryContactTree } from './DirectoryContactTree';
+export type { DirectoryContactTreeProps } from './DirectoryContactTree';
+
+export { useDirectoryContactTreeSelection } from './useDirectoryContactTreeSelection';
+export type {
+  DirectoryContactSelection,
+  DirectorySelectionMeta,
+  TreeCheckState,
+  UseDirectoryContactTreeSelectionResult,
+} from './useDirectoryContactTreeSelection';

--- a/frontend/src/components/contacts/shared/useDirectoryContactTreeSelection.ts
+++ b/frontend/src/components/contacts/shared/useDirectoryContactTreeSelection.ts
@@ -1,0 +1,171 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+
+/** Tri-state a directory parent checkbox can show in the tree. */
+export type TreeCheckState = 'checked' | 'unchecked' | 'indeterminate';
+
+/**
+ * The assign payload the tree emits: whole-directory picks travel as ids (expanded to
+ * their active contacts server-side) and individually-ticked contacts as `contact_ids`,
+ * so a directory with thousands of contacts never balloons into thousands of rows.
+ */
+export interface DirectoryContactSelection {
+  directory_ids: string[];
+  contact_ids: string[];
+}
+
+/** Per-directory info the hook needs to reason about tri-state. */
+export interface DirectorySelectionMeta {
+  /** Live contact count from the directory list (for the "empty → no-op" rule + tri-state). */
+  contactCount: number;
+}
+
+/**
+ * Selection state machine for the directory→contacts tri-state tree.
+ *
+ * WHAT: tracks two disjoint selection sets — whole directories (`selectedDirectoryIds`)
+ * and individual contacts (`selectedContactIds`) — and derives each directory parent's
+ * tri-state (`checked` when the whole directory is picked, `indeterminate` when only some
+ * of its loaded children are, else `unchecked`). Toggling a directory selects/clears the
+ * whole directory (clearing any of its individually-ticked contacts). Toggling a child
+ * peels the directory out of the "whole" set and manages that contact id directly.
+ *
+ * WHEN: drives `DirectoryContactTree`; the emitted `selection` feeds the assign hook's
+ * `{ directory_ids, contact_ids }` body.
+ *
+ * The hook is agnostic to lazy-loading: `contactIdsByDirectory` is whatever children have
+ * been loaded so far, so a not-yet-expanded whole-directory pick still counts correctly.
+ */
+export function useDirectoryContactTreeSelection() {
+  // Directories picked as a whole (sent as `directory_ids`).
+  const [selectedDirectoryIds, setSelectedDirectoryIds] = useState<Set<string>>(new Set());
+  // Contacts picked individually (sent as `contact_ids`).
+  const [selectedContactIds, setSelectedContactIds] = useState<Set<string>>(new Set());
+
+  const isDirectorySelected = useCallback(
+    (directoryId: string) => selectedDirectoryIds.has(directoryId),
+    [selectedDirectoryIds],
+  );
+
+  const isContactSelected = useCallback(
+    (contactId: string) => selectedContactIds.has(contactId),
+    [selectedContactIds],
+  );
+
+  /**
+   * Derive a directory's parent-checkbox state. A whole-directory pick is always
+   * `checked`; otherwise it's `indeterminate` if any of its loaded contacts are ticked,
+   * else `unchecked`. An empty directory can never be indeterminate.
+   */
+  const getDirectoryState = useCallback(
+    (directoryId: string, loadedContactIds: string[]): TreeCheckState => {
+      if (selectedDirectoryIds.has(directoryId)) return 'checked';
+      const anyChild = loadedContactIds.some((id) => selectedContactIds.has(id));
+      return anyChild ? 'indeterminate' : 'unchecked';
+    },
+    [selectedDirectoryIds, selectedContactIds],
+  );
+
+  /**
+   * Toggle a whole directory. Selecting it adds the directory id and drops any of its
+   * individually-ticked children (they're now covered by the whole-directory pick);
+   * deselecting removes the directory id. Empty directories are a no-op.
+   */
+  const toggleDirectory = useCallback(
+    (directoryId: string, loadedContactIds: string[], meta: DirectorySelectionMeta) => {
+      if (meta.contactCount <= 0) return; // empty directory → no-op
+      setSelectedDirectoryIds((prev) => {
+        const next = new Set(prev);
+        const willSelect = !next.has(directoryId);
+        if (willSelect) next.add(directoryId);
+        else next.delete(directoryId);
+        // When picking the whole directory, clear its now-redundant child ticks.
+        if (willSelect && loadedContactIds.length) {
+          setSelectedContactIds((prevContacts) => {
+            const nextContacts = new Set(prevContacts);
+            for (const id of loadedContactIds) nextContacts.delete(id);
+            return nextContacts;
+          });
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  /**
+   * Toggle a single contact. If its directory was picked as a whole, first "explode" that
+   * pick into the directory's currently-loaded contact ids so removing one child leaves
+   * the rest selected, then flip the target contact.
+   */
+  const toggleContact = useCallback(
+    (contactId: string, directoryId: string, loadedContactIds: string[]) => {
+      setSelectedDirectoryIds((prevDirs) => {
+        if (!prevDirs.has(directoryId)) return prevDirs;
+        // Explode the whole-directory pick into individual child ids.
+        setSelectedContactIds((prevContacts) => {
+          const next = new Set(prevContacts);
+          for (const id of loadedContactIds) next.add(id);
+          return next;
+        });
+        const nextDirs = new Set(prevDirs);
+        nextDirs.delete(directoryId);
+        return nextDirs;
+      });
+      setSelectedContactIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(contactId)) next.delete(contactId);
+        else next.add(contactId);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const clear = useCallback(() => {
+    setSelectedDirectoryIds(new Set());
+    setSelectedContactIds(new Set());
+  }, []);
+
+  const selection: DirectoryContactSelection = useMemo(
+    () => ({
+      directory_ids: Array.from(selectedDirectoryIds),
+      contact_ids: Array.from(selectedContactIds),
+    }),
+    [selectedDirectoryIds, selectedContactIds],
+  );
+
+  /**
+   * A rough "N selected" summary. Whole-directory picks contribute their `contactCount`
+   * (best-effort, from the meta map); individually-ticked contacts each count as one.
+   */
+  const countSelected = useCallback(
+    (metaByDirectory: Map<string, DirectorySelectionMeta>) => {
+      let total = selectedContactIds.size;
+      for (const dirId of selectedDirectoryIds) {
+        total += metaByDirectory.get(dirId)?.contactCount ?? 0;
+      }
+      return total;
+    },
+    [selectedContactIds, selectedDirectoryIds],
+  );
+
+  const hasSelection = selectedDirectoryIds.size > 0 || selectedContactIds.size > 0;
+
+  return {
+    selection,
+    hasSelection,
+    isDirectorySelected,
+    isContactSelected,
+    getDirectoryState,
+    toggleDirectory,
+    toggleContact,
+    clear,
+    countSelected,
+  };
+}
+
+export type UseDirectoryContactTreeSelectionResult = ReturnType<
+  typeof useDirectoryContactTreeSelection
+>;

--- a/frontend/src/components/contacts/shared/useSyncStatusPolling.ts
+++ b/frontend/src/components/contacts/shared/useSyncStatusPolling.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useContactSync } from '@/lib/api/contactSyncs';
+import {
+  CONTACT_SYNC_TERMINAL_STATUSES,
+  type ContactSync,
+  type ContactSyncStatus,
+} from '@/types/contactSync';
+
+/**
+ * Poll one sync until it reaches a terminal status.
+ *
+ * WHAT: wraps `useContactSync(id, { poll: true })` and derives convenience flags — the
+ * live sync, whether it's still running, whether it finished, and whether it completed
+ * WITH row-level warnings (partial failures). Polling stops automatically at a terminal
+ * status (`completed`/`failed`).
+ *
+ * WHEN: use in the sync stepper (`SyncContactsModal`) and the Agent Contacts auto-assign
+ * flow to drive the progress UI and the completed-with-warnings banner. Pass `null` to
+ * disable (before a sync has been created).
+ */
+export interface UseSyncStatusPollingResult {
+  sync: ContactSync | undefined;
+  status: ContactSyncStatus | undefined;
+  isPolling: boolean;
+  isTerminal: boolean;
+  isCompleted: boolean;
+  isFailed: boolean;
+  /** Completed, but at least one row was skipped/failed (has warnings + an error report). */
+  completedWithWarnings: boolean;
+  isLoading: boolean;
+}
+
+export function useSyncStatusPolling(
+  syncId: string | null | undefined,
+): UseSyncStatusPollingResult {
+  const { data: sync, isLoading } = useContactSync(syncId, { poll: true });
+  const status = sync?.status;
+
+  const isTerminal = status != null && CONTACT_SYNC_TERMINAL_STATUSES.includes(status);
+  const isCompleted = status === 'completed';
+  const isFailed = status === 'failed';
+
+  const counts = sync?.counts ?? {};
+  const hasRowWarnings =
+    (sync?.row_errors?.length ?? 0) > 0 || (counts.skipped ?? 0) > 0 || (counts.failed ?? 0) > 0;
+
+  return {
+    sync,
+    status,
+    isPolling: !!syncId && !isTerminal,
+    isTerminal,
+    isCompleted,
+    isFailed,
+    completedWithWarnings: isCompleted && hasRowWarnings,
+    isLoading,
+  };
+}

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Home,
   Phone,
   Settings,
+  Users,
   Wrench,
 } from 'lucide-react';
 import Link from 'next/link';
@@ -45,6 +46,7 @@ const NAV_SECTIONS: SidebarNavGroup[] = [
       { label: 'Tools', href: '/tools', icon: Wrench },
       { label: 'MCP', href: '/mcp', icon: Boxes },
       { label: 'Knowledge Base', href: '/knowledge-base', icon: BookOpen },
+      { label: 'Contacts', href: '/contacts', icon: Users },
       { label: 'Scheduled Calls', href: '/scheduled-calls', icon: CalendarClock },
       { label: 'Call History', href: '/call-history', icon: Phone },
     ],

--- a/frontend/src/components/outbound-calls/NewOutboundCallModal.tsx
+++ b/frontend/src/components/outbound-calls/NewOutboundCallModal.tsx
@@ -5,20 +5,22 @@ import {
   CheckboxField,
   CustomButton,
   CustomModal,
+  DateTimePicker,
   SelectInput,
   TextAreaField,
-  TextInput,
 } from '@/components/shared';
 import { listAgents } from '@/services/agentsService';
 import { getChannelsByType, listChannelPhoneNumbers } from '@/services/channelService';
 import type { CreateOutboundCallPayload } from '@/types/outboundCall';
+import { getBrowserTimeZone } from '@/utils/date';
+import { triggerCsvDownload } from '@/utils/download';
 import { handleApiError } from '@/utils/helpers';
 import { showToast } from '@/utils/toast';
 import { useSetAtom } from 'jotai';
 import { Download, Upload } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 
 interface Option {
   value: string;
@@ -69,19 +71,6 @@ function parseNumbers(text: string): string[] {
   return out;
 }
 
-/** Download a sample CSV so users know the expected format (one E.164 number per row). */
-function downloadSampleCsv(): void {
-  const csv = ['phone_number', '+14155550123', '+14155550124', '+442071838750'].join('\n');
-  const url = URL.createObjectURL(new Blob([csv], { type: 'text/csv;charset=utf-8;' }));
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = 'outbound-numbers-sample.csv';
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  URL.revokeObjectURL(url);
-}
-
 export default function NewOutboundCallModal({
   open,
   onClose,
@@ -111,7 +100,7 @@ export default function NewOutboundCallModal({
   const scheduleOn = watch('schedule');
   const numbersText = watch('to_numbers_text');
   const numberCount = useMemo(() => parseNumbers(numbersText).length, [numbersText]);
-  const nowLocal = useMemo(() => new Date().toISOString().slice(0, 16), []);
+  const browserTz = useMemo(() => getBrowserTimeZone(), []);
 
   useEffect(() => {
     if (!open) return;
@@ -290,7 +279,12 @@ export default function NewOutboundCallModal({
               <CustomButton
                 type="text"
                 icon={<Download className="size-3.5" />}
-                onClick={downloadSampleCsv}
+                onClick={() =>
+                  triggerCsvDownload(
+                    'outbound-numbers-sample.csv',
+                    ['phone_number', '+14155550123', '+14155550124', '+442071838750'].join('\n'),
+                  )
+                }
               >
                 Sample CSV
               </CustomButton>
@@ -327,14 +321,29 @@ export default function NewOutboundCallModal({
         </div>
         <CheckboxField id="schedule" control={control} label="Schedule for later" />
         {scheduleOn && (
-          <TextInput
+          <Controller
             name="scheduled_at"
             control={control}
-            type="datetime-local"
-            label="Scheduled time"
-            isRequired
-            min={nowLocal}
-            rules={{ required: 'Pick a time in the future' }}
+            rules={{
+              required: 'Pick a time in the future',
+              validate: (v: string) =>
+                (!!v && new Date(v).getTime() > Date.now()) || 'Pick a time in the future',
+            }}
+            render={({ field, fieldState }) => (
+              <div className="flex flex-col gap-1.5">
+                <label className="text-sm font-medium">
+                  Scheduled time <span className="text-destructive">*</span>
+                </label>
+                <DateTimePicker
+                  value={{ value: field.value || null, timeZone: browserTz }}
+                  onChange={(v) => field.onChange(v.value ?? '')}
+                  placeholder="Pick a date & time"
+                />
+                {fieldState.error && (
+                  <span className="text-xs text-destructive">{fieldState.error.message}</span>
+                )}
+              </div>
+            )}
           />
         )}
       </form>

--- a/frontend/src/components/scheduled-calls/ScheduledCallStatusChip.tsx
+++ b/frontend/src/components/scheduled-calls/ScheduledCallStatusChip.tsx
@@ -38,6 +38,12 @@ const STATUS_CONFIG: Record<ScheduledCallStatus, StatusConfig> = {
     Icon: PhoneOutgoing,
     pulse: true,
   },
+  in_progress: {
+    label: 'In progress',
+    className: 'bg-indigo-100 text-indigo-700 ring-indigo-200',
+    Icon: PhoneOutgoing,
+    pulse: true,
+  },
   completed: {
     label: 'Completed',
     className: 'bg-emerald-100 text-emerald-800 ring-emerald-200',

--- a/frontend/src/components/scheduled-calls/ScheduledCallsPage.tsx
+++ b/frontend/src/components/scheduled-calls/ScheduledCallsPage.tsx
@@ -11,10 +11,11 @@ import type { CustomTableColumn } from '@/components/shared';
 import { CustomButton, CustomModal, CustomTable, CustomTooltip } from '@/components/shared';
 import { Checkbox } from '@/components/ui/checkbox';
 import type { ScheduledCallRow, ScheduledCallStatus } from '@/types/outboundCall';
+import { triggerCsvDownload } from '@/utils/download';
 import { handleApiError } from '@/utils/helpers';
 import { showToast } from '@/utils/toast';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { Ban, PhoneForwarded, PhoneOutgoing } from 'lucide-react';
+import { Ban, Download, PhoneForwarded, PhoneOutgoing } from 'lucide-react';
 import Link from 'next/link';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -188,6 +189,18 @@ export default function ScheduledCallsPage() {
       render: (_v, record) => <ScheduledCallStatusChip status={record.status} />,
     },
     {
+      key: 'provider_call_sid',
+      title: 'Call SID',
+      render: (_v, record) =>
+        record.provider_call_sid ? (
+          <span className="font-mono text-xs text-muted-foreground">
+            {record.provider_call_sid}
+          </span>
+        ) : (
+          <span className="text-muted-foreground">—</span>
+        ),
+    },
+    {
       key: 'scheduled_at',
       title: 'Scheduled for',
       render: (_v, record) => (
@@ -226,19 +239,33 @@ export default function ScheduledCallsPage() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <div>
+        <div className="space-y-1">
           <h1 className="text-xl font-semibold tracking-tight">Scheduled Calls</h1>
           <p className="text-sm text-muted-foreground">
             Outbound calls queued to dial at a future time. Connected calls appear in Call History.
           </p>
         </div>
-        <CustomButton
-          type="primary"
-          icon={<PhoneOutgoing className="size-4" />}
-          onClick={() => setCreateOpen(true)}
-        >
-          Schedule Call
-        </CustomButton>
+        <div className="flex items-center gap-2">
+          <CustomButton
+            type="default"
+            icon={<Download className="size-4" />}
+            onClick={() =>
+              triggerCsvDownload(
+                'outbound-numbers-sample.csv',
+                ['phone_number', '+14155550123', '+14155550124', '+442071838750'].join('\n'),
+              )
+            }
+          >
+            Sample CSV
+          </CustomButton>
+          <CustomButton
+            type="primary"
+            icon={<PhoneOutgoing className="size-4" />}
+            onClick={() => setCreateOpen(true)}
+          >
+            Schedule Call
+          </CustomButton>
+        </div>
       </div>
 
       {selectedCount > 0 && (

--- a/frontend/src/components/shared/CollapsibleSection.tsx
+++ b/frontend/src/components/shared/CollapsibleSection.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { ChevronDown } from 'lucide-react';
+import { type ReactNode, useId, useState } from 'react';
+
+import { cn } from '@/utils/cn';
+
+export interface CollapsibleSectionProps {
+  title: string;
+  description?: ReactNode | ((expanded: boolean) => ReactNode);
+  icon?: ReactNode;
+  defaultExpanded?: boolean;
+  expanded?: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
+  children: ReactNode;
+  className?: string;
+}
+
+export default function CollapsibleSection({
+  title,
+  description,
+  icon,
+  defaultExpanded = false,
+  expanded: expandedProp,
+  onExpandedChange,
+  children,
+  className,
+}: CollapsibleSectionProps) {
+  const [internalExpanded, setInternalExpanded] = useState(defaultExpanded);
+  const isControlled = expandedProp !== undefined;
+  const expanded = isControlled ? expandedProp : internalExpanded;
+  const reduceMotion = useReducedMotion();
+  const panelId = useId();
+
+  const toggle = () => {
+    const next = !expanded;
+    if (!isControlled) setInternalExpanded(next);
+    onExpandedChange?.(next);
+  };
+
+  const resolvedDescription =
+    typeof description === 'function' ? description(expanded) : description;
+
+  return (
+    <div
+      className={cn(
+        'overflow-hidden rounded-xl border bg-card transition-colors duration-200',
+        expanded ? 'border-primary/30 shadow-sm' : 'border-border',
+        className,
+      )}
+    >
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-controls={panelId}
+        onClick={toggle}
+        className={cn(
+          'group flex w-full cursor-pointer items-center gap-3 px-3.5 py-3 text-left',
+          'transition-colors hover:bg-muted/40',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring',
+        )}
+      >
+        {icon && (
+          <span
+            className={cn(
+              'flex size-8 shrink-0 items-center justify-center rounded-lg transition-colors duration-200',
+              expanded
+                ? 'bg-primary/10 text-primary'
+                : 'bg-muted text-muted-foreground group-hover:text-foreground',
+            )}
+          >
+            {icon}
+          </span>
+        )}
+
+        <span className="min-w-0 flex-1">
+          <span className="block text-sm font-medium text-foreground">{title}</span>
+          {resolvedDescription != null && (
+            <span className="block truncate text-xs text-muted-foreground">
+              {resolvedDescription}
+            </span>
+          )}
+        </span>
+
+        <ChevronDown
+          className={cn(
+            'size-4 shrink-0 text-muted-foreground',
+            'motion-safe:transition-transform motion-safe:duration-200',
+            expanded && 'rotate-180 text-primary',
+          )}
+          aria-hidden
+        />
+      </button>
+
+      <AnimatePresence initial={false}>
+        {expanded && (
+          <motion.div
+            id={panelId}
+            key="panel"
+            initial={reduceMotion ? false : { height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={reduceMotion ? { opacity: 0 } : { height: 0, opacity: 0 }}
+            transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] }}
+            className="overflow-hidden"
+          >
+            <div className="border-t border-border px-3.5 pb-3.5 pt-3">{children}</div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/frontend/src/components/shared/CustomTable.tsx
+++ b/frontend/src/components/shared/CustomTable.tsx
@@ -75,6 +75,8 @@ function CustomTableInner<TRow>({
   title,
   description,
   initialSort = null,
+  fillHeight = false,
+  groupRows = false,
 }: CustomTableProps<TRow>) {
   const [sorting, setSorting] = useState<SortingState>(() => {
     if (!initialSort) return [];
@@ -233,7 +235,7 @@ function CustomTableInner<TRow>({
     !!description;
 
   return (
-    <div className={cn('flex flex-col gap-4 min-h-0', className)}>
+    <div className={cn('flex flex-col gap-4 min-h-0', fillHeight && 'h-full flex-1', className)}>
       {(title || description) && (
         <div className="flex flex-col gap-1">
           {title && <h3 className="text-base font-semibold tracking-tight">{title}</h3>}
@@ -333,7 +335,12 @@ function CustomTableInner<TRow>({
         </div>
       )}
 
-      <div className="flex flex-col min-h-0 overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+      <div
+        className={cn(
+          'flex flex-col min-h-0 overflow-hidden rounded-xl border border-border bg-card shadow-sm',
+          fillHeight && 'flex-1',
+        )}
+      >
         <DataTable
           table={table}
           rows={paginatedRows}
@@ -343,6 +350,8 @@ function CustomTableInner<TRow>({
           onRowClick={onRowClick}
           getRowKey={getRowKey}
           density={density}
+          groupRows={groupRows}
+          fill={fillHeight}
         />
 
         {paginationEnabled && !loading && processedRows.length > 0 && (

--- a/frontend/src/components/shared/DateRangePicker.tsx
+++ b/frontend/src/components/shared/DateRangePicker.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { TZDate } from '@date-fns/tz';
 import { CalendarDays, ChevronDown, Clock } from 'lucide-react';
 import React, { useEffect, useMemo, useState } from 'react';
 import type { DateRange } from 'react-day-picker';
@@ -13,7 +12,13 @@ import SearchableSelect, {
 import { Calendar } from '@/components/ui/calendar';
 import type { DateRangePickerProps } from '@/types/components';
 import { cn } from '@/utils/cn';
-import { formatTzDateTime, getBrowserTimeZone } from '@/utils/date';
+import {
+  combineToIso,
+  formatTzDateTime,
+  getBrowserTimeZone,
+  getTimeZones,
+  splitFromIso,
+} from '@/utils/date';
 
 export type { DateRangePickerProps, DateRangeValue } from '@/types/components';
 
@@ -27,8 +32,6 @@ const PRESETS: Array<{ key: string; label: string; title: string; ms: number }> 
   { key: '7d', label: '7d', title: 'Last 7 days', ms: 7 * 24 * 60 * 60_000 },
 ];
 
-const pad = (n: number) => String(n).padStart(2, '0');
-
 /** `Jun 5, 2026` for the Start/End summary rows. */
 function formatDayLabel(day?: Date): string {
   if (!day) return 'Select a day';
@@ -37,44 +40,6 @@ function formatDayLabel(day?: Date): string {
     day: 'numeric',
     year: 'numeric',
   }).format(day);
-}
-
-/**
- * Combine a calendar day + `HH:mm` time, interpreted in `tz`, into a `Z`-normalized
- * UTC ISO instant (e.g. `2026-06-05T11:14:00.000Z`) — the form the backend's
- * `started_at` comparison expects.
- */
-function combineToIso(day: Date, time: string, tz: string): string {
-  const [h, m] = time.split(':').map((s) => parseInt(s, 10));
-  const tzDate = TZDate.tz(
-    tz,
-    day.getFullYear(),
-    day.getMonth(),
-    day.getDate(),
-    Number.isFinite(h) ? h : 0,
-    Number.isFinite(m) ? m : 0,
-  );
-  return new Date(tzDate.getTime()).toISOString();
-}
-
-/** Split a UTC ISO instant into its wall-clock day + `HH:mm` time within `tz`. */
-function splitFromIso(iso: string, tz: string): { day: Date; time: string } {
-  const d = new TZDate(new Date(iso), tz);
-  return {
-    day: new Date(d.getFullYear(), d.getMonth(), d.getDate()),
-    time: `${pad(d.getHours())}:${pad(d.getMinutes())}`,
-  };
-}
-
-function getTimeZones(): string[] {
-  try {
-    const supported = (Intl as unknown as { supportedValuesOf?: (k: string) => string[] })
-      .supportedValuesOf;
-    if (typeof supported === 'function') return supported('timeZone');
-  } catch {
-    /* older runtimes — fall through */
-  }
-  return ['UTC', BROWSER_TZ];
 }
 
 /**

--- a/frontend/src/components/shared/DateTimePicker.tsx
+++ b/frontend/src/components/shared/DateTimePicker.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { CalendarDays, ChevronDown, Clock } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from 'react';
+
+import CustomButton from '@/components/shared/CustomButton';
+import CustomPopover from '@/components/shared/CustomPopover';
+import SearchableSelect, {
+  type SearchableSelectOption,
+} from '@/components/shared/SearchableSelect';
+import { Calendar } from '@/components/ui/calendar';
+import type { DateTimePickerProps } from '@/types/components';
+import { cn } from '@/utils/cn';
+import {
+  combineToIso,
+  formatTzDateTime,
+  getBrowserTimeZone,
+  getTimeZones,
+  splitFromIso,
+} from '@/utils/date';
+
+export type { DateTimePickerProps, DateTimeValue } from '@/types/components';
+
+const BROWSER_TZ = getBrowserTimeZone();
+
+/** `Jun 5, 2026` for the summary row. */
+function formatDayLabel(day?: Date): string {
+  if (!day) return 'Select a day';
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(day);
+}
+
+/**
+ * Shared, timezone-aware **single-instant** picker (calendar + `HH:mm` time + IANA
+ * timezone), styled to match {@link DateRangePicker}. Emits `{ value, timeZone }` where
+ * `value` is a UTC ISO instant — the form the backend's `scheduled_at` expects. No range,
+ * no relative presets. Drafts live inside the popover until Apply.
+ */
+const DateTimePicker: React.FC<DateTimePickerProps> = ({
+  value,
+  onChange,
+  placeholder = 'Select date & time',
+  align = 'start',
+  className,
+  triggerClassName,
+  disabled,
+}) => {
+  const [open, setOpen] = useState(false);
+  const [day, setDay] = useState<Date | undefined>(undefined);
+  const [time, setTime] = useState('09:00');
+  const [timeZone, setTimeZone] = useState(value?.timeZone || BROWSER_TZ);
+
+  // Seed the draft from the applied value every time the popover opens.
+  useEffect(() => {
+    if (!open) return;
+    const tz = value?.timeZone || BROWSER_TZ;
+    setTimeZone(tz);
+    if (value?.value) {
+      const s = splitFromIso(value.value, tz);
+      setDay(s.day);
+      setTime(s.time);
+    } else {
+      setDay(undefined);
+      setTime('09:00');
+    }
+  }, [open, value?.value, value?.timeZone]);
+
+  const tzOptions = useMemo<SearchableSelectOption[]>(() => {
+    const zones = getTimeZones();
+    if (!zones.includes(BROWSER_TZ)) zones.unshift(BROWSER_TZ);
+    return zones.map((z) => ({ value: z, label: z.replace(/_/g, ' ') }));
+  }, []);
+
+  const handleApply = () => {
+    if (!day) {
+      onChange?.({ value: null, timeZone });
+      setOpen(false);
+      return;
+    }
+    onChange?.({ value: combineToIso(day, time, timeZone), timeZone });
+    setOpen(false);
+  };
+
+  const handleClear = () => {
+    setDay(undefined);
+    onChange?.({ value: null, timeZone });
+    setOpen(false);
+  };
+
+  const hasValue = !!value?.value;
+  const triggerLabel = hasValue ? formatTzDateTime(value!.value!, value!.timeZone) : placeholder;
+
+  return (
+    <CustomPopover
+      open={open}
+      onOpenChange={setOpen}
+      modal
+      align={align}
+      width="w-[320px]"
+      className={cn(
+        'flex max-h-[min(85vh,var(--radix-popover-content-available-height))] flex-col overflow-hidden',
+        className,
+      )}
+      contentClassName="min-h-0 max-h-none flex-1 space-y-2.5 px-2 py-2.5"
+      trigger={
+        <CustomButton
+          type="default"
+          size="sm"
+          disabled={disabled}
+          aria-label="Select date and time"
+          className={cn(
+            'justify-start gap-2 font-normal',
+            hasValue
+              ? 'border-solid border-primary/40 bg-primary/5 text-foreground hover:bg-primary/10'
+              : 'border-dashed text-muted-foreground',
+            triggerClassName,
+          )}
+        >
+          <CalendarDays
+            className={cn('size-4 shrink-0', hasValue ? 'text-primary' : 'text-muted-foreground')}
+          />
+          <span className="truncate">{triggerLabel}</span>
+          <ChevronDown className="ml-auto size-4 shrink-0 opacity-60" />
+        </CustomButton>
+      }
+      footer={
+        <>
+          <CustomButton type="text" size="sm" onClick={handleClear} disabled={!day}>
+            Clear
+          </CustomButton>
+          <CustomButton type="primary" size="sm" onClick={handleApply}>
+            Apply
+          </CustomButton>
+        </>
+      }
+    >
+      <div className="flex justify-center">
+        <Calendar
+          mode="single"
+          selected={day}
+          onSelect={setDay}
+          numberOfMonths={1}
+          defaultMonth={day}
+        />
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-border">
+        <div className="flex items-center gap-2 px-2.5 py-2">
+          <span className="w-10 shrink-0 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            When
+          </span>
+          <div className="flex min-w-0 flex-1 items-center gap-1.5 text-sm">
+            <CalendarDays className="size-3.5 shrink-0 text-muted-foreground" />
+            <span className={cn('truncate tabular-nums', !day && 'text-muted-foreground')}>
+              {formatDayLabel(day)}
+            </span>
+          </div>
+          <div className="flex shrink-0 items-center gap-1.5 rounded-md border border-input bg-background pl-2 transition-colors focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/30">
+            <Clock className="size-3.5 shrink-0 text-muted-foreground" />
+            <input
+              type="time"
+              value={time}
+              onChange={(e) => setTime(e.target.value)}
+              aria-label="time"
+              className="h-8 w-[104px] bg-transparent pr-2 text-sm tabular-nums outline-none"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-3">
+        <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Timezone
+        </span>
+        <div className="min-w-0 flex-1">
+          <SearchableSelect
+            name="dtp-timezone"
+            options={tzOptions}
+            value={timeZone}
+            onValueChange={setTimeZone}
+            searchPlaceholder="Search timezone..."
+          />
+        </div>
+      </div>
+    </CustomPopover>
+  );
+};
+
+export default React.memo(DateTimePicker);

--- a/frontend/src/components/shared/index.tsx
+++ b/frontend/src/components/shared/index.tsx
@@ -1,6 +1,7 @@
 import ActionMenu from './ActionMenu';
 import AppLoader from './AppLoader';
 import CheckboxField from './CheckboxField';
+import CollapsibleSection from './CollapsibleSection';
 import CustomButton from './CustomButton';
 import CustomCard from './CustomCard';
 import CustomDrawer from './CustomDrawer';
@@ -11,6 +12,7 @@ import CustomTab from './CustomTab';
 import CustomTable from './CustomTable';
 import CustomTooltip from './CustomTooltip';
 import DateRangePicker from './DateRangePicker';
+import DateTimePicker from './DateTimePicker';
 import Divider from './Divider';
 import ErrorBoundary from './ErrorBoundary';
 import Form from './Form';
@@ -39,6 +41,8 @@ export type {
   CustomTableProps,
   DateRangePickerProps,
   DateRangeValue,
+  DateTimePickerProps,
+  DateTimeValue,
   FormCheckboxFieldProps,
   FormMultiSelectFieldProps,
   FormRadioGroupFieldProps,
@@ -60,6 +64,7 @@ export type {
   TokenSearchBarProps,
   TokenSearchField,
 } from '@/types/components';
+export type { CollapsibleSectionProps } from './CollapsibleSection';
 export type { CustomCardProps } from './CustomCard';
 export type { SearchableSelectOption } from './SearchableSelect';
 export type { TabItem } from './CustomTab';
@@ -80,6 +85,7 @@ export {
   ActionMenu,
   AppLoader,
   CheckboxField,
+  CollapsibleSection,
   CustomButton,
   CustomCard,
   CustomDrawer,
@@ -90,6 +96,7 @@ export {
   CustomTable,
   CustomTooltip,
   DateRangePicker,
+  DateTimePicker,
   Divider,
   ErrorBoundary,
   Form,

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -26,9 +26,18 @@ function alignClass(align?: 'left' | 'center' | 'right') {
 /*  Base primitives (shadcn)                                                  */
 /* -------------------------------------------------------------------------- */
 
-function Table({ className, ...props }: React.ComponentProps<'table'>) {
+function Table({
+  className,
+  fill = false,
+  ...props
+}: React.ComponentProps<'table'> & { fill?: boolean }) {
   return (
-    <div data-slot="table-container" className="relative w-full overflow-auto">
+    <div
+      data-slot="table-container"
+      // `fill` opts a table into growing to fill a flex-column parent; off by default so
+      // ordinary tables don't flex-grow (a layout-shift risk) inside such parents.
+      className={cn('relative w-full overflow-auto', fill && 'min-h-0 flex-1')}
+    >
       <table
         data-slot="table"
         className={cn('w-full caption-bottom text-sm', className)}
@@ -132,6 +141,10 @@ interface DataTableProps<TData> {
   onRowClick?: (record: TData, index: number) => void;
   getRowKey?: (record: TData) => string | number;
   density?: TableDensity;
+  /** Tag each body row with `group` so cells can reveal content on `group-hover`. */
+  groupRows?: boolean;
+  /** Let the scroll container grow to fill a flex-column parent (sticky header + internal scroll). */
+  fill?: boolean;
 }
 
 function DataTableInner<TData>(
@@ -144,6 +157,8 @@ function DataTableInner<TData>(
     onRowClick,
     getRowKey,
     density = 'cozy',
+    groupRows = false,
+    fill = false,
   }: DataTableProps<TData>,
   _ref: React.Ref<HTMLTableElement>,
 ) {
@@ -153,15 +168,24 @@ function DataTableInner<TData>(
   const visibleColumns = table.getVisibleLeafColumns();
 
   return (
-    <Table>
+    <Table fill={fill}>
       <TableHeader className="sticky top-0 z-10 bg-card">
         <TableRow className="border-b border-border bg-muted/40 hover:bg-muted/40">
           {headerGroup.headers.map((header) => {
             const meta = header.column.columnDef.meta;
             const canSort = header.column.getCanSort();
+            const sorted = header.column.getIsSorted();
+            const ariaSort = canSort
+              ? sorted === 'asc'
+                ? 'ascending'
+                : sorted === 'desc'
+                  ? 'descending'
+                  : 'none'
+              : undefined;
             return (
               <TableHead
                 key={header.id}
+                aria-sort={ariaSort}
                 className={cn(
                   'h-11 px-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground',
                   alignClass(meta?.align),
@@ -222,7 +246,8 @@ function DataTableInner<TData>(
             <TableRow
               key={getRowKey ? getRowKey(row.original) : row.id}
               className={cn(
-                'border-b border-border/50 transition-colors hover:bg-muted/20',
+                'border-b border-border/50 transition-colors hover:bg-muted/40',
+                groupRows && 'group',
                 onRowClick && 'cursor-pointer',
               )}
               onClick={

--- a/frontend/src/lib/api/agentContacts.ts
+++ b/frontend/src/lib/api/agentContacts.ts
@@ -1,0 +1,77 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { contactKeys } from '@/lib/api/queryKeys';
+import { toListBody, usePaginatedList } from '@/lib/api/usePaginatedList';
+import type {
+  AgentContactRow,
+  AssignContactsPayload,
+  AssignContactsResult,
+  UnassignContactsPayload,
+  UnassignContactsResult,
+} from '@/types/agentContact';
+import type { PaginatedListParams, PaginatedResponse } from '@/types/contactList';
+import axios from '@/utils/axios';
+
+/** Thin typed wrapper over the `/agents/{id}/contacts/*` assignment endpoints. */
+export const agentContactsApi = {
+  list: async (
+    agentId: string,
+    params: PaginatedListParams = {},
+  ): Promise<PaginatedResponse<AgentContactRow>> => {
+    const { data } = await axios.post<PaginatedResponse<AgentContactRow>>(
+      `/agents/${agentId}/contacts/list`,
+      toListBody(params),
+    );
+    return data;
+  },
+  assign: async (
+    agentId: string,
+    payload: AssignContactsPayload,
+  ): Promise<AssignContactsResult> => {
+    const { data } = await axios.post<AssignContactsResult>(
+      `/agents/${agentId}/contacts/assign`,
+      payload,
+    );
+    return data;
+  },
+  unassign: async (
+    agentId: string,
+    payload: UnassignContactsPayload,
+  ): Promise<UnassignContactsResult> => {
+    const { data } = await axios.post<UnassignContactsResult>(
+      `/agents/${agentId}/contacts/unassign`,
+      payload,
+    );
+    return data;
+  },
+};
+
+/** Paginated list of contacts assigned to an agent (enabled once `agentId` is set). */
+export function useAgentContactsList(
+  agentId: string | null | undefined,
+  params: PaginatedListParams = {},
+) {
+  return usePaginatedList<AgentContactRow>(
+    contactKeys.agentContacts.list(agentId ?? '', params),
+    () => agentContactsApi.list(agentId as string, params),
+    params,
+    { enabled: !!agentId },
+  );
+}
+
+export function useAssignContacts(agentId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: AssignContactsPayload) => agentContactsApi.assign(agentId, payload),
+    onSuccess: () => qc.invalidateQueries({ queryKey: contactKeys.agentContacts.lists(agentId) }),
+  });
+}
+
+export function useUnassignContacts(agentId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (contactIds: string[]) =>
+      agentContactsApi.unassign(agentId, { contact_ids: contactIds }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: contactKeys.agentContacts.lists(agentId) }),
+  });
+}

--- a/frontend/src/lib/api/contactDatasources.ts
+++ b/frontend/src/lib/api/contactDatasources.ts
@@ -1,0 +1,60 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { contactKeys } from '@/lib/api/queryKeys';
+import { toListBody, usePaginatedList } from '@/lib/api/usePaginatedList';
+import type {
+  ContactDatasource,
+  CreateDatasourcePayload,
+  ListDatasourcesParams,
+} from '@/types/contactDatasource';
+import type { PaginatedListParams, PaginatedResponse } from '@/types/contactList';
+import axios from '@/utils/axios';
+
+/** Combined params for the datasource list (paging + optional directory scoping). */
+export type ListDatasourcesQuery = PaginatedListParams & ListDatasourcesParams;
+
+/** Thin typed wrapper over the `/contact-datasources` endpoints. */
+export const datasourcesApi = {
+  list: async (
+    params: ListDatasourcesQuery = {},
+  ): Promise<PaginatedResponse<ContactDatasource>> => {
+    const { data } = await axios.post<PaginatedResponse<ContactDatasource>>(
+      '/contact-datasources/list',
+      toListBody(params),
+    );
+    return data;
+  },
+  create: async (payload: CreateDatasourcePayload): Promise<ContactDatasource> => {
+    const { data } = await axios.post<ContactDatasource>('/contact-datasources', payload);
+    return data;
+  },
+  remove: async (id: string): Promise<{ ok: boolean }> => {
+    const { data } = await axios.delete<{ ok: boolean }>(`/contact-datasources/${id}`);
+    return data;
+  },
+};
+
+/** Paginated datasource list (optionally scoped to one directory). */
+export function useDatasourcesList(params: ListDatasourcesQuery = {}) {
+  return usePaginatedList<ContactDatasource>(
+    contactKeys.datasources.list(params),
+    () => datasourcesApi.list(params),
+    params,
+  );
+}
+
+export function useCreateDatasource() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: CreateDatasourcePayload) => datasourcesApi.create(payload),
+    onSuccess: () => qc.invalidateQueries({ queryKey: contactKeys.datasources.lists() }),
+  });
+}
+
+export function useDeleteDatasource() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => datasourcesApi.remove(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: contactKeys.datasources.lists() }),
+  });
+}

--- a/frontend/src/lib/api/contactDirectories.ts
+++ b/frontend/src/lib/api/contactDirectories.ts
@@ -1,0 +1,113 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { contactKeys } from '@/lib/api/queryKeys';
+import { toListBody, usePaginatedList } from '@/lib/api/usePaginatedList';
+import type { PaginatedListParams } from '@/types/contactList';
+import type {
+  ContactDirectory,
+  ContactDirectoryListItem,
+  CreateDirectoryPayload,
+  DirectoryDeleteImpact,
+  DirectoryDeleteResult,
+  UpdateDirectoryPayload,
+} from '@/types/contactDirectory';
+import type { PaginatedResponse } from '@/types/contactList';
+import axios from '@/utils/axios';
+
+/** Thin typed wrapper over the `/contact-directories` endpoints (no `any`). */
+export const directoriesApi = {
+  list: async (
+    params: PaginatedListParams = {},
+  ): Promise<PaginatedResponse<ContactDirectoryListItem>> => {
+    const { data } = await axios.post<PaginatedResponse<ContactDirectoryListItem>>(
+      '/contact-directories/list',
+      toListBody(params),
+    );
+    return data;
+  },
+  get: async (id: string): Promise<ContactDirectory> => {
+    const { data } = await axios.get<ContactDirectory>(`/contact-directories/${id}`);
+    return data;
+  },
+  create: async (payload: CreateDirectoryPayload): Promise<ContactDirectory> => {
+    const { data } = await axios.post<ContactDirectory>('/contact-directories', payload);
+    return data;
+  },
+  update: async (id: string, payload: UpdateDirectoryPayload): Promise<ContactDirectory> => {
+    const { data } = await axios.patch<ContactDirectory>(`/contact-directories/${id}`, payload);
+    return data;
+  },
+  deleteImpact: async (id: string): Promise<DirectoryDeleteImpact> => {
+    const { data } = await axios.get<DirectoryDeleteImpact>(
+      `/contact-directories/${id}/delete-impact`,
+    );
+    return data;
+  },
+  remove: async (id: string): Promise<DirectoryDeleteResult> => {
+    const { data } = await axios.delete<DirectoryDeleteResult>(`/contact-directories/${id}`);
+    return data;
+  },
+};
+
+/** Paginated directory list (each row carries a live `contact_count`). */
+export function useDirectoriesList(
+  params: PaginatedListParams = {},
+  options?: { enabled?: boolean },
+) {
+  return usePaginatedList<ContactDirectoryListItem>(
+    contactKeys.directories.list(params),
+    () => directoriesApi.list(params),
+    params,
+    options,
+  );
+}
+
+/** A single directory (enabled only once an id is known). */
+export function useDirectory(id: string | null | undefined) {
+  return useQuery({
+    queryKey: contactKeys.directories.detail(id ?? ''),
+    queryFn: () => directoriesApi.get(id as string),
+    enabled: !!id,
+  });
+}
+
+/** Delete-impact counts for the confirm modal (fetched lazily when `id` is set). */
+export function useDirectoryDeleteImpact(id: string | null | undefined) {
+  return useQuery({
+    queryKey: contactKeys.directories.deleteImpact(id ?? ''),
+    queryFn: () => directoriesApi.deleteImpact(id as string),
+    enabled: !!id,
+  });
+}
+
+export function useCreateDirectory() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: CreateDirectoryPayload) => directoriesApi.create(payload),
+    onSuccess: () => qc.invalidateQueries({ queryKey: contactKeys.directories.lists() }),
+  });
+}
+
+export function useUpdateDirectory() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: UpdateDirectoryPayload }) =>
+      directoriesApi.update(id, payload),
+    onSuccess: (_data, { id }) => {
+      qc.invalidateQueries({ queryKey: contactKeys.directories.lists() });
+      qc.invalidateQueries({ queryKey: contactKeys.directories.detail(id) });
+    },
+  });
+}
+
+export function useDeleteDirectory() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => directoriesApi.remove(id),
+    // Only refresh the lists (rail drops the deleted row). Do NOT invalidate
+    // `all()` — that matches the still-mounted `detail(id)`/`deleteImpact(id)`
+    // queries for the just-deleted directory and refetches them → 404. Those
+    // idle queries GC on navigation away.
+    onSuccess: () => qc.invalidateQueries({ queryKey: contactKeys.directories.lists() }),
+  });
+}

--- a/frontend/src/lib/api/contactSchemas.ts
+++ b/frontend/src/lib/api/contactSchemas.ts
@@ -1,0 +1,153 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { contactKeys } from '@/lib/api/queryKeys';
+import { toListBody, usePaginatedList } from '@/lib/api/usePaginatedList';
+import type { PaginatedListParams, PaginatedResponse } from '@/types/contactList';
+import type {
+  ContactSchema,
+  ContactSchemaDeleteResult,
+  ContactSchemaDetail,
+  ContactSchemaUpdateResult,
+  CreateSchemaFieldPayload,
+  CreateSchemaPayload,
+  SchemaField,
+  UpdateSchemaFieldPayload,
+  UpdateSchemaPayload,
+} from '@/types/contactSchema';
+import axios from '@/utils/axios';
+
+/**
+ * Thin typed wrapper over the org-level `/contact-schemas` + `/schema-fields` endpoints.
+ * Schemas are reusable across directories/syncs; setting a directory's default is done
+ * via the directories client (`PATCH /contact-directories/{id}`), NOT here.
+ */
+export const schemasApi = {
+  list: async (params: PaginatedListParams = {}): Promise<PaginatedResponse<ContactSchema>> => {
+    const { data } = await axios.post<PaginatedResponse<ContactSchema>>(
+      '/contact-schemas/list',
+      toListBody(params),
+    );
+    return data;
+  },
+  get: async (id: string): Promise<ContactSchemaDetail> => {
+    const { data } = await axios.get<ContactSchemaDetail>(`/contact-schemas/${id}`);
+    return data;
+  },
+  create: async (payload: CreateSchemaPayload): Promise<ContactSchema> => {
+    const { data } = await axios.post<ContactSchema>('/contact-schemas', payload);
+    return data;
+  },
+  update: async (id: string, payload: UpdateSchemaPayload): Promise<ContactSchemaUpdateResult> => {
+    const { data } = await axios.patch<ContactSchemaUpdateResult>(
+      `/contact-schemas/${id}`,
+      payload,
+    );
+    return data;
+  },
+  remove: async (id: string): Promise<ContactSchemaDeleteResult> => {
+    const { data } = await axios.delete<ContactSchemaDeleteResult>(`/contact-schemas/${id}`);
+    return data;
+  },
+  createField: async (
+    schemaId: string,
+    payload: CreateSchemaFieldPayload,
+  ): Promise<SchemaField> => {
+    const { data } = await axios.post<SchemaField>(`/contact-schemas/${schemaId}/fields`, payload);
+    return data;
+  },
+  updateField: async (fieldId: string, payload: UpdateSchemaFieldPayload): Promise<SchemaField> => {
+    const { data } = await axios.patch<SchemaField>(`/schema-fields/${fieldId}`, payload);
+    return data;
+  },
+  removeField: async (fieldId: string): Promise<{ ok: boolean }> => {
+    const { data } = await axios.delete<{ ok: boolean }>(`/schema-fields/${fieldId}`);
+    return data;
+  },
+};
+
+/** Paginated org-schema list. */
+export function useSchemasList(params: PaginatedListParams = {}) {
+  return usePaginatedList<ContactSchema>(
+    contactKeys.schemas.list(params),
+    () => schemasApi.list(params),
+    params,
+  );
+}
+
+/** One schema with its active fields + `referenced_by` counts. */
+export function useSchema(id: string | null | undefined) {
+  return useQuery({
+    queryKey: contactKeys.schemas.detail(id ?? ''),
+    queryFn: () => schemasApi.get(id as string),
+    enabled: !!id,
+  });
+}
+
+export function useCreateSchema() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: CreateSchemaPayload) => schemasApi.create(payload),
+    onSuccess: () => qc.invalidateQueries({ queryKey: contactKeys.schemas.lists() }),
+  });
+}
+
+export function useUpdateSchema() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: UpdateSchemaPayload }) =>
+      schemasApi.update(id, payload),
+    onSuccess: (_data, { id }) => {
+      qc.invalidateQueries({ queryKey: contactKeys.schemas.lists() });
+      qc.invalidateQueries({ queryKey: contactKeys.schemas.detail(id) });
+    },
+  });
+}
+
+export function useDeleteSchema() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => schemasApi.remove(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: contactKeys.schemas.lists() });
+      // A schema may be a directory's default; refresh directories too.
+      qc.invalidateQueries({ queryKey: contactKeys.directories.lists() });
+    },
+  });
+}
+
+export function useCreateSchemaField() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ schemaId, payload }: { schemaId: string; payload: CreateSchemaFieldPayload }) =>
+      schemasApi.createField(schemaId, payload),
+    onSuccess: (_data, { schemaId }) =>
+      qc.invalidateQueries({ queryKey: contactKeys.schemas.detail(schemaId) }),
+  });
+}
+
+export function useUpdateSchemaField() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      fieldId,
+      payload,
+    }: {
+      fieldId: string;
+      /** The parent schema id — needed only to invalidate its detail query. */
+      schemaId: string;
+      payload: UpdateSchemaFieldPayload;
+    }) => schemasApi.updateField(fieldId, payload),
+    onSuccess: (_data, { schemaId }) =>
+      qc.invalidateQueries({ queryKey: contactKeys.schemas.detail(schemaId) }),
+  });
+}
+
+export function useDeleteSchemaField() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ fieldId }: { fieldId: string; schemaId: string }) =>
+      schemasApi.removeField(fieldId),
+    onSuccess: (_data, { schemaId }) =>
+      qc.invalidateQueries({ queryKey: contactKeys.schemas.detail(schemaId) }),
+  });
+}

--- a/frontend/src/lib/api/contactSyncs.ts
+++ b/frontend/src/lib/api/contactSyncs.ts
@@ -1,0 +1,83 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { contactKeys } from '@/lib/api/queryKeys';
+import { toListBody, usePaginatedList } from '@/lib/api/usePaginatedList';
+import type { PaginatedListParams, PaginatedResponse } from '@/types/contactList';
+import {
+  CONTACT_SYNC_TERMINAL_STATUSES,
+  type ContactSync,
+  type CreateContactSyncPayload,
+  type ListContactSyncsParams,
+} from '@/types/contactSync';
+import axios from '@/utils/axios';
+
+/** Combined params for the sync list (paging/sort + optional directory scoping). */
+export type ListContactSyncsQuery = Omit<PaginatedListParams, 'search'> & ListContactSyncsParams;
+
+/** Thin typed wrapper over the `/contact-syncs` endpoints. */
+export const contactSyncsApi = {
+  /**
+   * Create + enqueue a sync from an uploaded CSV. Sent as multipart `FormData`; the
+   * response is the pending sync — poll `get(id)` until it reaches a terminal status.
+   */
+  create: async (payload: CreateContactSyncPayload): Promise<ContactSync> => {
+    const form = new FormData();
+    form.append('directory_id', payload.directory_id);
+    form.append('schema_id', payload.schema_id);
+    if (payload.agent_id) form.append('agent_id', payload.agent_id);
+    form.append('file', payload.file);
+    const { data } = await axios.post<ContactSync>('/contact-syncs', form, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+    return data;
+  },
+  list: async (params: ListContactSyncsQuery = {}): Promise<PaginatedResponse<ContactSync>> => {
+    const { data } = await axios.post<PaginatedResponse<ContactSync>>(
+      '/contact-syncs/list',
+      toListBody(params),
+    );
+    return data;
+  },
+  get: async (id: string): Promise<ContactSync> => {
+    const { data } = await axios.get<ContactSync>(`/contact-syncs/${id}`);
+    return data;
+  },
+};
+
+/** Paginated sync list (optionally scoped to one directory). */
+export function useContactSyncsList(params: ListContactSyncsQuery = {}) {
+  return usePaginatedList<ContactSync>(
+    contactKeys.syncs.list(params),
+    () => contactSyncsApi.list(params),
+    params,
+  );
+}
+
+/**
+ * A single sync, polled while it is still running. Once the sync reaches a terminal
+ * status (`completed`/`failed`) polling stops. Enabled only when `id` is set.
+ */
+export function useContactSync(id: string | null | undefined, options?: { poll?: boolean }) {
+  return useQuery({
+    queryKey: contactKeys.syncs.detail(id ?? ''),
+    queryFn: () => contactSyncsApi.get(id as string),
+    enabled: !!id,
+    refetchInterval: (query) => {
+      if (!options?.poll) return false;
+      const status = query.state.data?.status;
+      if (status && CONTACT_SYNC_TERMINAL_STATUSES.includes(status)) return false;
+      return 2000;
+    },
+  });
+}
+
+export function useCreateContactSync() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: CreateContactSyncPayload) => contactSyncsApi.create(payload),
+    onSuccess: (_data, payload) => {
+      qc.invalidateQueries({ queryKey: contactKeys.syncs.lists() });
+      qc.invalidateQueries({ queryKey: contactKeys.contacts.lists(payload.directory_id) });
+    },
+  });
+}

--- a/frontend/src/lib/api/contacts.ts
+++ b/frontend/src/lib/api/contacts.ts
@@ -1,0 +1,144 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { contactKeys } from '@/lib/api/queryKeys';
+import { toListBody, usePaginatedList } from '@/lib/api/usePaginatedList';
+import type {
+  BulkDeleteContactsResponse,
+  Contact,
+  ContactListResponse,
+  CreateContactsPayload,
+  CreateContactsResponse,
+  ListContactsParams,
+  ScheduleContactCallsPayload,
+  ScheduleContactCallsResponse,
+  UpdateContactPayload,
+} from '@/types/contact';
+import axios from '@/utils/axios';
+
+/**
+ * Directory-scoped contacts client. Every list/create/bulk-delete route is nested under
+ * `/contact-directories/{directoryId}`; single-contact update/delete address by contact
+ * id (the backend still directory-scopes the lookup). Create is bulk + partial (C-7).
+ */
+export const contactsApi = {
+  list: async (
+    directoryId: string,
+    params: ListContactsParams = {},
+  ): Promise<ContactListResponse> => {
+    const { data } = await axios.post<ContactListResponse>(
+      `/contact-directories/${directoryId}/contacts/list`,
+      toListBody(params),
+    );
+    return data;
+  },
+  /**
+   * Create one or many contacts (partial success). Returns `{ created, failed }` (C-7) —
+   * callers must handle `failed[]` (per-row `{ index, errors }`), not assume a single
+   * contact came back.
+   */
+  create: async (
+    directoryId: string,
+    payload: CreateContactsPayload,
+  ): Promise<CreateContactsResponse> => {
+    const { data } = await axios.post<CreateContactsResponse>(
+      `/contact-directories/${directoryId}/contacts`,
+      payload,
+    );
+    return data;
+  },
+  update: async (id: string, payload: UpdateContactPayload): Promise<Contact> => {
+    const { data } = await axios.patch<Contact>(`/contacts/${id}`, payload);
+    return data;
+  },
+  remove: async (id: string): Promise<void> => {
+    await axios.delete(`/contacts/${id}`);
+  },
+  bulkDelete: async (directoryId: string, ids: string[]): Promise<BulkDeleteContactsResponse> => {
+    const { data } = await axios.post<BulkDeleteContactsResponse>(
+      `/contact-directories/${directoryId}/contacts/bulk-delete`,
+      { ids },
+    );
+    return data;
+  },
+  scheduleCalls: async (
+    payload: ScheduleContactCallsPayload,
+  ): Promise<ScheduleContactCallsResponse> => {
+    const { data } = await axios.post<ScheduleContactCallsResponse>(
+      '/contact/schedule-calls',
+      payload,
+    );
+    return data;
+  },
+};
+
+/** Paginated contacts for one directory. `poll` surfaces rows landing from a live sync. */
+export function useContactsList(
+  directoryId: string | null | undefined,
+  params: ListContactsParams = {},
+  options?: { poll?: boolean },
+) {
+  return usePaginatedList<Contact>(
+    contactKeys.contacts.list(directoryId ?? '', params),
+    () => contactsApi.list(directoryId as string, params),
+    params,
+    {
+      enabled: !!directoryId,
+      refetchInterval: options?.poll ? 4000 : false,
+    },
+  );
+}
+
+export function useCreateContacts(directoryId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: CreateContactsPayload) => contactsApi.create(directoryId, payload),
+    onSuccess: (_data, payload) => {
+      qc.invalidateQueries({ queryKey: contactKeys.contacts.lists(directoryId) });
+      qc.invalidateQueries({ queryKey: contactKeys.directories.lists() });
+      // Create-and-assign (payload carries `agent_id`) also mutates that agent's contact
+      // list server-side, so refetch it too.
+      if (payload.agent_id) {
+        qc.invalidateQueries({ queryKey: contactKeys.agentContacts.lists(payload.agent_id) });
+      }
+    },
+  });
+}
+
+export function useUpdateContact(directoryId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: UpdateContactPayload }) =>
+      contactsApi.update(id, payload),
+    onSuccess: () => qc.invalidateQueries({ queryKey: contactKeys.contacts.lists(directoryId) }),
+  });
+}
+
+export function useDeleteContact(directoryId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => contactsApi.remove(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: contactKeys.contacts.lists(directoryId) });
+      qc.invalidateQueries({ queryKey: contactKeys.directories.lists() });
+    },
+  });
+}
+
+export function useBulkDeleteContacts(directoryId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (ids: string[]) => contactsApi.bulkDelete(directoryId, ids),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: contactKeys.contacts.lists(directoryId) });
+      qc.invalidateQueries({ queryKey: contactKeys.directories.lists() });
+    },
+  });
+}
+
+export function useScheduleContactCalls() {
+  return useMutation({
+    mutationFn: (payload: ScheduleContactCallsPayload) => contactsApi.scheduleCalls(payload),
+  });
+}
+
+export type { Contact };

--- a/frontend/src/lib/api/queryKeys.ts
+++ b/frontend/src/lib/api/queryKeys.ts
@@ -1,0 +1,57 @@
+/**
+ * Typed TanStack Query key factory for the Contact Directories feature.
+ *
+ * WHAT: a single source of truth for every query key used by the contacts api clients,
+ * so lists/details/mutations invalidate consistently (partial-key invalidation works
+ * because keys share a stable prefix tuple).
+ *
+ * WHEN: use these instead of hand-writing string arrays in any contacts query or
+ * `invalidateQueries` call. Passing `params` narrows to one query; omitting it (or
+ * invalidating the plain `.lists()` key) refetches every page/filter of that resource.
+ *
+ * Keys are `as const` tuples so `queryClient.invalidateQueries({ queryKey })` can match
+ * by prefix (e.g. invalidate ALL directory lists by passing `contactKeys.directories.lists()`).
+ */
+
+/** Any params object attached to a list key (paging/search/sort/scoping). */
+type ListParams = object | undefined;
+
+export const contactKeys = {
+  directories: {
+    all: () => ['contact-directories'] as const,
+    lists: () => ['contact-directories', 'list'] as const,
+    list: (params?: ListParams) => ['contact-directories', 'list', params ?? {}] as const,
+    detail: (id: string) => ['contact-directories', 'detail', id] as const,
+    deleteImpact: (id: string) => ['contact-directories', 'delete-impact', id] as const,
+  },
+  datasources: {
+    all: () => ['contact-datasources'] as const,
+    lists: () => ['contact-datasources', 'list'] as const,
+    list: (params?: ListParams) => ['contact-datasources', 'list', params ?? {}] as const,
+  },
+  schemas: {
+    all: () => ['contact-schemas'] as const,
+    lists: () => ['contact-schemas', 'list'] as const,
+    list: (params?: ListParams) => ['contact-schemas', 'list', params ?? {}] as const,
+    detail: (id: string) => ['contact-schemas', 'detail', id] as const,
+  },
+  contacts: {
+    all: () => ['contacts'] as const,
+    /** All contact lists for one directory (invalidate to refetch every page/filter). */
+    lists: (directoryId: string) => ['contacts', directoryId, 'list'] as const,
+    list: (directoryId: string, params?: ListParams) =>
+      ['contacts', directoryId, 'list', params ?? {}] as const,
+  },
+  syncs: {
+    all: () => ['contact-syncs'] as const,
+    lists: () => ['contact-syncs', 'list'] as const,
+    list: (params?: ListParams) => ['contact-syncs', 'list', params ?? {}] as const,
+    detail: (id: string) => ['contact-syncs', 'detail', id] as const,
+  },
+  agentContacts: {
+    all: (agentId: string) => ['agent-contacts', agentId] as const,
+    lists: (agentId: string) => ['agent-contacts', agentId, 'list'] as const,
+    list: (agentId: string, params?: ListParams) =>
+      ['agent-contacts', agentId, 'list', params ?? {}] as const,
+  },
+} as const;

--- a/frontend/src/lib/api/usePaginatedList.ts
+++ b/frontend/src/lib/api/usePaginatedList.ts
@@ -1,0 +1,52 @@
+import { useQuery, type QueryKey, type UseQueryResult } from '@tanstack/react-query';
+
+import type { PaginatedListParams, PaginatedResponse } from '@/types/contactList';
+
+/**
+ * Generic TanStack Query hook for the contacts backend's `POST /…/list` endpoints.
+ *
+ * WHAT: given a stable query key, a fetcher that returns the standard
+ * `{ data, total, page_no, page_size }` envelope, and the paging/search/sort params,
+ * this runs the query with `placeholderData` (so page/search changes don't flash empty)
+ * and an optional poll interval.
+ *
+ * WHEN: use it for EVERY paginated contacts list (directories, contacts, schemas, syncs,
+ * assigned contacts) instead of re-wiring `useQuery` per resource. Pass the matching key
+ * from `queryKeys.ts` and a client `.list` fetcher — e.g.
+ *   `usePaginatedList(contactKeys.directories.list(params), () => directoriesApi.list(params), params)`.
+ *
+ * `params` is passed through to the fetcher's closure by the caller; it is accepted here
+ * only to type the params surface and keep the call site self-documenting.
+ */
+export function usePaginatedList<T, P extends PaginatedListParams = PaginatedListParams>(
+  queryKey: QueryKey,
+  fetcher: () => Promise<PaginatedResponse<T>>,
+  _params?: P,
+  options?: {
+    /** Refetch interval in ms while mounted (e.g. to surface in-flight imports). `false` = off. */
+    refetchInterval?: number | false;
+    /** Disable the query until a dependency (e.g. a selected directory id) is ready. */
+    enabled?: boolean;
+  },
+): UseQueryResult<PaginatedResponse<T>> {
+  return useQuery({
+    queryKey,
+    queryFn: fetcher,
+    placeholderData: (prev) => prev,
+    refetchInterval: options?.refetchInterval ?? false,
+    enabled: options?.enabled ?? true,
+  });
+}
+
+/**
+ * Strip empty/undefined/null values from list params so they aren't sent as blank query
+ * fields (the backend treats an absent field as "no filter"). Reused by every list
+ * fetcher that POSTs a params body.
+ */
+export function toListBody(params: object = {}): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && value !== '') body[key] = value;
+  }
+  return body;
+}

--- a/frontend/src/types/agentContact.ts
+++ b/frontend/src/types/agentContact.ts
@@ -1,0 +1,42 @@
+/**
+ * AgentContact types — mirrors the agent-contacts router shapes. Assigning attaches
+ * contacts to an agent (idempotent, no scheduling gate); directories in the assign body
+ * are expanded server-side to their active contacts.
+ */
+
+import type { Contact } from '@/types/contact';
+
+/**
+ * A row in `POST /agents/{id}/contacts/list` — the assigned contact's `to_dict()` plus
+ * assignment metadata joined in by `list_agent_contacts`.
+ */
+export interface AgentContactRow extends Contact {
+  assignment_id: string;
+  assigned_at: string | null;
+}
+
+/**
+ * Body for `POST /agents/{id}/contacts/assign`. Send whole `directory_ids` (expanded to
+ * their active contacts server-side) and/or explicit `contact_ids`; at least one should
+ * be non-empty (otherwise the call is a no-op).
+ */
+export interface AssignContactsPayload {
+  directory_ids?: string[];
+  contact_ids?: string[];
+}
+
+/** `POST /agents/{id}/contacts/assign` response — idempotent assign counts. */
+export interface AssignContactsResult {
+  assigned: number;
+  skipped: number;
+}
+
+/** Body for `POST /agents/{id}/contacts/unassign`. */
+export interface UnassignContactsPayload {
+  contact_ids: string[];
+}
+
+/** `POST /agents/{id}/contacts/unassign` response — rows actually removed. */
+export interface UnassignContactsResult {
+  unassigned: number;
+}

--- a/frontend/src/types/components.ts
+++ b/frontend/src/types/components.ts
@@ -62,6 +62,18 @@ export interface CustomTableProps<TRow> {
   title?: React.ReactNode;
   /** Description displayed under the title. */
   description?: React.ReactNode;
+  /**
+   * Make the table card grow to fill its parent's height (`flex-1 min-h-0`) so the
+   * body scrolls internally and pagination stays pinned to the card bottom. The parent
+   * must be a `flex flex-col` with a bounded height. Defaults to `false` (auto height).
+   */
+  fillHeight?: boolean;
+  /**
+   * Tag each body row with the `group` class so per-cell content can reveal on
+   * `group-hover` / `group-focus-within` (e.g. hover-revealed row actions). Optional,
+   * back-compatible; defaults to `false`.
+   */
+  groupRows?: boolean;
 }
 
 export interface TextInputBaseProps extends Omit<React.ComponentProps<'input'>, 'size'> {
@@ -334,6 +346,22 @@ export interface DateRangePickerProps {
   placeholder?: string;
   /** Show the relative-range preset rail (Last 15m / 30m / 1h / 24h / 7d). */
   presets?: boolean;
+  align?: 'start' | 'center' | 'end';
+  className?: string;
+  triggerClassName?: string;
+  disabled?: boolean;
+}
+
+/** A single instant + the IANA zone it was picked in. `value` is a UTC ISO string. */
+export interface DateTimeValue {
+  value: string | null;
+  timeZone: string;
+}
+
+export interface DateTimePickerProps {
+  value?: DateTimeValue;
+  onChange?: (value: DateTimeValue) => void;
+  placeholder?: string;
   align?: 'start' | 'center' | 'end';
   className?: string;
   triggerClassName?: string;

--- a/frontend/src/types/contact.ts
+++ b/frontend/src/types/contact.ts
@@ -1,0 +1,102 @@
+/**
+ * Contact types — mirrors `core/models/contact.py` `to_dict()` and the directory-scoped
+ * contacts router shapes.
+ *
+ * A `Contact` now belongs to exactly one `ContactDirectory` (`directory_id`, required)
+ * and records the sync run that last wrote it (`sync_id`). The old `source_upload_id`
+ * field is GONE. Create is bulk + partial-success (C-7): `POST
+ * /contact-directories/{id}/contacts` returns `{ created, failed }`, not a single object.
+ */
+
+import type { PaginatedListParams, PaginatedResponse } from '@/types/contactList';
+
+/** A single contact row (mirrors `Contact.to_dict()`). */
+export interface Contact {
+  id: string;
+  directory_id: string | null;
+  external_id: string;
+  name: string | null;
+  phone_number: string | null;
+  contact_metadata: Record<string, unknown>;
+  sync_id: string | null;
+  is_active: boolean;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+/** `POST /contact-directories/{id}/contacts/list` response. */
+export type ContactListResponse = PaginatedResponse<Contact>;
+
+/** List params for the directory-scoped contacts list (paging/search/sort). */
+export type ListContactsParams = PaginatedListParams;
+
+/** One row in a create-contacts request body. */
+export interface ContactRowPayload {
+  name?: string | null;
+  phone_number?: string | null;
+  external_id?: string | null;
+  contact_metadata?: Record<string, unknown>;
+}
+
+/**
+ * Body for `POST /contact-directories/{id}/contacts`. Send EITHER a single `contact` or
+ * a `contacts` array — both normalise to the same `{ created, failed }` response.
+ */
+export interface CreateContactsPayload {
+  contact?: ContactRowPayload;
+  contacts?: ContactRowPayload[];
+  /**
+   * Optional agent to assign the created contacts to. When set, the backend also inserts
+   * `agent_contacts` for every created contact (idempotent); when omitted the contacts are
+   * just created. Lets the directory General view and the agent Contacts tab share one
+   * create endpoint.
+   */
+  agent_id?: string;
+}
+
+/** A row that failed create validation (C-7). `index` is its position in the input. */
+export interface CreateContactFailure {
+  index: number;
+  errors: string[];
+}
+
+/**
+ * `POST /contact-directories/{id}/contacts` response (C-7): partial success — valid rows
+ * land in `created`, invalid rows are reported in `failed` (nothing is rolled back).
+ */
+export interface CreateContactsResponse {
+  created: Contact[];
+  failed: CreateContactFailure[];
+  /** Present only when the request carried `agent_id` — count of contacts assigned. */
+  assigned?: number;
+}
+
+/** Body for `PATCH /contacts/{id}`. */
+export interface UpdateContactPayload {
+  name?: string | null;
+  phone_number?: string | null;
+  contact_metadata?: Record<string, unknown>;
+}
+
+/** `POST /contact-directories/{id}/contacts/bulk-delete` — soft-deletes by id. */
+export interface BulkDeleteContactsResponse {
+  deleted: number;
+}
+
+/**
+ * Body for `POST /contact/schedule-calls` (unchanged endpoint — no scheduling gate).
+ * `scheduled_at` is a UTC ISO string (from the shared `DateTimePicker`).
+ */
+export interface ScheduleContactCallsPayload {
+  agent_id: string;
+  from_number: string;
+  contact_ids: string[];
+  scheduled_at?: string | null;
+}
+
+/** `POST /contact/schedule-calls` response. */
+export interface ScheduleContactCallsResponse {
+  count: number;
+  invalid: { contact_id: string; error: string }[];
+  data: unknown[];
+}

--- a/frontend/src/types/contactDatasource.ts
+++ b/frontend/src/types/contactDatasource.ts
@@ -1,0 +1,35 @@
+/**
+ * ContactDatasource types — mirrors `core/models/datasource.py` `to_dict()` and the
+ * datasource router shapes. A datasource feeds contacts into a directory through the
+ * sync pipeline. CSV-only at launch (auto-provisioned one-per-directory); `config` is
+ * reserved for future REST datasources.
+ */
+
+/** The datasource kind. Only `csv` is accepted at launch; `rest` is reserved. */
+export type DatasourceType = 'csv' | 'rest';
+
+/** A datasource as returned by the datasource endpoints (`to_dict`). */
+export interface ContactDatasource {
+  id: string;
+  directory_id: string | null;
+  name: string;
+  type: DatasourceType;
+  config: Record<string, unknown>;
+  is_active: boolean;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+/** Body for `POST /contact-datasources` (create; admin/owner). */
+export interface CreateDatasourcePayload {
+  name: string;
+  directory_id?: string | null;
+  /** Defaults to `csv` on the backend; only `csv` is currently accepted. */
+  type?: DatasourceType;
+  config?: Record<string, unknown> | null;
+}
+
+/** Extra scoping field for `POST /contact-datasources/list` (on top of paging params). */
+export interface ListDatasourcesParams {
+  directory_id?: string | null;
+}

--- a/frontend/src/types/contactDirectory.ts
+++ b/frontend/src/types/contactDirectory.ts
@@ -1,0 +1,70 @@
+/**
+ * ContactDirectory types — mirrors `core/models/contact_directory.py` `to_dict()` and
+ * the directory router request/response shapes. A directory is the org-scoped container
+ * that owns its contacts + a CSV datasource and references one reusable org-level schema
+ * as its default shape (`default_schema_id`).
+ */
+
+/** A single directory as returned by `GET /contact-directories/{id}` (bare `to_dict`). */
+export interface ContactDirectory {
+  id: string;
+  name: string;
+  description: string | null;
+  default_schema_id: string | null;
+  is_active: boolean;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+/**
+ * A directory row inside `POST /contact-directories/list` — the list endpoint enriches
+ * each `to_dict` with a live `contact_count` for the rail + tree badges.
+ */
+export interface ContactDirectoryListItem extends ContactDirectory {
+  contact_count: number;
+}
+
+/** Body for `POST /contact-directories` (create; admin/owner). */
+export interface CreateDirectoryPayload {
+  name: string;
+  description?: string | null;
+  /** Optional org schema to set as the directory's default. Omitted → no default
+   * schema (none is auto-created per directory). */
+  default_schema_id?: string | null;
+}
+
+/** Body for `PATCH /contact-directories/{id}` (update; admin/owner). */
+export interface UpdateDirectoryPayload {
+  name?: string | null;
+  description?: string | null;
+  is_active?: boolean;
+  default_schema_id?: string | null;
+}
+
+/**
+ * `GET /contact-directories/{id}/delete-impact` — the confirm-modal blast radius from
+ * `summarize_directory_deletion`. Counts are rows that will be DELETED (contacts,
+ * agent_contacts, scheduled_calls) or DETACHED (syncs); org schemas are always kept.
+ */
+export interface DirectoryDeleteImpact {
+  contacts: number;
+  agent_contacts: number;
+  scheduled_calls: number;
+  syncs_detached: number;
+  schemas_kept: boolean;
+}
+
+/**
+ * `DELETE /contact-directories/{id}` — the summary from
+ * `hard_delete_directory_and_children` (what was actually removed/detached).
+ */
+export interface DirectoryDeleteResult {
+  directory_id: string;
+  contacts_deleted: number;
+  agent_contacts_deleted: number;
+  scheduled_calls_deleted: number;
+  dial_jobs_cancelled: number;
+  datasources_deleted: number;
+  syncs_marked_failed: number;
+  syncs_detached: number;
+}

--- a/frontend/src/types/contactList.ts
+++ b/frontend/src/types/contactList.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared list/pagination types for the Contact Directories feature.
+ *
+ * Every `POST /…/list` endpoint in the contacts backend returns the same envelope
+ * (`{ data, total, page_no, page_size }`) and accepts the same paging/search/sort
+ * params, so both live here and are reused by every contacts api client +
+ * `usePaginatedList`. (Kept separate from the older `types/list.ts`, whose `page`/`rows`
+ * shape does NOT match the contacts backend's `page_no`/`data`.)
+ */
+
+/** The uniform envelope returned by every contacts `POST /…/list` endpoint. */
+export interface PaginatedResponse<T> {
+  data: T[];
+  total: number;
+  page_no: number;
+  page_size: number;
+}
+
+/** Sort order accepted by every contacts list endpoint (`^(asc|desc)$` on the backend). */
+export type ContactSortOrder = 'asc' | 'desc';
+
+/**
+ * The common query params every contacts list endpoint accepts. Individual endpoints
+ * may add their own scoping fields (e.g. `directory_id`) on top of these.
+ */
+export interface PaginatedListParams {
+  page_no?: number;
+  page_size?: number;
+  search?: string;
+  sort_by?: string;
+  sort_order?: ContactSortOrder;
+}

--- a/frontend/src/types/contactSchema.ts
+++ b/frontend/src/types/contactSchema.ts
@@ -1,0 +1,132 @@
+/**
+ * ContactSchema + SchemaField types — mirrors `core/models/contact_schema.py` and
+ * `core/models/schema_field.py` `to_dict()`, plus the contact-schemas router shapes.
+ *
+ * A `ContactSchema` is an ORG-LEVEL, reusable contact-shape template that owns a set of
+ * `SchemaField` rows. A directory references one via `default_schema_id` (its manual-Add
+ * form + validation shape); a sync may pick any org schema for its external→target
+ * mapping.
+ */
+
+/** Primitive field types the backend accepts (`_ALLOWED_FIELD_TYPES`). */
+export type SchemaFieldType = 'string' | 'number' | 'integer' | 'boolean' | 'enum';
+
+/**
+ * The constrained JSON-Schema-subset validators the backend allows. String/enum fields
+ * accept `minLength`/`maxLength`/`pattern`; number/integer accept `minimum`/`maximum`.
+ */
+export interface SchemaFieldValidators {
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  minimum?: number;
+  maximum?: number;
+}
+
+/** An enum choice for a `type: 'enum'` field. */
+export interface SchemaFieldOption {
+  value: string;
+  label?: string;
+}
+
+/** A single field within a schema (mirrors `SchemaField.to_dict()`). */
+export interface SchemaField {
+  id: string;
+  schema_id: string;
+  field_name: string;
+  label: string | null;
+  is_mandatory: boolean;
+  type: SchemaFieldType;
+  format: string | null;
+  validators: SchemaFieldValidators;
+  options: SchemaFieldOption[] | null;
+  /** External header this field reads from when used as a sync mapping. null = identity. */
+  source_key: string | null;
+  field_metadata: Record<string, unknown>;
+  display_order: number;
+  is_active: boolean;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+/** A schema as returned by list/create/update (bare `to_dict`, no fields). */
+export interface ContactSchema {
+  id: string;
+  name: string;
+  description: string | null;
+  is_active: boolean;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+/**
+ * How many directories/syncs currently point at a schema — surfaced on
+ * get-detail / update / delete so the UI can warn that a change is shared.
+ */
+export interface SchemaReferencedBy {
+  directories: number;
+  syncs: number;
+}
+
+/**
+ * `GET /contact-schemas/{id}` — the schema enriched with its ACTIVE fields and the
+ * `referenced_by` counts (from `get_schema_detail`).
+ */
+export interface ContactSchemaDetail extends ContactSchema {
+  fields: SchemaField[];
+  referenced_by: SchemaReferencedBy;
+}
+
+/**
+ * `PATCH /contact-schemas/{id}` — the updated schema plus its `referenced_by` count so
+ * the caller can warn the edit is shared.
+ */
+export interface ContactSchemaUpdateResult extends ContactSchema {
+  referenced_by: SchemaReferencedBy;
+}
+
+/** `DELETE /contact-schemas/{id}` — soft-deleted; returns the reference counts it had. */
+export interface ContactSchemaDeleteResult {
+  ok: boolean;
+  referenced_by: SchemaReferencedBy;
+}
+
+/** Body for `POST /contact-schemas` (create; admin/owner). */
+export interface CreateSchemaPayload {
+  name: string;
+  description?: string | null;
+  is_active?: boolean;
+}
+
+/** Body for `PATCH /contact-schemas/{id}` (update; admin/owner). */
+export interface UpdateSchemaPayload {
+  name?: string | null;
+  description?: string | null;
+  is_active?: boolean;
+}
+
+/** Body for `POST /contact-schemas/{id}/fields` (create field; admin/owner). */
+export interface CreateSchemaFieldPayload {
+  field_name: string;
+  type?: SchemaFieldType;
+  label?: string | null;
+  format?: string | null;
+  is_mandatory?: boolean;
+  validators?: SchemaFieldValidators | null;
+  options?: SchemaFieldOption[] | null;
+  source_key?: string | null;
+  display_order?: number;
+}
+
+/** Body for `PATCH /schema-fields/{id}` (update field; admin/owner). */
+export interface UpdateSchemaFieldPayload {
+  label?: string | null;
+  type?: SchemaFieldType;
+  format?: string | null;
+  is_mandatory?: boolean;
+  validators?: SchemaFieldValidators | null;
+  options?: SchemaFieldOption[] | null;
+  source_key?: string | null;
+  display_order?: number;
+  is_active?: boolean;
+}

--- a/frontend/src/types/contactSync.ts
+++ b/frontend/src/types/contactSync.ts
@@ -1,0 +1,62 @@
+/**
+ * ContactSync types — mirrors `core/models/contact_sync.py` `to_dict()` and the
+ * contact-syncs router shapes. A `ContactSync` is one run of the datasource-driven CSV
+ * import into a directory (partial-success: valid rows imported, invalid rows recorded).
+ */
+
+/** Sync lifecycle status (pending → processing → completed | failed). */
+export type ContactSyncStatus = 'pending' | 'processing' | 'completed' | 'failed';
+
+/** The terminal statuses — polling stops once a sync reaches one of these. */
+export const CONTACT_SYNC_TERMINAL_STATUSES: readonly ContactSyncStatus[] = ['completed', 'failed'];
+
+/** Per-run counts written by `run_contact_sync`. */
+export interface ContactSyncCounts {
+  created?: number;
+  updated?: number;
+  skipped?: number;
+  failed?: number;
+}
+
+/** A single per-row error entry in `row_errors` (partial-failure detail). */
+export interface ContactSyncRowError {
+  row: number;
+  field: string | null;
+  message: string;
+  /** The failed row's identity, so the report shows WHICH contact failed. */
+  name?: string | null;
+  phone_number?: string | null;
+}
+
+/** A sync as returned by `to_dict()` (create / get / list rows). */
+export interface ContactSync {
+  id: string;
+  directory_id: string | null;
+  datasource_id: string | null;
+  schema_id: string | null;
+  upload_id: string | null;
+  agent_id: string | null;
+  status: ContactSyncStatus;
+  counts: ContactSyncCounts;
+  row_errors: ContactSyncRowError[];
+  error: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+/**
+ * Multipart body for `POST /contact-syncs`. Sent as `FormData` (the CSV `file` plus the
+ * scalar fields), NOT JSON.
+ */
+export interface CreateContactSyncPayload {
+  directory_id: string;
+  schema_id: string;
+  agent_id?: string | null;
+  file: File;
+}
+
+/** Extra scoping field for `POST /contact-syncs/list` (on top of paging params). */
+export interface ListContactSyncsParams {
+  directory_id?: string | null;
+  status?: ContactSyncStatus | null;
+}

--- a/frontend/src/types/outboundCall.ts
+++ b/frontend/src/types/outboundCall.ts
@@ -18,6 +18,7 @@ export type ScheduledCallStatus =
   | 'scheduled'
   | 'processing'
   | 'dispatched'
+  | 'in_progress'
   | 'completed'
   | 'busy'
   | 'no_answer'
@@ -28,6 +29,9 @@ export interface ScheduledCallRow {
   id: string;
   agent_id: string;
   agent_name: string | null;
+  contact_id: string | null;
+  contact_name: string | null;
+  contact_phone_number: string | null;
   status: ScheduledCallStatus | null;
   from_number: string | null;
   to_number: string | null;

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,9 +1,12 @@
+import { TZDate } from '@date-fns/tz';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import utc from 'dayjs/plugin/utc';
 
 dayjs.extend(utc);
 dayjs.extend(relativeTime);
+
+const pad = (n: number) => String(n).padStart(2, '0');
 
 export const DATE_FORMAT = 'DD MMM YYYY, HH:mm A';
 
@@ -41,6 +44,45 @@ export function getBrowserTimeZone(): string {
   } catch {
     return 'UTC';
   }
+}
+
+/**
+ * Combine a calendar day + `HH:mm` time, interpreted in `tz`, into a `Z`-normalized
+ * UTC ISO instant (e.g. `2026-06-05T11:14:00.000Z`). Shared by the DateRangePicker and
+ * the single-instant DateTimePicker so both emit the same UTC form the backend expects.
+ */
+export function combineToIso(day: Date, time: string, tz: string): string {
+  const [h, m] = time.split(':').map((s) => parseInt(s, 10));
+  const tzDate = TZDate.tz(
+    tz,
+    day.getFullYear(),
+    day.getMonth(),
+    day.getDate(),
+    Number.isFinite(h) ? h : 0,
+    Number.isFinite(m) ? m : 0,
+  );
+  return new Date(tzDate.getTime()).toISOString();
+}
+
+/** Split a UTC ISO instant into its wall-clock day + `HH:mm` time within `tz`. */
+export function splitFromIso(iso: string, tz: string): { day: Date; time: string } {
+  const d = new TZDate(new Date(iso), tz);
+  return {
+    day: new Date(d.getFullYear(), d.getMonth(), d.getDate()),
+    time: `${pad(d.getHours())}:${pad(d.getMinutes())}`,
+  };
+}
+
+/** All IANA timezones the runtime exposes, falling back to `['UTC', browserTz]`. */
+export function getTimeZones(): string[] {
+  try {
+    const supported = (Intl as unknown as { supportedValuesOf?: (k: string) => string[] })
+      .supportedValuesOf;
+    if (typeof supported === 'function') return supported('timeZone');
+  } catch {
+    /* older runtimes — fall through */
+  }
+  return ['UTC', getBrowserTimeZone()];
 }
 
 /**

--- a/frontend/src/utils/download.ts
+++ b/frontend/src/utils/download.ts
@@ -1,0 +1,20 @@
+/**
+ * Trigger a client-side download of an in-memory CSV string as a file.
+ *
+ * WHAT: wraps the CSV text in a Blob, creates a temporary object URL, clicks a hidden
+ * anchor, then revokes the URL. No network round-trip — the file is built in the browser.
+ *
+ * WHEN: reuse for every "download this as a .csv" affordance (sync sample templates, the
+ * per-sync error report, etc.) instead of re-implementing the Blob/anchor dance.
+ */
+export function triggerCsvDownload(filename: string, csv: string): void {
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}

--- a/main.py
+++ b/main.py
@@ -35,7 +35,9 @@ if _LOAD_FULL_API:
         auth, users, organizations, agent_configs, channels, oauth,
         agents, agent_readiness, mcp_servers, services, tools, dashboard,
         call_logs, call_metrics, sessions, workflows, audit_logs,
-        app_integrations, outbound_calls, admin,
+        app_integrations, outbound_calls, admin, contacts,
+        contact_directories, contact_datasources, contact_schemas,
+        contact_syncs, agent_contacts,
     )
 from core.middleware.request_context import RequestContextMiddleware
 from core.api.telephony_routes import router as telephony_router
@@ -145,6 +147,16 @@ if ee_enabled:
         api_v1.include_router(workflows.router, prefix="/workflow", tags=["workflow"])
         api_v1.include_router(audit_logs.router, prefix="/audit-log", tags=["audit-log"])
         api_v1.include_router(outbound_calls.router, prefix="/outbound-call", tags=["outbound-call"])
+        # Contact Directories module: contacts.router carries full paths
+        # (/contact-directories/{id}/contacts/*, /contacts/{id}, /contact/schedule-calls)
+        # so it mounts at the api-v1 root; the resource routers set their own prefixes.
+        api_v1.include_router(contacts.router, tags=["contact"])
+        api_v1.include_router(contact_directories.router, prefix="/contact-directories", tags=["contact-directory"])
+        api_v1.include_router(contact_datasources.router, prefix="/contact-datasources", tags=["contact-datasource"])
+        api_v1.include_router(contact_schemas.router, tags=["contact-schema"])
+        api_v1.include_router(contact_schemas.field_router, tags=["contact-schema"])
+        api_v1.include_router(contact_syncs.router, prefix="/contact-syncs", tags=["contact-sync"])
+        api_v1.include_router(agent_contacts.router, prefix="/agents", tags=["agent-contacts"])
         api_v1.include_router(admin.router, prefix="/admin", tags=["admin"])
     # webrtc is always mounted — needed on call pods for WebRTC signaling.
     api_v1.include_router(webrtc.router, prefix="/webrtc", tags=["webrtc"])
@@ -172,6 +184,16 @@ else:
         api_v1.include_router(workflows.router, prefix="/workflow", tags=["workflow"])
         api_v1.include_router(audit_logs.router, prefix="/audit-log", tags=["audit-log"])
         api_v1.include_router(outbound_calls.router, prefix="/outbound-call", tags=["outbound-call"])
+        # Contact Directories module: contacts.router carries full paths
+        # (/contact-directories/{id}/contacts/*, /contacts/{id}, /contact/schedule-calls)
+        # so it mounts at the api-v1 root; the resource routers set their own prefixes.
+        api_v1.include_router(contacts.router, tags=["contact"])
+        api_v1.include_router(contact_directories.router, prefix="/contact-directories", tags=["contact-directory"])
+        api_v1.include_router(contact_datasources.router, prefix="/contact-datasources", tags=["contact-datasource"])
+        api_v1.include_router(contact_schemas.router, tags=["contact-schema"])
+        api_v1.include_router(contact_schemas.field_router, tags=["contact-schema"])
+        api_v1.include_router(contact_syncs.router, prefix="/contact-syncs", tags=["contact-sync"])
+        api_v1.include_router(agent_contacts.router, prefix="/agents", tags=["agent-contacts"])
         api_v1.include_router(admin.router, prefix="/admin", tags=["admin"])
     # webrtc is always mounted — needed on call pods for WebRTC signaling.
     api_v1.include_router(webrtc.router, prefix="/webrtc", tags=["webrtc"])

--- a/test-cases/core/test_agent_contacts.py
+++ b/test-cases/core/test_agent_contacts.py
@@ -1,0 +1,303 @@
+"""AgentContactService tests (Core edition) — real DB, service-level.
+
+Covers B6 ACs: directory-expansion assign, union with explicit contact_ids, dedupe of
+already-assigned rows (idempotent), unassign, the unique ``(agent_id, contact_id)``
+constraint, empty-directory assign is a no-op, and org IDOR (agent/contacts in another
+org are invisible).
+
+The router isn't mounted here (B7 owns wiring) and ``ContactService`` is owned by a
+parallel agent, so these exercise ``AgentContactService`` directly against the DB session.
+Directory-expansion assertions are skipped if ``ContactService`` isn't present yet.
+"""
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine, text
+
+from core.models.agent import Agent
+from core.models.agent_contact import AgentContact
+from core.models.contact import Contact
+from core.models.contact_directory import ContactDirectory
+from core.services.contacts.agent_contact_service import AgentContactService
+from shared.config import settings
+
+
+def _first_row(query: str, default):
+    conn = create_engine(settings.DATABASE_URL, pool_pre_ping=True).connect()
+    try:
+        row = conn.execute(text(query)).fetchone()
+        return row[0] if row else default
+    finally:
+        conn.close()
+
+
+ORG_ID = uuid.UUID(str(_first_row("SELECT id FROM organizations LIMIT 1", settings.DEFAULT_ORG_ID)))
+OTHER_ORG_ID = uuid.uuid4()
+REAL_USER_ID = _first_row("SELECT id FROM users LIMIT 1", None)
+
+
+def _svc(db, org_id=ORG_ID):
+    return AgentContactService(db, user_id=REAL_USER_ID, org_id=org_id)
+
+
+def _make_agent(db, org_id=ORG_ID, agent_type="outbound"):
+    agent = Agent(
+        organization_id=org_id,
+        name=f"agent-{uuid.uuid4().hex[:8]}",
+        agent_type=agent_type,
+        created_by_user_id=REAL_USER_ID,
+        is_active=True,
+    )
+    db.add(agent)
+    db.commit()
+    db.refresh(agent)
+    return agent
+
+
+def _make_directory(db, org_id=ORG_ID):
+    directory = ContactDirectory(
+        organization_id=org_id,
+        name=f"dir-{uuid.uuid4().hex[:8]}",
+        is_active=True,
+    )
+    db.add(directory)
+    db.commit()
+    db.refresh(directory)
+    return directory
+
+
+def _make_contact(db, directory_id, org_id=ORG_ID, phone="+14155550100", name="C"):
+    contact = Contact(
+        organization_id=org_id,
+        directory_id=directory_id,
+        external_id=f"ext-{uuid.uuid4().hex[:8]}",
+        name=name,
+        phone_number=phone,
+        contact_metadata={},
+        is_active=True,
+    )
+    db.add(contact)
+    db.commit()
+    db.refresh(contact)
+    return contact
+
+
+def _has_contact_service() -> bool:
+    try:
+        import core.services.contacts.contact_service  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+# --------------------------------------------------------------------- assign
+
+class TestAssign:
+    def test_assign_explicit_contact_ids(self, db_session):
+        agent = _make_agent(db_session)
+        directory = _make_directory(db_session)
+        c1 = _make_contact(db_session, directory.id)
+        c2 = _make_contact(db_session, directory.id)
+
+        result = _svc(db_session).assign_contacts_to_agent(
+            agent.id, contact_ids=[c1.id, c2.id]
+        )
+        assert result == {"assigned": 2, "skipped": 0}
+
+        rows = (
+            db_session.query(AgentContact)
+            .filter(AgentContact.agent_id == agent.id)
+            .all()
+        )
+        assert {r.contact_id for r in rows} == {c1.id, c2.id}
+
+    def test_assign_is_idempotent_dedupes_already_assigned(self, db_session):
+        agent = _make_agent(db_session)
+        directory = _make_directory(db_session)
+        c1 = _make_contact(db_session, directory.id)
+        c2 = _make_contact(db_session, directory.id)
+
+        svc = _svc(db_session)
+        first = svc.assign_contacts_to_agent(agent.id, contact_ids=[c1.id])
+        assert first == {"assigned": 1, "skipped": 0}
+
+        # c1 already assigned → skipped; c2 new → assigned.
+        second = svc.assign_contacts_to_agent(agent.id, contact_ids=[c1.id, c2.id])
+        assert second == {"assigned": 1, "skipped": 1}
+
+        count = (
+            db_session.query(AgentContact)
+            .filter(AgentContact.agent_id == agent.id)
+            .count()
+        )
+        assert count == 2
+
+    def test_assign_from_directory_expands_active_contacts(self, db_session):
+        if not _has_contact_service():
+            pytest.skip("ContactService (parallel agent) not present yet")
+        agent = _make_agent(db_session)
+        directory = _make_directory(db_session)
+        c1 = _make_contact(db_session, directory.id)
+        c2 = _make_contact(db_session, directory.id)
+
+        result = _svc(db_session).assign_contacts_to_agent(
+            agent.id, directory_ids=[directory.id]
+        )
+        assert result["assigned"] == 2
+
+        rows = (
+            db_session.query(AgentContact)
+            .filter(AgentContact.agent_id == agent.id)
+            .all()
+        )
+        assert {r.contact_id for r in rows} == {c1.id, c2.id}
+
+    def test_assign_unions_directory_and_explicit_ids_without_double_counting(
+        self, db_session
+    ):
+        if not _has_contact_service():
+            pytest.skip("ContactService (parallel agent) not present yet")
+        agent = _make_agent(db_session)
+        directory = _make_directory(db_session)
+        c1 = _make_contact(db_session, directory.id)  # in directory
+        other_dir = _make_directory(db_session)
+        c2 = _make_contact(db_session, other_dir.id)  # explicit only
+
+        # c1 appears in BOTH the directory expansion and the explicit list → counted once.
+        result = _svc(db_session).assign_contacts_to_agent(
+            agent.id, directory_ids=[directory.id], contact_ids=[c1.id, c2.id]
+        )
+        assert result["assigned"] == 2
+
+        rows = (
+            db_session.query(AgentContact)
+            .filter(AgentContact.agent_id == agent.id)
+            .all()
+        )
+        assert {r.contact_id for r in rows} == {c1.id, c2.id}
+
+    def test_assign_empty_directory_is_no_op(self, db_session):
+        if not _has_contact_service():
+            pytest.skip("ContactService (parallel agent) not present yet")
+        agent = _make_agent(db_session)
+        empty_dir = _make_directory(db_session)  # no contacts
+
+        result = _svc(db_session).assign_contacts_to_agent(
+            agent.id, directory_ids=[empty_dir.id]
+        )
+        assert result == {"assigned": 0, "skipped": 0}
+        assert (
+            db_session.query(AgentContact)
+            .filter(AgentContact.agent_id == agent.id)
+            .count()
+            == 0
+        )
+
+    def test_assign_nothing_is_no_op(self, db_session):
+        agent = _make_agent(db_session)
+        result = _svc(db_session).assign_contacts_to_agent(agent.id)
+        assert result == {"assigned": 0, "skipped": 0}
+
+    def test_unique_constraint_prevents_duplicate_rows(self, db_session):
+        """Even a direct double-insert of the same (agent, contact) is rejected by the
+        unique constraint — the idempotent assign path relies on it."""
+        from sqlalchemy.exc import IntegrityError
+
+        agent = _make_agent(db_session)
+        directory = _make_directory(db_session)
+        c1 = _make_contact(db_session, directory.id)
+
+        db_session.add(
+            AgentContact(organization_id=ORG_ID, agent_id=agent.id, contact_id=c1.id)
+        )
+        db_session.commit()
+
+        db_session.add(
+            AgentContact(organization_id=ORG_ID, agent_id=agent.id, contact_id=c1.id)
+        )
+        with pytest.raises(IntegrityError):
+            db_session.commit()
+        db_session.rollback()
+
+
+# --------------------------------------------------------------------- list
+
+class TestList:
+    def test_list_returns_assigned_contacts(self, db_session):
+        agent = _make_agent(db_session)
+        directory = _make_directory(db_session)
+        c1 = _make_contact(db_session, directory.id, name="Alice")
+        _make_contact(db_session, directory.id, name="Bob")  # not assigned
+
+        svc = _svc(db_session)
+        svc.assign_contacts_to_agent(agent.id, contact_ids=[c1.id])
+
+        result = svc.list_agent_contacts(agent.id)
+        assert result["total"] == 1
+        assert result["data"][0]["id"] == str(c1.id)
+        assert "assignment_id" in result["data"][0]
+
+
+# --------------------------------------------------------------------- unassign
+
+class TestUnassign:
+    def test_unassign_removes_only_join_rows(self, db_session):
+        agent = _make_agent(db_session)
+        directory = _make_directory(db_session)
+        c1 = _make_contact(db_session, directory.id)
+        c2 = _make_contact(db_session, directory.id)
+
+        svc = _svc(db_session)
+        svc.assign_contacts_to_agent(agent.id, contact_ids=[c1.id, c2.id])
+
+        result = svc.unassign_contacts_from_agent(agent.id, [c1.id])
+        assert result == {"unassigned": 1}
+
+        # Join row gone, but the contact itself is untouched.
+        assert (
+            db_session.query(AgentContact)
+            .filter(AgentContact.agent_id == agent.id)
+            .count()
+            == 1
+        )
+        assert db_session.query(Contact).filter(Contact.id == c1.id).first() is not None
+
+    def test_unassign_empty_list_is_no_op(self, db_session):
+        agent = _make_agent(db_session)
+        result = _svc(db_session).unassign_contacts_from_agent(agent.id, [])
+        assert result == {"unassigned": 0}
+
+
+# --------------------------------------------------------------------- IDOR
+
+class TestOrgIsolation:
+    def test_assign_to_agent_in_other_org_raises_404(self, db_session):
+        other_agent = _make_agent(db_session, org_id=OTHER_ORG_ID)
+        with pytest.raises(HTTPException) as exc:
+            _svc(db_session).assign_contacts_to_agent(other_agent.id)
+        assert exc.value.status_code == 404
+
+    def test_contact_from_other_org_not_assigned(self, db_session):
+        agent = _make_agent(db_session)
+        other_dir = _make_directory(db_session, org_id=OTHER_ORG_ID)
+        other_contact = _make_contact(db_session, other_dir.id, org_id=OTHER_ORG_ID)
+
+        # Explicit id from another org is silently dropped (org-scoped Contact query).
+        result = _svc(db_session).assign_contacts_to_agent(
+            agent.id, contact_ids=[other_contact.id]
+        )
+        assert result["assigned"] == 0
+        assert (
+            db_session.query(AgentContact)
+            .filter(AgentContact.agent_id == agent.id)
+            .count()
+            == 0
+        )
+
+    def test_list_for_agent_in_other_org_raises_404(self, db_session):
+        other_agent = _make_agent(db_session, org_id=OTHER_ORG_ID)
+        with pytest.raises(HTTPException) as exc:
+            _svc(db_session).list_agent_contacts(other_agent.id)
+        assert exc.value.status_code == 404

--- a/test-cases/core/test_contact_datasources.py
+++ b/test-cases/core/test_contact_datasources.py
@@ -1,0 +1,185 @@
+"""ContactDatasourceService + router tests (Core edition) — real DB.
+
+Covers (subtask B2):
+- create (CSV only; non-csv rejected)
+- ``ensure_csv_datasource`` idempotency (returns existing, creates when absent)
+- org-scoping / IDOR on directory binding + delete
+- list scoped to a directory
+- admin-guard: member gets a real 403 on create/delete; member can list
+"""
+
+import uuid
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from core.api.v1 import contact_datasources as datasources_router
+from core.database.session import get_db
+from core.middleware.auth import JWTClaims, get_jwt_claims
+from core.models.contact_directory import ContactDirectory
+from core.models.datasource import Datasource
+from core.services.contacts.contact_datasource_service import ContactDatasourceService
+from core.services.contacts.contact_directory_service import ContactDirectoryService
+
+from sqlalchemy import create_engine, text
+from shared.config import settings
+
+
+def _first(query: str, default):
+    conn = create_engine(settings.DATABASE_URL, pool_pre_ping=True).connect()
+    try:
+        row = conn.execute(text(query)).fetchone()
+        return row[0] if row else default
+    finally:
+        conn.close()
+
+
+ORG_ID = str(_first("SELECT id FROM organizations LIMIT 1", settings.DEFAULT_ORG_ID))
+REAL_USER_ID = _first("SELECT id FROM users LIMIT 1", None)
+
+
+def _ds_svc(db):
+    return ContactDatasourceService(db, user_id=REAL_USER_ID, org_id=uuid.UUID(str(ORG_ID)))
+
+
+def _make_directory(db):
+    svc = ContactDirectoryService(db, user_id=REAL_USER_ID, org_id=uuid.UUID(str(ORG_ID)))
+    return svc.create_directory(name=f"Dir-{uuid.uuid4().hex[:6]}")
+
+
+# --------------------------------------------------------------------- create
+
+class TestCreate:
+    def test_create_csv_datasource(self, db_session):
+        directory = _make_directory(db_session)
+        ds = _ds_svc(db_session).create_datasource(name="Extra CSV", directory_id=directory.id)
+        assert ds.type == "csv"
+        assert ds.directory_id == directory.id
+        assert ds.organization_id == uuid.UUID(str(ORG_ID))
+
+    def test_non_csv_rejected(self, db_session):
+        with pytest.raises(HTTPException) as exc:
+            _ds_svc(db_session).create_datasource(name="REST", type="rest")
+        assert exc.value.status_code == 400
+
+    def test_create_rejects_foreign_directory(self, db_session):
+        foreign = ContactDirectory(organization_id=uuid.uuid4(), name="Foreign", is_active=True)
+        db_session.add(foreign)
+        db_session.commit()
+        with pytest.raises(HTTPException) as exc:
+            _ds_svc(db_session).create_datasource(name="X", directory_id=foreign.id)
+        assert exc.value.status_code == 404
+
+
+# ----------------------------------------------------------- ensure_csv_datasource
+
+class TestEnsureCsv:
+    def test_ensure_returns_existing(self, db_session):
+        # create_directory already provisions one CSV datasource.
+        directory = _make_directory(db_session)
+        existing = db_session.query(Datasource).filter(
+            Datasource.directory_id == directory.id
+        ).one()
+
+        got = _ds_svc(db_session).ensure_csv_datasource(directory.id)
+        assert got.id == existing.id
+        # No duplicate created.
+        assert db_session.query(Datasource).filter(
+            Datasource.directory_id == directory.id, Datasource.type == "csv"
+        ).count() == 1
+
+    def test_ensure_creates_when_absent(self, db_session):
+        # A directory row without the auto-provisioned datasource.
+        directory = ContactDirectory(
+            organization_id=uuid.UUID(str(ORG_ID)), name=f"Bare-{uuid.uuid4().hex[:6]}",
+            is_active=True,
+        )
+        db_session.add(directory)
+        db_session.commit()
+
+        assert db_session.query(Datasource).filter(
+            Datasource.directory_id == directory.id
+        ).count() == 0
+
+        got = _ds_svc(db_session).ensure_csv_datasource(directory.id)
+        assert got.type == "csv"
+        assert got.directory_id == directory.id
+        assert db_session.query(Datasource).filter(
+            Datasource.directory_id == directory.id
+        ).count() == 1
+
+    def test_ensure_rejects_foreign_directory(self, db_session):
+        foreign = ContactDirectory(organization_id=uuid.uuid4(), name="Foreign", is_active=True)
+        db_session.add(foreign)
+        db_session.commit()
+        with pytest.raises(HTTPException) as exc:
+            _ds_svc(db_session).ensure_csv_datasource(foreign.id)
+        assert exc.value.status_code == 404
+
+
+# ----------------------------------------------------------------- list + delete
+
+class TestListDelete:
+    def test_list_scoped_to_directory(self, db_session):
+        directory = _make_directory(db_session)
+        res = _ds_svc(db_session).list_datasources(directory_id=directory.id)
+        assert res["total"] >= 1
+        assert all(d["directory_id"] == str(directory.id) for d in res["data"])
+
+    def test_delete_soft_deletes(self, db_session):
+        directory = _make_directory(db_session)
+        ds = db_session.query(Datasource).filter(
+            Datasource.directory_id == directory.id
+        ).first()
+        _ds_svc(db_session).delete_datasource(ds.id)
+        db_session.refresh(ds)
+        assert ds.deleted_at is not None
+        assert ds.is_active is False
+
+    def test_delete_rejects_foreign(self, db_session):
+        foreign = Datasource(
+            organization_id=uuid.uuid4(), name="Foreign", type="csv", config={},
+            is_active=True,
+        )
+        db_session.add(foreign)
+        db_session.commit()
+        with pytest.raises(HTTPException) as exc:
+            _ds_svc(db_session).delete_datasource(foreign.id)
+        assert exc.value.status_code == 404
+
+
+# ----------------------------------------------------------------- admin guard
+
+def _guarded_client(db_session, role: str):
+    app = FastAPI()
+    app.include_router(datasources_router.router, prefix="/api/v1/contact-datasources")
+
+    def _claims():
+        import time
+        now = int(time.time())
+        return JWTClaims(
+            user_id=str(REAL_USER_ID), org_id=str(ORG_ID), role=role,
+            email="t@test.com", exp=now + 3600, iat=now,
+        )
+
+    app.dependency_overrides[get_jwt_claims] = _claims
+    app.dependency_overrides[get_db] = lambda: (yield db_session)
+    return TestClient(app)
+
+
+class TestAdminGuard:
+    def test_member_gets_403_on_create(self, db_session):
+        client = _guarded_client(db_session, role="member")
+        r = client.post("/api/v1/contact-datasources", json={"name": "X"})
+        assert r.status_code == 403
+
+    def test_member_gets_403_on_delete(self, db_session):
+        client = _guarded_client(db_session, role="member")
+        r = client.delete(f"/api/v1/contact-datasources/{uuid.uuid4()}")
+        assert r.status_code == 403
+
+    def test_member_can_list(self, db_session):
+        client = _guarded_client(db_session, role="member")
+        r = client.post("/api/v1/contact-datasources/list", json={"page_no": 1, "page_size": 5})
+        assert r.status_code == 200

--- a/test-cases/core/test_contact_directories.py
+++ b/test-cases/core/test_contact_directories.py
@@ -1,0 +1,347 @@
+"""ContactDirectoryService + router tests (Core edition) — real DB.
+
+Covers (subtask B2):
+- IDOR / org-scoping on get/update/delete
+- create provisions a CSV datasource + an empty default schema + sets default_schema_id
+- delete cascade: contacts + agent_contacts + scheduled_calls + CSV datasource deleted
+- schema retention (org schemas kept)
+- sync detach (SET NULL directory_id/datasource_id)
+- queued dial-job cancel + scheduled_calls deleted
+- C-3: pending/processing syncs marked 'failed' before detach
+- call-log (calls) preservation
+- admin-guard: a member role receives a real 403 on directory writes
+
+The delete path exercises hard deletes + a Procrastinate ``cancel_outbound_job`` call,
+which is monkeypatched to stay hermetic.
+"""
+
+import uuid
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from core.api.v1 import contact_directories as directories_router
+from core.middleware.auth import JWTClaims, get_jwt_claims
+from core.database.session import get_db
+from core.models.agent_contact import AgentContact
+from core.models.contact import Contact
+from core.models.contact_directory import ContactDirectory
+from core.models.contact_schema import ContactSchema
+from core.models.contact_sync import ContactSync
+from core.models.datasource import Datasource
+from core.models.scheduled_call import ScheduledCall
+from core.services.contacts.contact_directory_service import ContactDirectoryService
+
+from sqlalchemy import create_engine, text
+from shared.config import settings
+
+
+def _first(query: str, default):
+    conn = create_engine(settings.DATABASE_URL, pool_pre_ping=True).connect()
+    try:
+        row = conn.execute(text(query)).fetchone()
+        return row[0] if row else default
+    finally:
+        conn.close()
+
+
+ORG_ID = str(_first("SELECT id FROM organizations LIMIT 1", settings.DEFAULT_ORG_ID))
+REAL_USER_ID = _first("SELECT id FROM users LIMIT 1", None)
+
+
+def _dir_svc(db):
+    return ContactDirectoryService(db, user_id=REAL_USER_ID, org_id=uuid.UUID(str(ORG_ID)))
+
+
+# ------------------------------------------------------------ create + provision
+
+class TestCreateProvisions:
+    def test_create_provisions_datasource_but_no_auto_schema(self, db_session):
+        svc = _dir_svc(db_session)
+        directory = svc.create_directory(name=f"Dir-{uuid.uuid4().hex[:6]}")
+
+        # No schema is auto-created per directory (would pollute the org library).
+        assert directory.default_schema_id is None
+
+        # But the CSV datasource IS provisioned.
+        from core.models.datasource import Datasource
+        assert db_session.query(Datasource).filter(
+            Datasource.directory_id == directory.id, Datasource.type == "csv"
+        ).count() == 1
+
+    def test_create_with_user_selected_default_schema(self, db_session):
+        svc = _dir_svc(db_session)
+        schema = ContactSchema(
+            organization_id=uuid.UUID(str(ORG_ID)), name=f"Sch-{uuid.uuid4().hex[:6]}"
+        )
+        db_session.add(schema)
+        db_session.flush()
+
+        directory = svc.create_directory(
+            name=f"Dir-{uuid.uuid4().hex[:6]}", default_schema_id=schema.id
+        )
+        assert directory.default_schema_id == schema.id
+
+        datasources = db_session.query(Datasource).filter(
+            Datasource.directory_id == directory.id
+        ).all()
+        assert len(datasources) == 1
+        assert datasources[0].type == "csv"
+
+
+# --------------------------------------------------------------- IDOR / scoping
+
+class TestOrgScoping:
+    def test_foreign_directory_not_fetchable(self, db_session):
+        foreign = ContactDirectory(
+            organization_id=uuid.uuid4(),  # not ORG_ID
+            name="Foreign",
+            is_active=True,
+        )
+        db_session.add(foreign)
+        db_session.commit()
+
+        svc = _dir_svc(db_session)
+        with pytest.raises(HTTPException) as exc:
+            svc.get_directory(foreign.id)
+        assert exc.value.status_code == 404
+
+    def test_foreign_directory_not_deletable(self, db_session):
+        foreign = ContactDirectory(
+            organization_id=uuid.uuid4(),
+            name="Foreign",
+            is_active=True,
+        )
+        db_session.add(foreign)
+        db_session.commit()
+
+        svc = _dir_svc(db_session)
+        with pytest.raises(HTTPException) as exc:
+            svc.delete_directory(foreign.id)
+        assert exc.value.status_code == 404
+
+    def test_update_default_schema_rejects_foreign_schema(self, db_session):
+        svc = _dir_svc(db_session)
+        directory = svc.create_directory(name=f"Dir-{uuid.uuid4().hex[:6]}")
+
+        foreign_schema = ContactSchema(
+            organization_id=uuid.uuid4(),  # not ORG_ID
+            name="Foreign schema",
+            is_active=True,
+        )
+        db_session.add(foreign_schema)
+        db_session.commit()
+
+        with pytest.raises(HTTPException) as exc:
+            svc.update_directory(directory.id, default_schema_id=foreign_schema.id)
+        assert exc.value.status_code == 404
+
+
+# --------------------------------------------------------------- delete cascade
+
+class TestDeleteCascade:
+    def _seed_full_directory(self, db_session, monkeypatch):
+        """Create a directory with a contact, agent_contact, scheduled_call (queued job),
+        a completed call log, and a pending sync. Returns the seeded ids."""
+        # cancel_outbound_job is imported lazily inside hard_delete_directory_and_children,
+        # so patch it on its source module.
+        import core.services.ingestion_queue as iq
+        cancelled = []
+        monkeypatch.setattr(iq, "cancel_outbound_job",
+                            lambda job_id: cancelled.append(job_id) or True)
+
+        svc = _dir_svc(db_session)
+        org = uuid.UUID(str(ORG_ID))
+
+        # An org schema for the directory to reference (directories no longer auto-create
+        # one). Set as the directory's default so the sync + retention checks have a target.
+        schema = ContactSchema(organization_id=org, name=f"Sch-{uuid.uuid4().hex[:6]}")
+        db_session.add(schema)
+        db_session.flush()
+        directory = svc.create_directory(
+            name=f"Dir-{uuid.uuid4().hex[:6]}", default_schema_id=schema.id
+        )
+
+        contact = Contact(
+            organization_id=org,
+            directory_id=directory.id,
+            external_id=f"c-{uuid.uuid4().hex[:6]}",
+            name="Target",
+            phone_number="+14155550123",
+            contact_metadata={},
+            is_active=True,
+        )
+        db_session.add(contact)
+        db_session.flush()
+
+        # An agent to hang the agent_contact + scheduled_call off of.
+        from core.models.agent import Agent
+        agent = db_session.query(Agent).filter(Agent.organization_id == org).first()
+        agent_id = agent.id if agent else None
+
+        if agent_id:
+            ac = AgentContact(
+                organization_id=org, agent_id=agent_id, contact_id=contact.id,
+            )
+            db_session.add(ac)
+
+        # A completed call log that must survive the delete (needs a real agent).
+        call_id = None
+        if agent_id:
+            from core.models.call import Call
+            call = Call(
+                organization_id=org,
+                agent_id=agent_id,
+                direction="outbound",
+                to_number="+14155550123",
+            )
+            db_session.add(call)
+            db_session.flush()
+            call_id = call.id
+
+        sc = ScheduledCall(
+            organization_id=org,
+            agent_id=agent_id,
+            contact_id=contact.id,
+            from_number="+14155550000",
+            to_number="+14155550123",
+            scheduled_at=__import__("datetime").datetime.now(__import__("datetime").timezone.utc),
+            status="scheduled",
+            queue_job_id=4242,
+            call_id=call_id,
+        )
+        db_session.add(sc)
+
+        # A pending sync bound to the directory (must be marked failed then detached).
+        sync = ContactSync(
+            organization_id=org,
+            directory_id=directory.id,
+            datasource_id=None,
+            schema_id=directory.default_schema_id,
+            status="pending",
+            counts={},
+            row_errors=[],
+        )
+        db_session.add(sync)
+        db_session.commit()
+
+        return {
+            "directory_id": directory.id,
+            "default_schema_id": directory.default_schema_id,
+            "contact_id": contact.id,
+            "call_id": call_id,
+            "sync_id": sync.id,
+            "cancelled": cancelled,
+            "agent_id": agent_id,
+        }
+
+    def test_hard_delete_cascades_and_preserves_history(self, db_session, monkeypatch):
+        seeded = self._seed_full_directory(db_session, monkeypatch)
+        directory_id = seeded["directory_id"]
+        default_schema_id = seeded["default_schema_id"]
+
+        svc = _dir_svc(db_session)
+        summary = svc.delete_directory(directory_id)
+
+        # Directory gone.
+        assert db_session.query(ContactDirectory).filter(
+            ContactDirectory.id == directory_id
+        ).first() is None
+
+        # Contacts deleted.
+        assert db_session.query(Contact).filter(
+            Contact.id == seeded["contact_id"]
+        ).first() is None
+
+        # agent_contacts deleted.
+        assert db_session.query(AgentContact).filter(
+            AgentContact.contact_id == seeded["contact_id"]
+        ).count() == 0
+
+        # scheduled_calls deleted + queued job cancelled.
+        assert db_session.query(ScheduledCall).filter(
+            ScheduledCall.contact_id == seeded["contact_id"]
+        ).count() == 0
+        assert 4242 in seeded["cancelled"]
+        assert summary["dial_jobs_cancelled"] >= 1
+
+        # CSV datasource deleted.
+        assert db_session.query(Datasource).filter(
+            Datasource.directory_id == directory_id
+        ).count() == 0
+
+        # Sync marked failed AND detached (kept for audit).
+        sync = db_session.query(ContactSync).filter(
+            ContactSync.id == seeded["sync_id"]
+        ).first()
+        assert sync is not None
+        assert sync.status == "failed"
+        assert sync.error == "directory deleted"
+        assert sync.directory_id is None
+        assert sync.datasource_id is None
+
+        # Org default schema KEPT.
+        assert db_session.query(ContactSchema).filter(
+            ContactSchema.id == default_schema_id
+        ).first() is not None
+
+        # Completed call log preserved (when one was seeded).
+        if seeded["call_id"] is not None:
+            from core.models.call import Call
+            assert db_session.query(Call).filter(
+                Call.id == seeded["call_id"]
+            ).first() is not None
+
+    def test_delete_impact_counts(self, db_session, monkeypatch):
+        seeded = self._seed_full_directory(db_session, monkeypatch)
+        svc = _dir_svc(db_session)
+        impact = svc.delete_impact(seeded["directory_id"])
+        assert impact["contacts"] == 1
+        assert impact["scheduled_calls"] == 1
+        assert impact["syncs_detached"] == 1
+        assert impact["schemas_kept"] is True
+
+
+# ---------------------------------------------------------------- admin guard
+
+def _guarded_client(db_session, role: str):
+    """Mount the directories router on a throwaway app and stub auth to ``role``."""
+    app = FastAPI()
+    app.include_router(directories_router.router, prefix="/api/v1/contact-directories")
+
+    def _claims():
+        import time
+        now = int(time.time())
+        return JWTClaims(
+            user_id=str(REAL_USER_ID), org_id=str(ORG_ID), role=role,
+            email="t@test.com", exp=now + 3600, iat=now,
+        )
+
+    app.dependency_overrides[get_jwt_claims] = _claims
+    app.dependency_overrides[get_db] = lambda: (yield db_session)
+    return TestClient(app)
+
+
+class TestAdminGuard:
+    def test_member_gets_403_on_create(self, db_session):
+        client = _guarded_client(db_session, role="member")
+        r = client.post("/api/v1/contact-directories", json={"name": "X"})
+        assert r.status_code == 403
+
+    def test_admin_can_create(self, db_session):
+        client = _guarded_client(db_session, role="admin")
+        r = client.post("/api/v1/contact-directories", json={"name": f"D-{uuid.uuid4().hex[:6]}"})
+        assert r.status_code == 201
+        # No schema is auto-created; default is null unless the user provides one.
+        assert r.json()["default_schema_id"] is None
+
+    def test_member_gets_403_on_delete(self, db_session):
+        client = _guarded_client(db_session, role="member")
+        r = client.delete(f"/api/v1/contact-directories/{uuid.uuid4()}")
+        assert r.status_code == 403
+
+    def test_member_can_list(self, db_session):
+        client = _guarded_client(db_session, role="member")
+        r = client.post("/api/v1/contact-directories/list", json={"page_no": 1, "page_size": 5})
+        assert r.status_code == 200

--- a/test-cases/core/test_contact_foundations.py
+++ b/test-cases/core/test_contact_foundations.py
@@ -1,0 +1,191 @@
+"""Unit tests for the reusable contacts foundations (B0) — pure logic, no DB.
+
+Covers the shared helpers every contacts service reuses:
+- ``build_contact_field_json_schema`` / ``make_contact_metadata_validator`` /
+  ``validate_contact_metadata`` (metadata validation ported from the old field-def
+  service, now driven by ``SchemaField``-shaped rows).
+- ``map_source_row_to_contact`` (source_key → field_name mapping + type coercion).
+- ``apply_search_sort_pagination`` sort-key whitelisting semantics.
+"""
+
+from dataclasses import dataclass, field as dc_field
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from core.services.common.list_query import apply_search_sort_pagination
+from core.services.contact_ingestion.contact_mapping import map_source_row_to_contact
+from core.services.contacts.contact_metadata_validation import (
+    build_contact_field_json_schema,
+    make_contact_metadata_validator,
+    validate_contact_metadata,
+)
+
+
+@dataclass
+class _Field:
+    """Minimal stand-in for a ``SchemaField`` row (only the attrs the helpers read)."""
+
+    field_name: str
+    type: str = "string"
+    is_mandatory: bool = False
+    format: Optional[str] = None
+    validators: Dict[str, Any] = dc_field(default_factory=dict)
+    options: Optional[List[Any]] = None
+    source_key: Optional[str] = None
+
+
+# ---------------------------------------------------------------- validation
+
+
+def test_build_json_schema_types_validators_and_required():
+    fields = [
+        _Field("first_name", type="string", is_mandatory=True, validators={"minLength": 2}),
+        _Field("age", type="integer", validators={"minimum": 0}),
+        _Field("tier", type="enum", options=[{"value": "gold"}, {"value": "silver"}]),
+        _Field("subscribed", type="boolean"),
+    ]
+    schema = build_contact_field_json_schema(fields)
+    props = schema["properties"]
+    assert props["first_name"] == {"type": "string", "minLength": 2}
+    assert props["age"] == {"type": "integer", "minimum": 0}
+    assert props["tier"] == {"enum": ["gold", "silver"]}
+    assert props["subscribed"] == {"type": "boolean"}
+    assert schema["required"] == ["first_name"]
+
+
+def test_validator_reports_errors_only_for_managed_keys():
+    fields = [_Field("age", type="integer", is_mandatory=True, validators={"minimum": 18})]
+    managed, validator = make_contact_metadata_validator(fields)
+    assert managed == {"age"}
+
+    # Valid + an unmanaged extra key -> no errors (extra keys are allowed).
+    assert validate_contact_metadata({"age": 30, "extra": "ok"}, managed, validator) == []
+    # Violates the minimum -> reported.
+    assert validate_contact_metadata({"age": 5}, managed, validator)
+
+
+def test_empty_fields_make_noop_validator():
+    managed, validator = make_contact_metadata_validator([])
+    assert managed == set()
+    assert validator is None
+    assert validate_contact_metadata({"anything": 1}, managed, validator) == []
+
+
+def test_mandatory_field_present_but_empty_is_rejected():
+    # A required field whose value is a blank/whitespace string (e.g. an empty CSV cell)
+    # must fail its `required` constraint, not slip through as "present".
+    fields = [_Field("city", type="string", is_mandatory=True)]
+    managed, validator = make_contact_metadata_validator(fields)
+    assert validate_contact_metadata({"city": "SF"}, managed, validator) == []
+    assert validate_contact_metadata({"city": ""}, managed, validator)      # blank
+    assert validate_contact_metadata({"city": "   "}, managed, validator)   # whitespace
+    assert validate_contact_metadata({"city": None}, managed, validator)    # null
+    assert validate_contact_metadata({}, managed, validator)                # missing
+
+
+def test_mandatory_boolean_false_and_number_zero_are_valid():
+    # 0 / False are real values — never treated as "empty" for required fields.
+    fields = [
+        _Field("opted_in", type="boolean", is_mandatory=True),
+        _Field("score", type="integer", is_mandatory=True),
+    ]
+    managed, validator = make_contact_metadata_validator(fields)
+    assert validate_contact_metadata({"opted_in": False, "score": 0}, managed, validator) == []
+
+
+# ------------------------------------------------------------------ mapping
+
+
+def test_map_source_row_remaps_source_key_to_field_name():
+    fields = [
+        _Field("name", source_key="Full Name"),
+        _Field("phone_number", source_key="Mobile"),
+        _Field("external_id", source_key="CRM ID"),
+        _Field("age", type="integer", source_key="Age"),
+    ]
+    raw = {"Full Name": "Ada", "Mobile": "+15551230000", "CRM ID": "crm-1", "Age": "42"}
+    mapped = map_source_row_to_contact(raw, fields)
+    assert mapped["name"] == "Ada"
+    assert mapped["phone_number"] == "+15551230000"
+    assert mapped["external_id"] == "crm-1"
+    assert mapped["contact_metadata"] == {"age": 42}  # coerced to int, nested in metadata
+
+
+def test_map_source_row_null_source_key_is_identity():
+    fields = [_Field("name"), _Field("company")]  # no source_key -> read from field_name
+    raw = {"name": "Grace", "company": "Acme"}
+    mapped = map_source_row_to_contact(raw, fields)
+    assert mapped["name"] == "Grace"
+    assert mapped["contact_metadata"] == {"company": "Acme"}
+
+
+def test_map_source_row_skips_missing_and_blank():
+    fields = [_Field("name"), _Field("note")]
+    mapped = map_source_row_to_contact({"name": ""}, fields)  # note absent, name blank
+    assert mapped["name"] == ""
+    assert mapped["contact_metadata"] == {}  # blank/missing not written to metadata
+
+
+# --------------------------------------------------------------- list_query
+
+
+class _FakeQuery:
+    """Tiny fake SQLAlchemy Query recording the applied order/offset/limit."""
+
+    def __init__(self, rows):
+        self._rows = rows
+        self.ordered_by = None
+
+    def filter(self, *a):  # search path unused here
+        return self
+
+    def count(self):
+        return len(self._rows)
+
+    def order_by(self, col):
+        self.ordered_by = col
+        return self
+
+    def offset(self, n):
+        self._offset = n
+        return self
+
+    def limit(self, n):
+        self._limit = n
+        return self
+
+    def all(self):
+        return self._rows[self._offset:self._offset + self._limit]
+
+
+class _Col:
+    def __init__(self, name):
+        self.name = name
+
+    def asc(self):
+        return f"{self.name} asc"
+
+    def desc(self):
+        return f"{self.name} desc"
+
+
+def test_pagination_and_whitelisted_sort():
+    rows = list(range(10))
+    q = _FakeQuery(rows)
+    sort_map = {"name": _Col("name"), "created_at": _Col("created_at")}
+    page, total = apply_search_sort_pagination(
+        q, sort_by="name", sort_order="asc", sort_map=sort_map, page_no=2, page_size=3
+    )
+    assert total == 10
+    assert page == [3, 4, 5]
+    assert q.ordered_by == "name asc"
+
+
+def test_unknown_sort_key_falls_back_to_first_map_entry():
+    q = _FakeQuery(list(range(5)))
+    sort_map = {"created_at": _Col("created_at")}
+    _, _ = apply_search_sort_pagination(
+        q, sort_by="not_a_column", sort_order="desc", sort_map=sort_map
+    )
+    assert q.ordered_by == "created_at desc"

--- a/test-cases/core/test_contact_schemas.py
+++ b/test-cases/core/test_contact_schemas.py
@@ -1,0 +1,321 @@
+"""Contact schema + field tests (org-level ``ContactSchema`` / ``SchemaField``) — real DB.
+
+Ported from the old ``test_contact_fields.py`` (which targeted the removed flat
+``contact_field_definitions`` table). Keeps the equivalent coverage against the new
+schema-scoped model — bad type rejected, enum requires options, unsupported validator
+rejected, mandatory enforcement, unmanaged keys allowed, disabling a field stops
+enforcement — and adds schema-service specifics: referenced-by warning, delete-default
+blocked, and the admin-guard (member 403).
+
+Enforcement is asserted against the shared reusable validator composed from a schema's
+fields (``contact_metadata_validation``), which is the exact code the contact-create and
+sync paths reuse — ``ContactService`` itself is directory-scoped and owned by B4, so we
+validate the schema/field layer here.
+"""
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine, text
+
+from core.services.contacts.contact_metadata_validation import (
+    make_contact_metadata_validator,
+    validate_contact_metadata,
+)
+from core.services.contacts.contact_schema_service import ContactSchemaService
+from shared.config import settings
+
+
+def _org_id():
+    conn = create_engine(settings.DATABASE_URL, pool_pre_ping=True).connect()
+    try:
+        row = conn.execute(text("SELECT id FROM organizations LIMIT 1")).fetchone()
+        return uuid.UUID(str(row[0])) if row else uuid.UUID(settings.DEFAULT_ORG_ID)
+    finally:
+        conn.close()
+
+
+ORG_ID = _org_id()
+
+
+def _svc(db):
+    return ContactSchemaService(db, user_id=None, org_id=ORG_ID)
+
+
+def _sname():
+    return f"schema_{uuid.uuid4().hex[:8]}"
+
+
+def _fname():
+    return f"field_{uuid.uuid4().hex[:8]}"
+
+
+def _new_schema(svc):
+    return svc.create_schema(name=_sname())
+
+
+def _validate(fields, metadata):
+    """Compose the reusable validator from a schema's fields and return errors."""
+    managed, validator = make_contact_metadata_validator(fields)
+    return validate_contact_metadata(metadata, managed, validator)
+
+
+# ---------------------------------------------------------------------------
+# Schema CRUD
+# ---------------------------------------------------------------------------
+
+class TestSchemaCrud:
+    def test_create_and_list(self, db_session):
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        listed = svc.list_schemas(page_size=100)["data"]
+        assert any(s["id"] == str(schema.id) for s in listed)
+
+    def test_get_detail_includes_fields_and_referenced_by(self, db_session):
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        svc.create_schema_field(schema.id, field_name=_fname(), type="string")
+        detail = svc.get_schema_detail(schema.id)
+        assert len(detail["fields"]) == 1
+        assert detail["referenced_by"] == {"directories": 0, "syncs": 0}
+
+    def test_get_missing_schema_404(self, db_session):
+        with pytest.raises(HTTPException) as exc:
+            _svc(db_session).get_schema(uuid.uuid4())
+        assert exc.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Field CRUD + guardrails (ported from test_contact_fields.py)
+# ---------------------------------------------------------------------------
+
+class TestFieldCrud:
+    def test_create_and_list_field(self, db_session):
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        name = _fname()
+        svc.create_schema_field(schema.id, field_name=name, type="string", is_mandatory=True)
+        detail = svc.get_schema_detail(schema.id)
+        assert any(f["field_name"] == name for f in detail["fields"])
+
+    def test_duplicate_field_conflicts(self, db_session):
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        name = _fname()
+        svc.create_schema_field(schema.id, field_name=name, type="string")
+        with pytest.raises(HTTPException) as exc:
+            svc.create_schema_field(schema.id, field_name=name, type="string")
+        assert exc.value.status_code == 409
+
+    def test_recreate_after_delete_revives_not_500(self, db_session):
+        # The (schema_id, field_name) unique constraint counts soft-deleted rows, so
+        # re-adding a previously-removed field must revive it, not violate the constraint.
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        name = _fname()
+        f = svc.create_schema_field(schema.id, field_name=name, type="string")
+        svc.delete_schema_field(f.id)  # soft-delete
+        revived = svc.create_schema_field(
+            schema.id, field_name=name, type="integer", is_mandatory=True
+        )
+        assert revived.type == "integer" and revived.is_mandatory is True
+        assert revived.deleted_at is None and revived.is_active is True
+        rows = [f for f in svc.get_schema_detail(schema.id)["fields"] if f["field_name"] == name]
+        assert len(rows) == 1
+
+    def test_bad_type_rejected(self, db_session):
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        with pytest.raises(HTTPException):
+            svc.create_schema_field(schema.id, field_name=_fname(), type="datetime")
+
+    def test_unsupported_validator_rejected(self, db_session):
+        # minimum is a number validator; illegal on a string field.
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        with pytest.raises(HTTPException):
+            svc.create_schema_field(
+                schema.id, field_name=_fname(), type="string", validators={"minimum": 3}
+            )
+
+    def test_invalid_pattern_validator_rejected(self, db_session):
+        # A malformed regex must be rejected at field-create (400), not accepted and
+        # later crashed with a 500 when jsonschema compiles it at contact-write time.
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        with pytest.raises(HTTPException) as exc:
+            svc.create_schema_field(
+                schema.id, field_name=_fname(), type="string", validators={"pattern": "["}
+            )
+        assert exc.value.status_code == 400
+
+    def test_valid_pattern_validator_accepted(self, db_session):
+        # A well-formed regex is accepted and enforced by the composed validator.
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        name = _fname()
+        f = svc.create_schema_field(
+            schema.id, field_name=name, type="string", validators={"pattern": "^[0-9]+$"}
+        )
+        assert f.validators == {"pattern": "^[0-9]+$"}
+        assert _validate(svc._active_fields(schema.id), {name: "123"}) == []
+        assert _validate(svc._active_fields(schema.id), {name: "abc"})
+
+    def test_enum_requires_options(self, db_session):
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        with pytest.raises(HTTPException):
+            svc.create_schema_field(schema.id, field_name=_fname(), type="enum")
+
+    def test_enum_with_options_ok(self, db_session):
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        f = svc.create_schema_field(
+            schema.id,
+            field_name=_fname(),
+            type="enum",
+            options=[{"value": "a", "label": "A"}, {"value": "b", "label": "B"}],
+        )
+        assert f.type == "enum"
+
+
+# ---------------------------------------------------------------------------
+# JSON-Schema composition + enforcement (via reusable validator)
+# ---------------------------------------------------------------------------
+
+class TestEnforcement:
+    def test_mandatory_missing_rejected(self, db_session):
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        name = _fname()
+        svc.create_schema_field(schema.id, field_name=name, type="string", is_mandatory=True)
+        errors = _validate(svc._active_fields(schema.id), {})
+        assert errors  # missing required field flagged
+
+    def test_validator_violation_rejected(self, db_session):
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        name = _fname()
+        svc.create_schema_field(
+            schema.id, field_name=name, type="string", validators={"maxLength": 3}
+        )
+        errors = _validate(svc._active_fields(schema.id), {name: "toolong"})
+        assert errors
+
+    def test_valid_metadata_accepted(self, db_session):
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        name = _fname()
+        svc.create_schema_field(
+            schema.id, field_name=name, type="string", is_mandatory=True,
+            validators={"maxLength": 10},
+        )
+        errors = _validate(svc._active_fields(schema.id), {name: "ok"})
+        assert errors == []
+
+    def test_unmanaged_extra_keys_allowed(self, db_session):
+        # No field for 'company' → it flows through untouched.
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        svc.create_schema_field(schema.id, field_name=_fname(), type="string")
+        errors = _validate(svc._active_fields(schema.id), {"company": "Acme"})
+        assert errors == []
+
+    def test_disabling_field_stops_enforcement(self, db_session):
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        name = _fname()
+        f = svc.create_schema_field(
+            schema.id, field_name=name, type="string", is_mandatory=True
+        )
+        svc.delete_schema_field(f.id)  # soft-disable
+        # Mandatory no longer enforced → empty metadata validates clean.
+        errors = _validate(svc._active_fields(schema.id), {})
+        assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# Referenced-by warning + delete-default blocked
+# ---------------------------------------------------------------------------
+
+class TestSchemaReferences:
+    def _make_directory(self, db_session, default_schema_id=None):
+        from core.models.contact_directory import ContactDirectory
+
+        directory = ContactDirectory(
+            organization_id=ORG_ID,
+            name=f"dir_{uuid.uuid4().hex[:8]}",
+            default_schema_id=default_schema_id,
+            is_active=True,
+        )
+        db_session.add(directory)
+        db_session.commit()
+        db_session.refresh(directory)
+        return directory
+
+    def test_referenced_by_counts_directories(self, db_session):
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        self._make_directory(db_session, default_schema_id=schema.id)
+        result = svc.update_schema(schema.id, description="edited")
+        assert result["referenced_by"]["directories"] == 1
+
+    def test_referenced_by_counts_syncs(self, db_session):
+        from core.models.contact_sync import ContactSync
+
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        sync = ContactSync(
+            organization_id=ORG_ID, schema_id=schema.id, status="completed",
+        )
+        db_session.add(sync)
+        db_session.commit()
+        result = svc.update_schema(schema.id, name=_sname())
+        assert result["referenced_by"]["syncs"] == 1
+
+    def test_delete_default_schema_blocked(self, db_session):
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        self._make_directory(db_session, default_schema_id=schema.id)
+        with pytest.raises(HTTPException) as exc:
+            svc.delete_schema(schema.id)
+        assert exc.value.status_code == 409
+
+    def test_delete_unreferenced_schema_ok(self, db_session):
+        svc = _svc(db_session)
+        schema = _new_schema(svc)
+        result = svc.delete_schema(schema.id)
+        assert result["ok"] is True
+        # Soft-deleted → no longer listed.
+        listed = svc.list_schemas(page_size=100)["data"]
+        assert all(s["id"] != str(schema.id) for s in listed)
+
+
+# ---------------------------------------------------------------------------
+# Admin guard (member 403) — via the real router
+# ---------------------------------------------------------------------------
+
+class TestAdminGuard:
+    def test_member_cannot_create_schema(self, client_as_member):
+        resp = client_as_member.post(
+            "/api/v1/contact-schemas", json={"name": _sname()}
+        )
+        assert resp.status_code == 403
+
+    def test_admin_can_create_schema(self, client_as_admin):
+        resp = client_as_admin.post(
+            "/api/v1/contact-schemas", json={"name": _sname()}
+        )
+        assert resp.status_code == 201
+
+    def test_member_can_list_schemas(self, client_as_member):
+        resp = client_as_member.post("/api/v1/contact-schemas/list", json={})
+        assert resp.status_code == 200
+
+    def test_member_cannot_delete_schema(self, client_as_admin, client_as_member):
+        created = client_as_admin.post(
+            "/api/v1/contact-schemas", json={"name": _sname()}
+        ).json()
+        resp = client_as_member.delete(f"/api/v1/contact-schemas/{created['id']}")
+        assert resp.status_code == 403

--- a/test-cases/core/test_contact_syncs.py
+++ b/test-cases/core/test_contact_syncs.py
@@ -1,0 +1,421 @@
+"""ContactSyncService tests (Core edition) — real DB, R2 download monkeypatched.
+
+Exercises the unified sync executor ``run_contact_sync`` directly (the Procrastinate
+worker just loads the sync and calls it), covering:
+- partial failure: valid rows land with ``sync_id``, invalid rows recorded in
+  ``row_errors`` and skipped; counts correct; status ``completed``.
+- auto-assign: an ``agent_id`` on the sync inserts ``agent_contacts`` for imported rows.
+- hard failure: a file whose rows all fail validation → status ``failed``, nothing lands.
+- idempotent redelivery: re-running a terminal sync is a no-op.
+- C-3: a directory hard-deleted (soft-deleted) mid-run aborts cleanly as
+  ``failed`` (error="directory deleted") without upserting.
+
+The R2 blob download is monkeypatched to return canned CSV bytes so these stay hermetic.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from core.models.agent import Agent
+from core.models.agent_contact import AgentContact
+from core.models.contact import Contact
+from core.models.contact_directory import ContactDirectory
+from core.models.contact_schema import ContactSchema
+from core.models.contact_sync import ContactSync
+from core.models.datasource import Datasource
+from core.models.schema_field import SchemaField
+from core.models.upload import Upload
+from core.services.contacts.contact_sync_service import ContactSyncService
+from shared.config import settings
+
+
+def _first_row(query: str, default):
+    conn = create_engine(settings.DATABASE_URL, pool_pre_ping=True).connect()
+    try:
+        row = conn.execute(text(query)).fetchone()
+        return row[0] if row else default
+    finally:
+        conn.close()
+
+
+ORG_ID = str(_first_row("SELECT id FROM organizations LIMIT 1", settings.DEFAULT_ORG_ID))
+REAL_USER_ID = _first_row("SELECT id FROM users LIMIT 1", 1)
+
+
+def _svc(db):
+    return ContactSyncService(db, user_id=REAL_USER_ID, org_id=uuid.UUID(str(ORG_ID)))
+
+
+# --------------------------------------------------------------------- fixtures
+
+
+def _make_schema(db, *, field_name="priority", mandatory=True, source_key=None):
+    """Org schema with reserved name/phone/external_id fields + one mandatory metadata
+    field, so a row missing that field fails validation (drives partial/hard failure)."""
+    schema = ContactSchema(
+        organization_id=uuid.UUID(str(ORG_ID)),
+        name=f"Schema {uuid.uuid4().hex[:6]}",
+        is_active=True,
+    )
+    db.add(schema)
+    db.commit()
+    db.refresh(schema)
+
+    fields = [
+        ("name", "string", False),
+        ("phone_number", "string", False),
+        ("external_id", "string", False),
+        (field_name, "string", mandatory),
+    ]
+    for fname, ftype, is_mand in fields:
+        db.add(
+            SchemaField(
+                organization_id=uuid.UUID(str(ORG_ID)),
+                schema_id=schema.id,
+                field_name=fname,
+                type=ftype,
+                is_mandatory=is_mand,
+                source_key=source_key if fname == field_name else None,
+                is_active=True,
+            )
+        )
+    db.commit()
+    return schema
+
+
+def _make_directory(db, *, default_schema_id=None):
+    directory = ContactDirectory(
+        organization_id=uuid.UUID(str(ORG_ID)),
+        name=f"Dir {uuid.uuid4().hex[:6]}",
+        default_schema_id=default_schema_id,
+        is_active=True,
+    )
+    db.add(directory)
+    db.commit()
+    db.refresh(directory)
+    return directory
+
+
+def _make_datasource(db, directory_id):
+    ds = Datasource(
+        organization_id=uuid.UUID(str(ORG_ID)),
+        directory_id=directory_id,
+        name="CSV Import",
+        type="csv",
+        config={},
+        is_active=True,
+    )
+    db.add(ds)
+    db.commit()
+    db.refresh(ds)
+    return ds
+
+
+def _make_upload(db):
+    up = Upload(
+        organization_id=uuid.UUID(str(ORG_ID)),
+        container_name="bucket",
+        file_path=f"contacts/{ORG_ID}/{uuid.uuid4()}/f.csv",
+        file_name="f.csv",
+        file_type="text/csv",
+        size_bytes=10,
+        purpose="contact_import",
+        status="ready",
+        meta_data={},
+    )
+    db.add(up)
+    db.commit()
+    db.refresh(up)
+    return up
+
+
+def _make_agent(db):
+    agent = Agent(
+        organization_id=uuid.UUID(str(ORG_ID)),
+        name=f"Agent {uuid.uuid4().hex[:6]}",
+        agent_type="outbound",
+        created_by_user_id=REAL_USER_ID,
+        is_active=True,
+    )
+    db.add(agent)
+    db.commit()
+    db.refresh(agent)
+    return agent
+
+
+def _make_sync(db, *, directory, schema, upload, datasource, agent_id=None):
+    sync = ContactSync(
+        organization_id=uuid.UUID(str(ORG_ID)),
+        directory_id=directory.id,
+        datasource_id=datasource.id,
+        schema_id=schema.id,
+        upload_id=upload.id,
+        agent_id=agent_id,
+        status="pending",
+        counts={},
+        row_errors=[],
+        created_by_user_id=REAL_USER_ID,
+    )
+    db.add(sync)
+    db.commit()
+    db.refresh(sync)
+    return sync
+
+
+def _patch_download(monkeypatch, csv_text: str):
+    """Make R2 download return the given CSV bytes (hermetic)."""
+    from core.services import r2_storage_service
+
+    def _fake_download(self, object_key):
+        return csv_text.encode("utf-8")
+
+    monkeypatch.setattr(
+        r2_storage_service.R2StorageService, "download_file", _fake_download
+    )
+
+
+# ------------------------------------------------------------------- scenarios
+
+
+class TestPartialFailure:
+    def test_valid_rows_land_with_sync_id_invalid_recorded(self, db_session, monkeypatch):
+        schema = _make_schema(db_session)  # 'priority' mandatory
+        directory = _make_directory(db_session, default_schema_id=schema.id)
+        datasource = _make_datasource(db_session, directory.id)
+        upload = _make_upload(db_session)
+        sync = _make_sync(
+            db_session, directory=directory, schema=schema, upload=upload, datasource=datasource
+        )
+
+        # Row 1 valid (has priority); row 2 invalid (missing mandatory priority).
+        _patch_download(
+            monkeypatch,
+            "external_id,name,phone_number,priority\n"
+            "c1,Alice,+14155550123,high\n"
+            "c2,Bob,+14155550124,\n",
+        )
+
+        _svc(db_session).run_contact_sync(sync)
+        db_session.refresh(sync)
+
+        assert sync.status == "completed"
+        assert sync.counts["created"] == 1
+        assert sync.counts["failed"] == 1
+        assert len(sync.row_errors) >= 1
+
+        contacts = (
+            db_session.query(Contact)
+            .filter(Contact.directory_id == directory.id, Contact.deleted_at.is_(None))
+            .all()
+        )
+        assert len(contacts) == 1
+        assert contacts[0].external_id == "c1"
+        assert contacts[0].sync_id == sync.id
+
+    def test_metadata_only_schema_keeps_base_identity_partial(self, db_session, monkeypatch):
+        # The schema maps ONLY a mandatory metadata field (city); name/phone/external_id
+        # are NOT schema fields. The base identity (external_id synthesized from phone)
+        # must survive, so the valid row imports and the empty-city row is skipped —
+        # a partial success, NOT an all-rows-failed hard failure.
+        schema = _make_schema(db_session, field_name="city")  # 'city' mandatory
+        directory = _make_directory(db_session, default_schema_id=schema.id)
+        datasource = _make_datasource(db_session, directory.id)
+        upload = _make_upload(db_session)
+        sync = _make_sync(
+            db_session, directory=directory, schema=schema, upload=upload, datasource=datasource
+        )
+        # No external_id column — it must be synthesized from the phone number.
+        _patch_download(
+            monkeypatch,
+            "name,phone_number,city\n"
+            "John Doe,+919789483349,Erode\n"
+            "Testing,+911234567890,\n",
+        )
+
+        _svc(db_session).run_contact_sync(sync)
+        db_session.refresh(sync)
+
+        assert sync.status == "completed"
+        assert sync.counts["created"] == 1
+        assert sync.counts["failed"] == 1
+
+        contacts = (
+            db_session.query(Contact)
+            .filter(Contact.directory_id == directory.id, Contact.deleted_at.is_(None))
+            .all()
+        )
+        assert len(contacts) == 1
+        assert contacts[0].name == "John Doe"
+        assert contacts[0].external_id == "+919789483349"  # synthesized from phone
+        assert (contacts[0].contact_metadata or {}).get("city") == "Erode"
+
+        # The error report identifies WHICH row failed (name/phone), not just an index.
+        assert len(sync.row_errors) >= 1
+        err = sync.row_errors[0]
+        assert err["name"] == "Testing"
+        assert err["phone_number"] == "+911234567890"
+        assert "city" in err["message"].lower()
+
+
+class TestAutoAssign:
+    def test_agent_id_inserts_agent_contacts(self, db_session, monkeypatch):
+        schema = _make_schema(db_session)
+        directory = _make_directory(db_session, default_schema_id=schema.id)
+        datasource = _make_datasource(db_session, directory.id)
+        upload = _make_upload(db_session)
+        agent = _make_agent(db_session)
+        sync = _make_sync(
+            db_session,
+            directory=directory,
+            schema=schema,
+            upload=upload,
+            datasource=datasource,
+            agent_id=agent.id,
+        )
+
+        _patch_download(
+            monkeypatch,
+            "external_id,name,phone_number,priority\n"
+            "c1,Alice,+14155550123,high\n"
+            "c2,Bob,+14155550124,low\n",
+        )
+
+        _svc(db_session).run_contact_sync(sync)
+        db_session.refresh(sync)
+
+        assert sync.status == "completed"
+        assert sync.counts["created"] == 2
+
+        assignments = (
+            db_session.query(AgentContact)
+            .filter(AgentContact.agent_id == agent.id)
+            .all()
+        )
+        assert len(assignments) == 2
+
+
+class TestHardFailure:
+    def test_all_rows_invalid_marks_failed_nothing_imported(self, db_session, monkeypatch):
+        schema = _make_schema(db_session)  # 'priority' mandatory
+        directory = _make_directory(db_session, default_schema_id=schema.id)
+        datasource = _make_datasource(db_session, directory.id)
+        upload = _make_upload(db_session)
+        sync = _make_sync(
+            db_session, directory=directory, schema=schema, upload=upload, datasource=datasource
+        )
+
+        # Both rows miss the mandatory priority.
+        _patch_download(
+            monkeypatch,
+            "external_id,name,phone_number,priority\n"
+            "c1,Alice,+14155550123,\n"
+            "c2,Bob,+14155550124,\n",
+        )
+
+        _svc(db_session).run_contact_sync(sync)
+        db_session.refresh(sync)
+
+        assert sync.status == "failed"
+        assert sync.error
+        assert sync.counts.get("created", 0) == 0
+        contacts = (
+            db_session.query(Contact)
+            .filter(Contact.directory_id == directory.id)
+            .all()
+        )
+        assert contacts == []
+
+
+class TestIdempotentRedelivery:
+    def test_rerun_of_terminal_sync_is_noop(self, db_session, monkeypatch):
+        schema = _make_schema(db_session)
+        directory = _make_directory(db_session, default_schema_id=schema.id)
+        datasource = _make_datasource(db_session, directory.id)
+        upload = _make_upload(db_session)
+        sync = _make_sync(
+            db_session, directory=directory, schema=schema, upload=upload, datasource=datasource
+        )
+
+        _patch_download(
+            monkeypatch,
+            "external_id,name,phone_number,priority\nc1,Alice,+14155550123,high\n",
+        )
+
+        _svc(db_session).run_contact_sync(sync)
+        db_session.refresh(sync)
+        assert sync.status == "completed"
+        first_counts = dict(sync.counts)
+
+        # Re-running the same completed sync must NOT re-import or change counts.
+        _svc(db_session).run_contact_sync(sync)
+        db_session.refresh(sync)
+        assert sync.counts == first_counts
+        contacts = (
+            db_session.query(Contact)
+            .filter(Contact.directory_id == directory.id, Contact.deleted_at.is_(None))
+            .count()
+        )
+        assert contacts == 1
+
+    def test_reimport_same_external_id_upserts(self, db_session, monkeypatch):
+        """A second sync of the same external_id updates rather than duplicates."""
+        schema = _make_schema(db_session)
+        directory = _make_directory(db_session, default_schema_id=schema.id)
+        datasource = _make_datasource(db_session, directory.id)
+
+        for name in ("Alice", "Alice Updated"):
+            upload = _make_upload(db_session)
+            sync = _make_sync(
+                db_session, directory=directory, schema=schema, upload=upload, datasource=datasource
+            )
+            _patch_download(
+                monkeypatch,
+                f"external_id,name,phone_number,priority\nc1,{name},+14155550123,high\n",
+            )
+            _svc(db_session).run_contact_sync(sync)
+
+        contacts = (
+            db_session.query(Contact)
+            .filter(Contact.directory_id == directory.id, Contact.deleted_at.is_(None))
+            .all()
+        )
+        assert len(contacts) == 1
+        assert contacts[0].name == "Alice Updated"
+
+
+class TestDirectoryDeletedMidSync:
+    def test_directory_soft_deleted_before_run_aborts_cleanly(self, db_session, monkeypatch):
+        schema = _make_schema(db_session)
+        directory = _make_directory(db_session, default_schema_id=schema.id)
+        datasource = _make_datasource(db_session, directory.id)
+        upload = _make_upload(db_session)
+        sync = _make_sync(
+            db_session, directory=directory, schema=schema, upload=upload, datasource=datasource
+        )
+
+        _patch_download(
+            monkeypatch,
+            "external_id,name,phone_number,priority\nc1,Alice,+14155550123,high\n",
+        )
+
+        # C-3: simulate the directory being hard-deleted (soft-deleted / torn down) after
+        # the sync was enqueued but before the worker runs it.
+        directory.deleted_at = datetime.now(timezone.utc)
+        directory.is_active = False
+        db_session.commit()
+
+        _svc(db_session).run_contact_sync(sync)
+        db_session.refresh(sync)
+
+        assert sync.status == "failed"
+        assert sync.error == "directory deleted"
+        # Nothing upserted against the RESTRICT FK.
+        contacts = (
+            db_session.query(Contact)
+            .filter(Contact.directory_id == directory.id)
+            .all()
+        )
+        assert contacts == []

--- a/test-cases/core/test_contacts.py
+++ b/test-cases/core/test_contacts.py
@@ -1,0 +1,429 @@
+"""Directory-scoped contacts tests (Core edition) — real DB, real endpoints.
+
+Covers: contact API auth, directory-scoped list/create/update/delete, org + directory
+IDOR (a contact in another org / another directory never surfaces), partial multi-add
+(one invalid row → ``{created, failed}``), and ``(directory_id, external_id)``
+uniqueness (re-adding the same external_id upserts rather than duplicating).
+
+Every fixture provisions a ``ContactDirectory`` first because ``contacts.directory_id``
+is now REQUIRED (RESTRICT). Metadata validation is exercised via a directory whose
+default schema has one mandatory field.
+"""
+
+import uuid
+
+import pytest
+from fastapi import FastAPI
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+
+from core.api.v1 import contacts as contacts_router
+from core.database.session import get_db
+from core.middleware.auth import JWTManager
+from core.models.agent import Agent
+from core.models.agent_contact import AgentContact
+from core.models.contact import Contact
+from core.models.contact_directory import ContactDirectory
+from core.models.contact_schema import ContactSchema
+from core.models.schema_field import SchemaField
+from core.services.contacts.contact_service import ContactService
+from shared.config import settings
+
+
+def _first_row(query: str, default):
+    conn = create_engine(settings.DATABASE_URL, pool_pre_ping=True).connect()
+    try:
+        row = conn.execute(text(query)).fetchone()
+        return row[0] if row else default
+    finally:
+        conn.close()
+
+
+ORG_ID = str(_first_row("SELECT id FROM organizations LIMIT 1", settings.DEFAULT_ORG_ID))
+REAL_USER_ID = _first_row("SELECT id FROM users LIMIT 1", 1)
+
+
+def _svc(db):
+    return ContactService(db, user_id=REAL_USER_ID, org_id=uuid.UUID(str(ORG_ID)))
+
+
+# The contacts router is directory-scoped and mounted PREFIX-LESS by Phase C
+# (``/contact-directories/...`` + ``/contact/schedule-calls``). To exercise those exact
+# URLs independently of main.py wiring (owned by another subtask), mount the router on a
+# fresh app at prefix "" and point it at the test DB session.
+def _router_client(db_session, role="member"):
+    app = FastAPI()
+    app.include_router(contacts_router.router, prefix="/api/v1")
+
+    def _get_test_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _get_test_db
+    client = TestClient(app)
+    if role is not None:
+        token = JWTManager().create_access_token(
+            user_id=REAL_USER_ID, email=f"{role}@test.com", org_id=ORG_ID, role=role,
+        )
+        client.headers["Authorization"] = f"Bearer {token}"
+        client.headers["tenant_id"] = ORG_ID
+    return client
+
+
+def _make_directory(db, *, org_id=None, default_schema_id=None, name=None):
+    """Create a ContactDirectory row directly (RESTRICT FK requires one to exist)."""
+    directory = ContactDirectory(
+        organization_id=uuid.UUID(str(org_id or ORG_ID)),
+        name=name or f"Dir {uuid.uuid4().hex[:6]}",
+        default_schema_id=default_schema_id,
+        is_active=True,
+    )
+    db.add(directory)
+    db.commit()
+    db.refresh(directory)
+    return directory
+
+
+def _make_agent(db, *, org_id=None):
+    """Create an Agent row directly (for create-with-agent_id assignment tests)."""
+    agent = Agent(
+        organization_id=uuid.UUID(str(org_id or ORG_ID)),
+        name=f"agent-{uuid.uuid4().hex[:8]}",
+        agent_type="outbound",
+        created_by_user_id=REAL_USER_ID,
+        is_active=True,
+    )
+    db.add(agent)
+    db.commit()
+    db.refresh(agent)
+    return agent
+
+
+def _make_schema_with_mandatory_field(db, field_name="priority"):
+    """Create an org schema with one mandatory string field, return the schema."""
+    schema = ContactSchema(
+        organization_id=uuid.UUID(str(ORG_ID)),
+        name=f"Schema {uuid.uuid4().hex[:6]}",
+        is_active=True,
+    )
+    db.add(schema)
+    db.commit()
+    db.refresh(schema)
+    field = SchemaField(
+        organization_id=uuid.UUID(str(ORG_ID)),
+        schema_id=schema.id,
+        field_name=field_name,
+        type="string",
+        is_mandatory=True,
+        is_active=True,
+    )
+    db.add(field)
+    db.commit()
+    return schema
+
+
+# --------------------------------------------------------------------- API auth
+
+class TestContactApiAuth:
+    def test_list_requires_auth(self, db_session):
+        directory = _make_directory(db_session)
+        client = _router_client(db_session, role=None)
+        r = client.post(f"/api/v1/contact-directories/{directory.id}/contacts/list", json={})
+        assert r.status_code in (401, 403)
+
+    def test_member_can_list(self, db_session):
+        directory = _make_directory(db_session)
+        client = _router_client(db_session)
+        r = client.post(
+            f"/api/v1/contact-directories/{directory.id}/contacts/list",
+            json={"page_no": 1, "page_size": 10},
+        )
+        assert r.status_code == 200
+        assert "data" in r.json()
+
+    def test_create_returns_created_failed_shape(self, db_session):
+        directory = _make_directory(db_session)
+        client = _router_client(db_session)
+        ext = f"api-{uuid.uuid4().hex[:8]}"
+        r = client.post(
+            f"/api/v1/contact-directories/{directory.id}/contacts",
+            json={"contact": {"name": "API", "phone_number": "+14155550199", "external_id": ext}},
+        )
+        assert r.status_code == 201
+        body = r.json()
+        assert body["failed"] == []
+        assert len(body["created"]) == 1
+        assert body["created"][0]["external_id"] == ext
+        assert body["created"][0]["directory_id"] == str(directory.id)
+
+
+# -------------------------------------------------- create + agent assignment
+
+class TestCreateWithAgentAssignment:
+    def test_create_with_agent_id_assigns_created_contacts(self, db_session):
+        # Creating contacts WITH agent_id inserts agent_contacts for the created rows.
+        directory = _make_directory(db_session)
+        agent = _make_agent(db_session)
+        client = _router_client(db_session)
+        ext = f"assign-{uuid.uuid4().hex[:8]}"
+        r = client.post(
+            f"/api/v1/contact-directories/{directory.id}/contacts",
+            json={
+                "contact": {"name": "Assigned", "phone_number": "+14155550140", "external_id": ext},
+                "agent_id": str(agent.id),
+            },
+        )
+        assert r.status_code == 201
+        body = r.json()
+        assert len(body["created"]) == 1
+        assert body.get("assigned") == 1
+        created_id = uuid.UUID(body["created"][0]["id"])
+
+        rows = (
+            db_session.query(AgentContact)
+            .filter(AgentContact.agent_id == agent.id)
+            .all()
+        )
+        assert {row.contact_id for row in rows} == {created_id}
+
+    def test_create_without_agent_id_does_not_assign(self, db_session):
+        # Creating contacts WITHOUT agent_id must NOT create any agent_contacts.
+        directory = _make_directory(db_session)
+        agent = _make_agent(db_session)
+        client = _router_client(db_session)
+        ext = f"noassign-{uuid.uuid4().hex[:8]}"
+        r = client.post(
+            f"/api/v1/contact-directories/{directory.id}/contacts",
+            json={"contact": {"name": "Unassigned", "phone_number": "+14155550141", "external_id": ext}},
+        )
+        assert r.status_code == 201
+        assert "assigned" not in r.json()
+        assert (
+            db_session.query(AgentContact)
+            .filter(AgentContact.agent_id == agent.id)
+            .count()
+            == 0
+        )
+
+
+# ---------------------------------------------------------------------- IDOR
+
+class TestContactOrgScoping:
+    def test_foreign_org_contact_not_listed_or_fetchable(self, db_session):
+        # A contact belonging to a DIFFERENT org must never surface for ORG_ID.
+        foreign_org = uuid.uuid4()
+        foreign_dir = _make_directory(db_session, org_id=foreign_org)
+        foreign = Contact(
+            organization_id=foreign_org,
+            directory_id=foreign_dir.id,
+            external_id=f"foreign-{uuid.uuid4().hex[:8]}",
+            name="Foreign",
+            phone_number="+14155550111",
+            contact_metadata={},
+            is_active=True,
+        )
+        db_session.add(foreign)
+        db_session.commit()
+
+        # PATCH on a foreign contact id → 404 (org scoped).
+        client = _router_client(db_session)
+        r = client.patch(f"/api/v1/contacts/{foreign.id}", json={"name": "x"})
+        assert r.status_code == 404
+
+    def test_directory_scoping_isolates_contacts(self, db_session):
+        # A contact in directory A must not appear when listing directory B.
+        svc = _svc(db_session)
+        dir_a = _make_directory(db_session)
+        dir_b = _make_directory(db_session)
+        res = svc.create_contacts(dir_a.id, [{"name": "OnlyA", "external_id": f"a-{uuid.uuid4().hex[:6]}"}])
+        contact_id = res["created"][0]["id"]
+
+        listed_b = svc.list_contacts(dir_b.id, page_size=100)
+        assert all(row["id"] != contact_id for row in listed_b["data"])
+
+        listed_a = svc.list_contacts(dir_a.id, page_size=100)
+        assert any(row["id"] == contact_id for row in listed_a["data"])
+
+
+# ----------------------------------------------------------------- CRUD service
+
+class TestContactServiceCrud:
+    def test_create_search_delete(self, db_session):
+        svc = _svc(db_session)
+        directory = _make_directory(db_session)
+        res = svc.create_contacts(
+            directory.id,
+            [{"name": "Zoe", "phone_number": "+14155550123", "external_id": f"z-{uuid.uuid4().hex[:6]}"}],
+        )
+        contact_id = res["created"][0]["id"]
+        found = svc.list_contacts(directory.id, search="Zoe")
+        assert any(row["id"] == contact_id for row in found["data"])
+        svc.delete_contact(uuid.UUID(contact_id))
+        with pytest.raises(HTTPException):
+            svc.get_contact(uuid.UUID(contact_id))
+
+    def test_bulk_delete_directory_scoped(self, db_session):
+        svc = _svc(db_session)
+        directory = _make_directory(db_session)
+        res = svc.create_contacts(
+            directory.id,
+            [
+                {"name": "A", "external_id": f"a-{uuid.uuid4().hex[:6]}"},
+                {"name": "B", "external_id": f"b-{uuid.uuid4().hex[:6]}"},
+            ],
+        )
+        ids = [uuid.UUID(c["id"]) for c in res["created"]]
+        out = svc.bulk_delete_contacts(directory.id, ids)
+        assert out["deleted"] == 2
+
+    def test_missing_directory_404(self, db_session):
+        svc = _svc(db_session)
+        with pytest.raises(HTTPException) as exc:
+            svc.list_contacts(uuid.uuid4())
+        assert exc.value.status_code == 404
+
+
+# ------------------------------------------------ update identity invariant
+
+class TestUpdateContactInvariant:
+    def test_update_cannot_clear_only_identity(self, db_session):
+        # Clearing the name of a phone-less contact would leave an identity-less,
+        # un-dialable row — rejected (400), matching the create-time invariant. The
+        # row must be left untouched.
+        svc = _svc(db_session)
+        directory = _make_directory(db_session)
+        res = svc.create_contacts(
+            directory.id,
+            [{"name": "OnlyName", "external_id": f"only-{uuid.uuid4().hex[:6]}"}],
+        )
+        cid = uuid.UUID(res["created"][0]["id"])
+        with pytest.raises(HTTPException) as exc:
+            svc.update_contact(cid, name="")
+        assert exc.value.status_code == 400
+        # Rejected update leaves the row unchanged.
+        assert svc.get_contact(cid).name == "OnlyName"
+
+    def test_update_clearing_name_keeps_contact_with_phone(self, db_session):
+        # Clearing name is allowed while a phone number remains (identity preserved).
+        svc = _svc(db_session)
+        directory = _make_directory(db_session)
+        res = svc.create_contacts(
+            directory.id,
+            [{"name": "Named", "phone_number": "+14155550170",
+              "external_id": f"keep-{uuid.uuid4().hex[:6]}"}],
+        )
+        cid = uuid.UUID(res["created"][0]["id"])
+        updated = svc.update_contact(cid, name="")
+        assert updated.name is None
+        assert updated.phone_number == "+14155550170"
+
+    def test_api_patch_clearing_only_identity_returns_400(self, db_session):
+        directory = _make_directory(db_session)
+        client = _router_client(db_session)
+        ext = f"api-only-{uuid.uuid4().hex[:8]}"
+        created = client.post(
+            f"/api/v1/contact-directories/{directory.id}/contacts",
+            json={"contact": {"name": "OnlyName", "external_id": ext}},
+        ).json()
+        contact_id = created["created"][0]["id"]
+        r = client.patch(f"/api/v1/contacts/{contact_id}", json={"name": ""})
+        assert r.status_code == 400
+
+
+# ----------------------------------------------------- partial multi-add
+
+class TestPartialMultiAdd:
+    def test_one_invalid_row_partial(self, db_session):
+        # Directory with a schema requiring a mandatory "priority" field.
+        schema = _make_schema_with_mandatory_field(db_session, field_name="priority")
+        directory = _make_directory(db_session, default_schema_id=schema.id)
+        svc = _svc(db_session)
+        res = svc.create_contacts(
+            directory.id,
+            [
+                {"name": "Valid", "external_id": f"v-{uuid.uuid4().hex[:6]}",
+                 "contact_metadata": {"priority": "high"}},
+                {"name": "Invalid", "external_id": f"i-{uuid.uuid4().hex[:6]}",
+                 "contact_metadata": {}},  # missing mandatory field
+            ],
+        )
+        assert len(res["created"]) == 1
+        assert res["created"][0]["name"] == "Valid"
+        assert len(res["failed"]) == 1
+        assert res["failed"][0]["index"] == 1
+        assert res["failed"][0]["errors"]
+
+    def test_empty_rows_rejected(self, db_session):
+        svc = _svc(db_session)
+        directory = _make_directory(db_session)
+        with pytest.raises(HTTPException) as exc:
+            svc.create_contacts(directory.id, [])
+        assert exc.value.status_code == 400
+
+    def test_all_empty_contact_rejected(self, db_session):
+        # A row with neither name nor phone must not create an empty contact.
+        svc = _svc(db_session)
+        directory = _make_directory(db_session)
+        res = svc.create_contacts(
+            directory.id,
+            [{"name": None, "phone_number": None, "contact_metadata": {}}],
+        )
+        assert res["created"] == []
+        assert len(res["failed"]) == 1
+        assert res["failed"][0]["index"] == 0
+        assert res["failed"][0]["errors"]
+
+
+# ----------------------------------------------------- uniqueness (dir, external_id)
+
+class TestUniqueness:
+    def test_same_external_id_upserts_within_directory(self, db_session):
+        svc = _svc(db_session)
+        directory = _make_directory(db_session)
+        ext = f"dup-{uuid.uuid4().hex[:6]}"
+        first = svc.create_contacts(directory.id, [{"name": "First", "external_id": ext}])
+        first_id = first["created"][0]["id"]
+        second = svc.create_contacts(directory.id, [{"name": "Second", "external_id": ext}])
+        # Upsert: same row id, updated name — not a duplicate.
+        assert second["created"][0]["id"] == first_id
+        assert second["created"][0]["name"] == "Second"
+        listed = svc.list_contacts(directory.id, search=ext, page_size=100)
+        assert sum(1 for r in listed["data"] if r["external_id"] == ext) == 1
+
+    def test_same_external_id_distinct_across_directories(self, db_session):
+        svc = _svc(db_session)
+        dir_a = _make_directory(db_session)
+        dir_b = _make_directory(db_session)
+        ext = f"shared-{uuid.uuid4().hex[:6]}"
+        a = svc.create_contacts(dir_a.id, [{"name": "A", "external_id": ext}])
+        b = svc.create_contacts(dir_b.id, [{"name": "B", "external_id": ext}])
+        # Same external_id in two directories → two distinct contacts.
+        assert a["created"][0]["id"] != b["created"][0]["id"]
+
+
+# ------------------------------------------------- list_contact_ids_in_directories
+
+class TestListContactIdsInDirectories:
+    def test_returns_active_ids_across_directories(self, db_session):
+        svc = _svc(db_session)
+        dir_a = _make_directory(db_session)
+        dir_b = _make_directory(db_session)
+        a = svc.create_contacts(dir_a.id, [{"name": "A", "external_id": f"a-{uuid.uuid4().hex[:6]}"}])
+        b = svc.create_contacts(dir_b.id, [{"name": "B", "external_id": f"b-{uuid.uuid4().hex[:6]}"}])
+        ids = svc.list_contact_ids_in_directories([dir_a.id, dir_b.id])
+        ids_str = {str(i) for i in ids}
+        assert a["created"][0]["id"] in ids_str
+        assert b["created"][0]["id"] in ids_str
+
+    def test_empty_input_returns_empty(self, db_session):
+        svc = _svc(db_session)
+        assert svc.list_contact_ids_in_directories([]) == []
+
+    def test_excludes_deleted(self, db_session):
+        svc = _svc(db_session)
+        directory = _make_directory(db_session)
+        res = svc.create_contacts(directory.id, [{"name": "Gone", "external_id": f"g-{uuid.uuid4().hex[:6]}"}])
+        cid = res["created"][0]["id"]
+        svc.delete_contact(uuid.UUID(cid))
+        ids = {str(i) for i in svc.list_contact_ids_in_directories([directory.id])}
+        assert cid not in ids

--- a/test-cases/test_contact_ingestion.py
+++ b/test-cases/test_contact_ingestion.py
@@ -1,0 +1,146 @@
+"""Unit tests for contact ingestion + per-row schedule-time resolution.
+
+Pure logic, no DB:
+- core/services/contact_ingestion/csv_source.py — CSV parsing/normalization.
+- core/services/contact_ingestion/__init__.py — source factory.
+- core/services/outbound_call_service.py::_resolve_contact_when — per-row schedule time.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from core.services.contact_ingestion import get_contact_source
+from core.services.contact_ingestion.base import ParsedContact
+from core.services.contact_ingestion.csv_source import CSVContactSource
+from core.services.outbound_call_service import OutboundCallService as Svc
+
+
+def _parse(raw: str):
+    return list(CSVContactSource().parse(raw.encode("utf-8")))
+
+
+class TestCSVParsing:
+    def test_one_parsed_contact_per_row(self):
+        rows = _parse("name,phone_number\nAlice,+14155550123\nBob,+14155550124\n")
+        assert len(rows) == 2
+        assert rows[0].name == "Alice"
+        assert rows[0].phone_number == "+14155550123"
+
+    def test_headers_are_case_insensitive_and_aliased(self):
+        rows = _parse("Name,Phone\nAlice,+14155550123\n")
+        assert rows[0].name == "Alice"
+        assert rows[0].phone_number == "+14155550123"
+
+    def test_scheduled_at_goes_to_metadata_iso_utc(self):
+        rows = _parse("name,phone,scheduled_at\nA,+14155550123,2026-08-01T15:30:00Z\n")
+        assert rows[0].metadata["scheduled_at"] == "2026-08-01T15:30:00+00:00"
+
+    def test_naive_scheduled_at_assumed_utc(self):
+        rows = _parse("name,phone,call_time\nA,+14155550123,2026-08-01T15:30:00\n")
+        assert rows[0].metadata["scheduled_at"] == "2026-08-01T15:30:00+00:00"
+
+    def test_extra_columns_flow_to_metadata(self):
+        rows = _parse("name,phone,company,notes\nA,+14155550123,Acme,VIP\n")
+        assert rows[0].metadata["company"] == "Acme"
+        assert rows[0].metadata["notes"] == "VIP"
+
+    def test_required_marker_star_stripped_from_headers(self):
+        # Sample templates mark required columns with a trailing ``*`` (e.g. ``city*``);
+        # the marker is stripped so a filled-in template still maps to the real field.
+        rows = _parse("name*,phone_number*,city*\nJohn Doe,+14155550123,SF\n")
+        assert rows[0].name == "John Doe"
+        assert rows[0].phone_number == "+14155550123"
+        assert rows[0].metadata["city"] == "SF"
+
+    def test_external_id_used_when_present(self):
+        rows = _parse("external_id,name,phone\ncust-1,A,+14155550123\n")
+        assert rows[0].external_id == "cust-1"
+
+    def test_external_id_synthesized_from_phone_when_absent(self):
+        rows = _parse("name,phone\nA,+14155550123\n")
+        assert rows[0].external_id == "+14155550123"
+
+    def test_external_id_stable_hash_when_no_phone(self):
+        rows1 = _parse("name,company\nA,Acme\n")
+        rows2 = _parse("name,company\nA,Acme\n")
+        # Same row content → same synthesized id (idempotent re-import).
+        assert rows1[0].external_id == rows2[0].external_id
+        assert rows1[0].external_id.startswith("csv-")
+
+    def test_blank_rows_skipped(self):
+        rows = _parse("name,phone\nA,+14155550123\n,\n")
+        assert len(rows) == 1
+
+    def test_phone_normalization_strips_formatting(self):
+        rows = _parse("name,phone\nA,(415) 555-0123\n")
+        assert rows[0].phone_number == "4155550123"
+
+    def test_phone_00_prefix_becomes_plus(self):
+        rows = _parse("name,phone\nA,0044 20 7946 0000\n")
+        assert rows[0].phone_number == "+442079460000"
+
+    def test_unparseable_scheduled_at_dropped(self):
+        rows = _parse("name,phone,scheduled_at\nA,+14155550123,not-a-date\n")
+        assert "scheduled_at" not in rows[0].metadata
+
+    def test_bom_tolerated(self):
+        rows = list(CSVContactSource().parse("﻿name,phone\nA,+14155550123\n".encode("utf-8")))
+        assert rows[0].name == "A"
+
+
+class _FakeDatasource:
+    """Minimal stand-in for a ``Datasource`` row — the factory only reads ``.type``."""
+
+    def __init__(self, type):
+        self.type = type
+
+
+class TestSourceFactory:
+    def test_csv_default(self):
+        assert isinstance(get_contact_source(_FakeDatasource("csv")), CSVContactSource)
+
+    def test_csv_case_insensitive(self):
+        assert isinstance(get_contact_source(_FakeDatasource("CSV")), CSVContactSource)
+
+    def test_unknown_source_raises(self):
+        with pytest.raises(ValueError):
+            get_contact_source(_FakeDatasource("xlsx"))
+
+
+class _FakeContact:
+    def __init__(self, meta=None):
+        self.id = "c-1"
+        self.contact_metadata = meta or {}
+
+
+class TestResolveContactWhen:
+    def test_metadata_time_wins(self):
+        future = "2999-01-01T00:00:00+00:00"
+        c = _FakeContact({"scheduled_at": future})
+        got = Svc._resolve_contact_when(c, None)
+        assert got == datetime.fromisoformat(future)
+
+    def test_request_time_used_when_no_metadata(self):
+        req = datetime(2999, 6, 1, tzinfo=timezone.utc)
+        got = Svc._resolve_contact_when(_FakeContact(), req)
+        assert got == req
+
+    def test_past_metadata_time_collapses_to_now(self):
+        c = _FakeContact({"scheduled_at": "2000-01-01T00:00:00+00:00"})
+        got = Svc._resolve_contact_when(c, None)
+        assert (datetime.now(timezone.utc) - got).total_seconds() < 5
+
+    def test_none_when_no_time_is_asap(self):
+        got = Svc._resolve_contact_when(_FakeContact(), None)
+        assert (datetime.now(timezone.utc) - got).total_seconds() < 5
+
+    def test_unparseable_metadata_falls_back(self):
+        req = datetime(2999, 6, 1, tzinfo=timezone.utc)
+        c = _FakeContact({"scheduled_at": "garbage"})
+        assert Svc._resolve_contact_when(c, req) == req
+
+
+def test_parsed_contact_defaults():
+    pc = ParsedContact(external_id="x")
+    assert pc.name is None and pc.phone_number is None and pc.metadata == {}

--- a/test-cases/test_outbound_status_machine.py
+++ b/test-cases/test_outbound_status_machine.py
@@ -30,9 +30,14 @@ class TestE164:
 
 
 class TestTwilioStatusMap:
-    def test_inflight_collapses_to_dispatched(self):
-        for s in ("queued", "initiated", "ringing", "in-progress"):
+    def test_preanswer_inflight_collapses_to_dispatched(self):
+        # Pre-answer states collapse to "dispatched"; only the connected/live state
+        # ("in-progress") maps to the distinct "in_progress" status.
+        for s in ("queued", "initiated", "ringing"):
             assert _TWILIO_STATUS_MAP[s] == "dispatched"
+
+    def test_in_progress_maps_to_in_progress(self):
+        assert _TWILIO_STATUS_MAP["in-progress"] == "in_progress"
 
     def test_terminal_outcomes(self):
         assert _TWILIO_STATUS_MAP["completed"] == "completed"
@@ -42,7 +47,17 @@ class TestTwilioStatusMap:
         assert _TWILIO_STATUS_MAP["canceled"] == "canceled"
 
     def test_all_terminals_share_top_rank(self):
-        assert all(_STATUS_RANK[s] == 3 for s in _TERMINAL)
+        # Terminals sit above in_progress: scheduled<processing<dispatched<in_progress<terminal.
+        assert all(_STATUS_RANK[s] == 4 for s in _TERMINAL)
+
+    def test_rank_ordering(self):
+        assert (
+            _STATUS_RANK["scheduled"]
+            < _STATUS_RANK["processing"]
+            < _STATUS_RANK["dispatched"]
+            < _STATUS_RANK["in_progress"]
+            < _STATUS_RANK["completed"]
+        )
 
 
 class _FakeSc:
@@ -78,4 +93,24 @@ class TestRankGuard:
         svc = self._svc()
         sc = _FakeSc("completed")
         assert svc._apply_status(sc, "completed") is False
+        assert sc.status == "completed"
+
+    def test_in_progress_advances_from_dispatched(self):
+        svc = self._svc()
+        sc = _FakeSc("dispatched")
+        assert svc._apply_status(sc, "in_progress") is True
+        assert sc.status == "in_progress"
+
+    def test_terminal_advances_over_in_progress(self):
+        svc = self._svc()
+        sc = _FakeSc("in_progress")
+        assert svc._apply_status(sc, "completed") is True
+        assert sc.status == "completed"
+
+    def test_in_progress_cannot_regress_a_terminal(self):
+        # A connected call that already completed must not drop back to in_progress
+        # if a late "in-progress" callback arrives.
+        svc = self._svc()
+        sc = _FakeSc("completed")
+        assert svc._apply_status(sc, "in_progress") is False
         assert sc.status == "completed"


### PR DESCRIPTION
…wiring (#816) (#817)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage