### PR TITLE
feat(readiness): agent readiness run-history browsing + force re-run …

### DIFF
--- a/core/api/v1/agent_readiness.py
+++ b/core/api/v1/agent_readiness.py
@@ -25,6 +25,7 @@ from core.services.readiness.schemas import (
     Category,
     Depth,
     ReadinessReport,
+    ReadinessRunList,
     ReadinessSummary,
 )
 from shared.config import settings
@@ -47,6 +48,11 @@ class ReadinessRequest(BaseModel):
     # as "no categories" — every deep check is skipped, effectively equivalent
     # to a shallow run.
     categories: Optional[List[Category]] = None
+    # When true, bypass the read-through snapshot/coalesce caches and always run
+    # + persist a fresh event. Set by the "Run deep test" button so each explicit
+    # run appears as a new entry in the run-history list. Ignored for targeted
+    # deep (categories) which already bypasses caches.
+    force: bool = False
 
 
 def _get_service(claims: JWTClaims, db: Session) -> ReadinessService:
@@ -76,6 +82,7 @@ async def check_readiness(
         config_id=body.config_id,
         trigger=body.trigger or "api",
         deep_categories=set(body.categories) if body.categories is not None else None,
+        force=body.force,
     )
 
 
@@ -92,3 +99,31 @@ async def readiness_summary(
     return await svc.summary(
         agent_id, config_id=config_id, trigger=trigger or "list_page"
     )
+
+
+@router.get("/{agent_id}/readiness/runs", response_model=ReadinessRunList)
+async def list_readiness_runs(
+    agent_id: str,
+    limit: int = Query(20, ge=1, le=100, description="Max runs to return"),
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+) -> ReadinessRunList:
+    """List past deep readiness runs (newest first) for the run-history dropdown.
+
+    Metadata only — no per-check detail. Fetch a single run's full report via
+    the ``/runs/{run_number}`` route below.
+    """
+    svc = _get_service(claims, db)
+    return svc.list_runs(agent_id, limit=limit)
+
+
+@router.get("/{agent_id}/readiness/runs/{run_number}", response_model=ReadinessReport)
+async def get_readiness_run(
+    agent_id: str,
+    run_number: int,
+    claims: JWTClaims = Depends(require_org_member),
+    db: Session = Depends(get_db),
+) -> ReadinessReport:
+    """Return the full stored report (with checks) for one past run."""
+    svc = _get_service(claims, db)
+    return svc.get_run(agent_id, run_number)

--- a/core/api/v1/agents.py
+++ b/core/api/v1/agents.py
@@ -14,6 +14,7 @@ from core.models.agent import Agent
 from core.models.channel import Channel
 from core.models.phone_number import PhoneNumber
 from core.services.agent_service import AgentService
+from core.services.readiness import ReadinessService
 from core.utils.faceted_query import apply_filters, apply_sort, build_facets, distinct_values
 from core.utils.list_params import resolve_sort
 from shared.config import settings
@@ -234,7 +235,11 @@ def _phone_numbers_for(db: Session, org_id: UUID, agent_ids: list[UUID]) -> dict
     return grouped
 
 
-def _serialize_agent(agent: Agent, phone_map: dict[UUID, list[dict]]) -> dict:
+def _serialize_agent(
+    agent: Agent,
+    phone_map: dict[UUID, list[dict]],
+    readiness_map: dict[UUID, dict],
+) -> dict:
     return {
         "id": str(agent.id),
         "uuid": str(agent.id),
@@ -243,6 +248,8 @@ def _serialize_agent(agent: Agent, phone_map: dict[UUID, list[dict]]) -> dict:
         "agent_type": agent.agent_type,
         "is_active": agent.is_active,
         "phone_number": phone_map.get(agent.id, []),
+        # Last-known readiness for the list badge; None until a run is stored.
+        "readiness": readiness_map.get(agent.id),
         "created_at": agent.created_at.timestamp() if agent.created_at else None,
         "updated_at": agent.updated_at.timestamp() if agent.updated_at else None,
     }
@@ -276,9 +283,11 @@ def list_agents_for_org(db: Session, org_id: UUID, body: dict) -> dict:
 
     offset = (page - 1) * page_size
     items = query.offset(offset).limit(page_size).all()
-    phone_map = _phone_numbers_for(db, org_id, [a.id for a in items])
+    agent_ids = [a.id for a in items]
+    phone_map = _phone_numbers_for(db, org_id, agent_ids)
+    readiness_map = ReadinessService(db, org_id=org_id).latest_for_agents(agent_ids)
     return {
-        "items": [_serialize_agent(a, phone_map) for a in items],
+        "items": [_serialize_agent(a, phone_map, readiness_map) for a in items],
         "total": total,
         "page": page,
         "page_size": page_size,
@@ -512,8 +521,6 @@ async def switch_active_version(
     # Publish gate: verify the target version is safe to promote before we
     # flip the FK. Raises HTTPException(400) on blockers or unforced warnings,
     # which happens before any DB write so the transaction stays clean.
-    from core.services.readiness import ReadinessService
-
     readiness = ReadinessService(
         db,
         user_id=UUID(claims.user_id) if claims.user_id else None,

--- a/core/services/readiness/__init__.py
+++ b/core/services/readiness/__init__.py
@@ -14,7 +14,16 @@ from core.services.readiness.readiness_service import ReadinessService
 from core.services.readiness.schemas import (
     Depth,
     ReadinessReport,
+    ReadinessRunList,
+    ReadinessRunListItem,
     ReadinessSummary,
 )
 
-__all__ = ["ReadinessService", "Depth", "ReadinessReport", "ReadinessSummary"]
+__all__ = [
+    "ReadinessService",
+    "Depth",
+    "ReadinessReport",
+    "ReadinessRunList",
+    "ReadinessRunListItem",
+    "ReadinessSummary",
+]

--- a/core/services/readiness/readiness_service.py
+++ b/core/services/readiness/readiness_service.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import time
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional, Set
+from typing import Dict, List, Optional, Set, Union
 from uuid import UUID
 
 from fastapi import HTTPException, status
@@ -29,6 +29,7 @@ from loguru import logger
 from sqlalchemy import func, select
 
 from core.models.agent import Agent
+from core.models.agent_readiness_event import AgentReadinessEvent
 from core.models.agent_readiness_snapshot import AgentReadinessSnapshot
 from core.models.phone_number import PhoneNumber
 from core.services.base import BaseService
@@ -47,6 +48,8 @@ from core.services.readiness.schemas import (
     Depth,
     OverallStatus,
     ReadinessReport,
+    ReadinessRunList,
+    ReadinessRunListItem,
     ReadinessSummary,
 )
 
@@ -87,6 +90,7 @@ class ReadinessService(BaseService):
         *,
         trigger: str = TRIGGER_API,
         deep_categories: Optional[Set[Category]] = None,
+        force: bool = False,
     ) -> ReadinessReport:
         """Run a readiness check for one agent + (optionally explicit) config.
 
@@ -104,6 +108,13 @@ class ReadinessService(BaseService):
         publish gate. It also skips the rate limiter / coalesce cache because
         each targeted run has a different "shape" — those safeguards protect
         full-deep runs, not user-driven save-time probes.
+
+        ``force`` is for an **explicit, user-initiated run** (the "Run deep
+        test" button). It skips the read-through snapshot fast-path AND the
+        in-memory coalesce cache so the run actually executes and appends a
+        fresh ``agent_readiness_events`` row — otherwise a repeat deep test on
+        an unchanged agent returns the stored snapshot and the run-history list
+        never grows. The rate limiter still applies (1/min).
         """
         agent = self._require_agent(agent_id)
         stamp, resolved_config = self._compute_stamp(agent)
@@ -115,9 +126,12 @@ class ReadinessService(BaseService):
                 agent, config_id, Depth.DEEP, deep_categories=deep_categories
             )
 
-        fresh = self._read_fresh_snapshot(agent.id, effective_config_id, depth, stamp)
-        if fresh is not None:
-            return fresh
+        # A forced run skips the read-through fast-path so it always executes
+        # and records a new event (see docstring).
+        if not force:
+            fresh = self._read_fresh_snapshot(agent.id, effective_config_id, depth, stamp)
+            if fresh is not None:
+                return fresh
 
         if depth == Depth.SHALLOW:
             return await self._run_and_persist(
@@ -152,6 +166,11 @@ class ReadinessService(BaseService):
                 dependency_stamp=stamp,
             )
 
+        # A forced deep run bypasses the in-memory coalesce cache too, so it
+        # truly re-probes and appends a new event instead of returning a report
+        # cached from a run in the last 300s. Still rate-limited via _compute.
+        if force:
+            return await _compute()
         return await _deep_cache.get_or_compute(cache_key, _compute)
 
     async def summary(
@@ -166,6 +185,133 @@ class ReadinessService(BaseService):
             agent_id, Depth.SHALLOW, config_id, trigger=trigger
         )
         return report.to_summary()
+
+    def latest_for_agents(self, agent_ids: List[UUID]) -> Dict[UUID, Dict]:
+        """Batch-fetch the latest readiness snapshot per agent for the list badge.
+
+        Read-only: returns the most recently computed stored snapshot (any
+        config / depth) verbatim — no recompute, no dependency-stamp
+        re-validation. Powers the agent-list badge in a single query instead of
+        one live readiness call per row (the old N+1); the editor drawer still
+        recomputes accurately when opened. An agent with no stored run yet is
+        simply absent from the map (badge renders "unavailable").
+
+        Org-scoped by ``self.org_id``. Projects only the badge columns (skips the
+        heavy ``checks`` blob) and reuses ``_counts_from_mapping`` so the count
+        fallback set stays single-sourced with the row mappers.
+
+        Returns ``{agent_id: {overall_status, blocker_count, warning_count,
+        info_count, run_number, computed_at}}``.
+        """
+        if not agent_ids:
+            return {}
+        rows = (
+            self.db.query(
+                AgentReadinessSnapshot.agent_id,
+                AgentReadinessSnapshot.overall_status,
+                AgentReadinessSnapshot.counts,
+                AgentReadinessSnapshot.run_number,
+                AgentReadinessSnapshot.computed_at,
+            )
+            .filter(
+                AgentReadinessSnapshot.organization_id == self.org_id,
+                AgentReadinessSnapshot.agent_id.in_(agent_ids),
+            )
+            .order_by(AgentReadinessSnapshot.computed_at.desc())
+            .all()
+        )
+        latest: Dict[UUID, Dict] = {}
+        for agent_id, overall_status, counts, run_number, computed_at in rows:
+            # Rows arrive newest-first; keep only the first (latest) per agent.
+            if agent_id in latest:
+                continue
+            tallies = _counts_from_mapping(counts)
+            latest[agent_id] = {
+                "overall_status": overall_status,
+                "blocker_count": tallies["blockers"],
+                "warning_count": tallies["warnings"],
+                "info_count": tallies["info"],
+                "run_number": run_number,
+                "computed_at": computed_at.isoformat() if computed_at else None,
+            }
+        return latest
+
+    # Cap the history scan so a pathological agent can't force a huge read.
+    _MAX_RUNS_LIMIT = 100
+
+    def list_runs(self, agent_id: str, *, limit: int = 20) -> ReadinessRunList:
+        """List past **deep** readiness runs for one agent, newest first.
+
+        Only deep runs (Test agent + publish gate) are surfaced — background
+        shallow snapshots (editor loads, list-page impressions) are noise the
+        user never asked to run and would swamp the dropdown. History spans all
+        configs/versions of the agent; the UI badges cross-version rows.
+
+        Metadata only — the heavy ``checks`` list is fetched per-run via
+        ``get_run``. Org-scoped via ``_require_agent`` (404 for other orgs).
+        """
+        agent = self._require_agent(agent_id)
+        capped = max(1, min(limit, self._MAX_RUNS_LIMIT))
+        rows = (
+            self.db.query(AgentReadinessEvent)
+            .filter(
+                AgentReadinessEvent.organization_id == self.org_id,
+                AgentReadinessEvent.agent_id == agent.id,
+                AgentReadinessEvent.depth == Depth.DEEP.value,
+            )
+            .order_by(AgentReadinessEvent.run_number.desc())
+            .limit(capped)
+            .all()
+        )
+        items: List[ReadinessRunListItem] = []
+        for row in rows:
+            try:
+                items.append(_event_to_list_item(row))
+            except (ValueError, KeyError):
+                # One legacy/partial row with an out-of-enum status/counts must
+                # not 500 the whole history list — skip it (with a traceback).
+                logger.exception(
+                    "[readiness] skipping unmappable run event run_number={}",
+                    getattr(row, "run_number", None),
+                )
+        return ReadinessRunList(items=items)
+
+    def get_run(self, agent_id: str, run_number: int) -> ReadinessReport:
+        """Return the full stored report for one past run.
+
+        Reuses ``_row_to_report`` — an event row carries the same
+        ``ReadinessRowMixin`` columns as a snapshot, so the mapping is
+        identical. Org-scoped; raises 404 for an unknown agent or run.
+        """
+        agent = self._require_agent(agent_id)
+        row = (
+            self.db.query(AgentReadinessEvent)
+            .filter(
+                AgentReadinessEvent.organization_id == self.org_id,
+                AgentReadinessEvent.agent_id == agent.id,
+                # Deep-only, mirroring ``list_runs`` — a shallow run_number that
+                # never appears in the dropdown must 404, not return a report.
+                AgentReadinessEvent.depth == Depth.DEEP.value,
+                AgentReadinessEvent.run_number == run_number,
+            )
+            # Defensive: run_number is monotonic + concurrency-guarded so it's
+            # effectively unique per agent, but there's no DB uniqueness
+            # constraint — take the most recent row if two ever collide.
+            .order_by(AgentReadinessEvent.computed_at.desc())
+            .first()
+        )
+        if row is None:
+            raise HTTPException(status_code=404, detail="Readiness run not found")
+        try:
+            return _row_to_report(row)
+        except (ValueError, KeyError):
+            # A stored row with an out-of-enum value can't be rendered — treat it
+            # as unavailable rather than 500-ing (mirrors list_runs' skip). Log
+            # the traceback so the corrupt row stays diagnosable.
+            logger.exception(
+                "[readiness] run {} unmappable for agent {}", run_number, agent_id
+            )
+            raise HTTPException(status_code=404, detail="Readiness run not found")
 
     async def gate_publish(
         self,
@@ -326,30 +472,41 @@ class ReadinessService(BaseService):
         stamp: Optional[str],
     ) -> Optional[ReadinessReport]:
         """Return a stored snapshot iff its ``dependency_stamp`` matches the
-        currently-live stamp. Missing stamp (either side) always misses."""
+        currently-live stamp. Missing stamp (either side) always misses.
+
+        A **SHALLOW** request also accepts a **DEEP** snapshot: a deep run is a
+        superset of shallow (all shallow checks + live provider probes), so for
+        an unchanged config the most RECENT run governs the badge regardless of
+        depth. Without this, reloading the page fires a shallow summary read
+        that returns the stale shallow snapshot and resets the badge to "ready",
+        discarding a "Run deep test" result (e.g. a live-probe blocker) the user
+        just saw. A **DEEP** request (publish gate) still requires an actual deep
+        snapshot. When both depths match the stamp, the newest by ``computed_at``
+        wins — so a later shallow "Refresh" correctly supersedes an earlier deep
+        run, and vice-versa."""
         if not stamp:
             return None
-        q = (
-            self.db.query(AgentReadinessSnapshot)
-            .filter(
-                AgentReadinessSnapshot.organization_id == self.org_id,
-                AgentReadinessSnapshot.agent_id == agent_id,
-                AgentReadinessSnapshot.depth == depth.value,
-                AgentReadinessSnapshot.dependency_stamp == stamp,
-            )
+        q = self.db.query(AgentReadinessSnapshot).filter(
+            AgentReadinessSnapshot.organization_id == self.org_id,
+            AgentReadinessSnapshot.agent_id == agent_id,
+            AgentReadinessSnapshot.dependency_stamp == stamp,
         )
+        # Deep reads must not be satisfied by a shallow snapshot; shallow reads
+        # accept either depth (see docstring).
+        if depth == Depth.DEEP:
+            q = q.filter(AgentReadinessSnapshot.depth == Depth.DEEP.value)
         # SQLAlchemy translates ``== None`` to ``IS NULL`` — needed so a
         # brand-new-agent snapshot (config_id NULL) can still fast-path.
         if config_id is None:
             q = q.filter(AgentReadinessSnapshot.config_id.is_(None))
         else:
             q = q.filter(AgentReadinessSnapshot.config_id == config_id)
-        row = q.first()
+        row = q.order_by(AgentReadinessSnapshot.computed_at.desc()).first()
         if row is None:
             return None
         if depth == Depth.DEEP and _deep_snapshot_expired(row):
             return None
-        return _snapshot_to_report(row)
+        return _row_to_report(row)
 
     async def _run_and_persist(
         self,
@@ -398,8 +555,6 @@ class ReadinessService(BaseService):
         readiness runs for the same agent, so ``MAX + 1`` is race-free in
         practice. Falls back to 1 for the very first run.
         """
-        from core.models.agent_readiness_event import AgentReadinessEvent
-
         current = self.db.execute(
             select(func.max(AgentReadinessEvent.run_number))
             .where(AgentReadinessEvent.agent_id == agent_id)
@@ -436,30 +591,73 @@ def _deep_snapshot_expired(row: AgentReadinessSnapshot) -> bool:
     return age > timedelta(seconds=_DEEP_SNAPSHOT_TTL_SECONDS)
 
 
-def _snapshot_to_report(row: AgentReadinessSnapshot) -> ReadinessReport:
-    """Turn a stored snapshot row back into a ``ReadinessReport``. Both JSONB
+def _counts_from_mapping(stored: Optional[Dict]) -> Dict[str, int]:
+    """Extract the five severity/status tallies from a raw ``counts`` mapping,
+    defaulting any missing key to 0 so a row predating a new count key still
+    renders. The single source of truth for the fallback set — used by the row
+    mappers (via ``_counts_from_row``) and by the batch list-badge lookup
+    (``latest_for_agents``), which projects the ``counts`` column directly."""
+    stored = stored or {}
+    return {
+        "blockers": int(stored.get("blockers", 0)),
+        "warnings": int(stored.get("warnings", 0)),
+        "info": int(stored.get("info", 0)),
+        "passed": int(stored.get("passed", 0)),
+        "skipped": int(stored.get("skipped", 0)),
+    }
+
+
+def _counts_from_row(row: Union[AgentReadinessSnapshot, AgentReadinessEvent]) -> Dict[str, int]:
+    """Tallies for a full row — delegates to ``_counts_from_mapping``."""
+    return _counts_from_mapping(row.counts)
+
+
+def _row_to_report(row: Union[AgentReadinessSnapshot, AgentReadinessEvent]) -> ReadinessReport:
+    """Turn a stored readiness row back into a ``ReadinessReport``.
+
+    Accepts either an ``AgentReadinessSnapshot`` (latest state) or an
+    ``AgentReadinessEvent`` (history) — both carry the identical
+    ``ReadinessRowMixin`` columns, so one mapper serves both. Both JSONB
     columns (``counts`` and ``checks``) already carry the exact wire shape so
     there's no field-by-field mapping — just hand them to the Pydantic
-    models. Any missing count key falls back to 0 so an older snapshot
-    predating a new severity level still renders."""
+    models. Any missing count key falls back to 0 so an older row predating a
+    new severity level still renders."""
     checks: List[CheckResult] = [
         CheckResult.model_validate(c) for c in (row.checks or [])
     ]
-    stored_counts = row.counts or {}
     return ReadinessReport(
         agent_id=str(row.agent_id),
         config_id=str(row.config_id) if row.config_id else None,
         depth=Depth(row.depth),
         overall_status=OverallStatus(row.overall_status),
-        summary={
-            "blockers": int(stored_counts.get("blockers", 0)),
-            "warnings": int(stored_counts.get("warnings", 0)),
-            "info": int(stored_counts.get("info", 0)),
-            "passed": int(stored_counts.get("passed", 0)),
-            "skipped": int(stored_counts.get("skipped", 0)),
-        },
+        summary=_counts_from_row(row),
         checks=checks,
         generated_at=row.computed_at.isoformat() if row.computed_at else "",
         started_at=row.started_at.isoformat() if row.started_at else None,
         run_number=row.run_number,
+    )
+
+
+def _event_to_list_item(row: AgentReadinessEvent) -> ReadinessRunListItem:
+    """Flatten a history event row into a lightweight dropdown item.
+
+    Reuses ``_counts_from_row`` for the same defensive tallies as
+    ``_row_to_report`` but drops the heavy ``checks`` list — the dropdown only
+    needs summary tallies and provenance; full checks load lazily via
+    ``get_run``."""
+    counts = _counts_from_row(row)
+    return ReadinessRunListItem(
+        run_number=row.run_number,
+        depth=Depth(row.depth),
+        overall_status=OverallStatus(row.overall_status),
+        config_id=str(row.config_id) if row.config_id else None,
+        trigger=row.trigger,
+        blocker_count=counts["blockers"],
+        warning_count=counts["warnings"],
+        info_count=counts["info"],
+        passed_count=counts["passed"],
+        skipped_count=counts["skipped"],
+        started_at=row.started_at.isoformat() if row.started_at else None,
+        computed_at=row.computed_at.isoformat() if row.computed_at else "",
+        duration_ms=row.duration_ms,
     )

--- a/core/services/readiness/schemas.py
+++ b/core/services/readiness/schemas.py
@@ -100,6 +100,36 @@ class ReadinessSummary(BaseModel):
     run_number: Optional[int] = None
 
 
+class ReadinessRunListItem(BaseModel):
+    """One row in the readiness run-history dropdown.
+
+    Metadata only — deliberately omits the heavy ``checks`` blob. The dropdown
+    renders off these fields; selecting a row fetches the full report (with
+    ``checks``) via ``GET /agent/{id}/readiness/runs/{run_number}``.
+    """
+
+    run_number: int
+    depth: Depth
+    overall_status: OverallStatus
+    config_id: Optional[str] = None
+    trigger: str
+    blocker_count: int = 0
+    warning_count: int = 0
+    info_count: int = 0
+    passed_count: int = 0
+    skipped_count: int = 0
+    started_at: Optional[str] = None
+    # Completion timestamp (ISO-8601) — the dropdown's primary label.
+    computed_at: str
+    duration_ms: Optional[int] = None
+
+
+class ReadinessRunList(BaseModel):
+    """Response for ``GET /agent/{id}/readiness/runs`` — newest run first."""
+
+    items: List[ReadinessRunListItem] = Field(default_factory=list)
+
+
 class ReadinessReport(BaseModel):
     """Full report returned by ``POST /agent/{id}/readiness``.
 

--- a/docs/code-review/README.md
+++ b/docs/code-review/README.md
@@ -55,6 +55,8 @@ spend review cycles on style a tool can fix.**
 - [ ] Single responsibility — a function/component/service does one thing.
 - [ ] Public surface is minimal — export only what callers need.
 - [ ] Names say what, not how; no misleading names.
+- [ ] No magic constants or pure helper functions inlined in a component/module — they
+      live in a dedicated constants file and a helper/util file (see DRY doctrine).
 
 **Tests**
 - [ ] New behavior has tests. Bug fixes have a regression test that fails without the fix.
@@ -99,6 +101,13 @@ Reuse is a review priority in this repo, but **premature abstraction is a defect
   - BE: shared logic → a service extending `BaseService`; shared helpers → `core/utils`;
     shared schemas → Pydantic models reused across routers.
 - **A helper with more than ~3 config flags is a smell.** Split it.
+- **Don't inline constants or pure helper functions in a component.** Magic strings/numbers
+  and stateless helpers (label maps, formatters, sentinel values, `countLabel`-style
+  utilities) belong in a **dedicated constants file** and a **helper/util file** — not at the
+  top or bottom of the component that first used them. Co-locate feature-specific ones beside
+  the feature (e.g. `readinessConstants.ts` / `readinessHelpers.ts`); promote to `@/utils`
+  (FE) or `core/utils` (BE) once a second feature needs them (rule of three). This keeps
+  components JSX-only and the logic reusable + unit-testable.
 
 ## Author's pre-flight (run before requesting review)
 

--- a/ee/api/v1/agent_readiness.py
+++ b/ee/api/v1/agent_readiness.py
@@ -15,7 +15,11 @@ from sqlalchemy.orm import Session
 from core.api.v1.agent_readiness import ReadinessRequest
 from core.database.session import get_db
 from core.services.readiness import ReadinessService
-from core.services.readiness.schemas import ReadinessReport, ReadinessSummary
+from core.services.readiness.schemas import (
+    ReadinessReport,
+    ReadinessRunList,
+    ReadinessSummary,
+)
 from ee.middleware.auth import EEJWTClaims, require_ee_org_member
 
 router = APIRouter()
@@ -41,6 +45,7 @@ async def check_readiness(
         config_id=body.config_id,
         trigger=body.trigger or "api",
         deep_categories=set(body.categories) if body.categories is not None else None,
+        force=body.force,
     )
 
 
@@ -56,3 +61,25 @@ async def readiness_summary(
     return await svc.summary(
         agent_id, config_id=config_id, trigger=trigger or "list_page"
     )
+
+
+@router.get("/{agent_id}/readiness/runs", response_model=ReadinessRunList)
+async def list_readiness_runs(
+    agent_id: str,
+    limit: int = Query(20, ge=1, le=100, description="Max runs to return"),
+    claims: EEJWTClaims = Depends(require_ee_org_member),
+    db: Session = Depends(get_db),
+) -> ReadinessRunList:
+    svc = _get_service(claims, db)
+    return svc.list_runs(agent_id, limit=limit)
+
+
+@router.get("/{agent_id}/readiness/runs/{run_number}", response_model=ReadinessReport)
+async def get_readiness_run(
+    agent_id: str,
+    run_number: int,
+    claims: EEJWTClaims = Depends(require_ee_org_member),
+    db: Session = Depends(get_db),
+) -> ReadinessReport:
+    svc = _get_service(claims, db)
+    return svc.get_run(agent_id, run_number)

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -307,6 +307,7 @@ Applies **solid-checklist.md** in full — SRP, OCP, LSP, ISP, DIP, code smells,
 - **This project**: Service functions in `src/services/` must not import Jotai atoms directly (DIP). Atoms call services; services do not know about atoms.
 - Components must not call `src/services/` directly — all side effects go through Jotai write atoms; all HTTP goes through the service / `src/lib/api` layer (never raw `fetch`/`axios` in a component).
 - `agentFormUtils.ts` owns `AgentFormState` shape, `defaultFormState`, and serialisation — do not duplicate this logic in components.
+- **No inlined constants or pure helpers in a component.** Magic strings/values go in a co-located constants file (e.g. `readinessConstants.ts`); stateless helpers/formatters (label maps, `countLabel`-style utilities) go in a helper file (e.g. `readinessHelpers.ts`) or `@/utils` once a second feature needs them. Keeps components JSX-only and the logic reusable + unit-testable.
 
 #### 5. Security
 

--- a/frontend/src/atoms/ReadinessAtom.tsx
+++ b/frontend/src/atoms/ReadinessAtom.tsx
@@ -1,10 +1,16 @@
 import { atom } from 'jotai';
 
-import { getAgentReadiness, getAgentReadinessSummary } from '@/services/readinessService';
+import {
+  getAgentReadiness,
+  getAgentReadinessRun,
+  getAgentReadinessSummary,
+  listAgentReadinessRuns,
+} from '@/services/readinessService';
 import type {
   ReadinessCategory,
   ReadinessDepth,
   ReadinessReport,
+  ReadinessRunList,
   ReadinessSummary,
   ReadinessTrigger,
 } from '@/types/readiness';
@@ -30,9 +36,18 @@ export const fetchAgentReadinessAtom = atom(
       /** Targeted-deep filter — only probes these categories live when `depth`
        * is `'deep'`. Ignored when `depth` is `'shallow'`. */
       categories?: ReadinessCategory[];
+      /** Force a fresh run + persisted event (bypasses backend caches). */
+      force?: boolean;
     },
   ): Promise<ReadinessReport> =>
-    getAgentReadiness(args.agentId, args.depth, args.configId, args.trigger, args.categories),
+    getAgentReadiness(
+      args.agentId,
+      args.depth,
+      args.configId,
+      args.trigger,
+      args.categories,
+      args.force,
+    ),
 );
 
 export const fetchAgentReadinessSummaryAtom = atom(
@@ -47,4 +62,16 @@ export const fetchAgentReadinessSummaryAtom = atom(
     },
   ): Promise<ReadinessSummary> =>
     getAgentReadinessSummary(args.agentId, args.configId, args.trigger),
+);
+
+export const fetchAgentReadinessRunsAtom = atom(
+  null,
+  async (_get, _set, args: { agentId: string; limit?: number }): Promise<ReadinessRunList> =>
+    listAgentReadinessRuns(args.agentId, args.limit),
+);
+
+export const fetchAgentReadinessRunAtom = atom(
+  null,
+  async (_get, _set, args: { agentId: string; runNumber: number }): Promise<ReadinessReport> =>
+    getAgentReadinessRun(args.agentId, args.runNumber),
 );

--- a/frontend/src/components/agents/AgentEditorShell.tsx
+++ b/frontend/src/components/agents/AgentEditorShell.tsx
@@ -137,6 +137,15 @@ export default function AgentEditorShell({ agentType, agentId, children }: Agent
   /** Bump to force the summary effect to re-run (after save / publish / etc.). */
   const [readinessRefreshKey, setReadinessRefreshKey] = useState(0);
   const bumpReadiness = useCallback(() => setReadinessRefreshKey((k) => k + 1), []);
+  /** Keep the header pill (driven by `readinessSummary`) in sync whenever the
+   * drawer lands a fresh LIVE report (Refresh / Run deep test). Without this the
+   * drawer can show "3 blockers" while the header still reads "Ready". The
+   * drawer never calls this for historical run views, so browsing history can't
+   * corrupt the badge. Stable identity so the drawer's effects don't re-run. */
+  const handleReadinessReportChange = useCallback((report: ReadinessReport | null) => {
+    setReadinessReport(report);
+    if (report) setReadinessSummary(reportToSummary(report));
+  }, []);
   /** Set true immediately after a targeted-deep save lands so the shallow
    * readiness effect can skip its next run — otherwise a slower shallow
    * response overwrites the fresh deep summary and the badge silently drops
@@ -1061,7 +1070,7 @@ export default function AgentEditorShell({ agentType, agentId, children }: Agent
                 configId={detail?.config?.id ?? null}
                 trigger="editor_load"
                 initialReport={readinessReport}
-                onReportChange={setReadinessReport}
+                onReportChange={handleReadinessReportChange}
               />
             )}
 

--- a/frontend/src/components/agents/AgentListPage.tsx
+++ b/frontend/src/components/agents/AgentListPage.tsx
@@ -114,7 +114,11 @@ const AgentListPage: React.FC = () => {
       key: 'readiness',
       title: 'Readiness',
       render: (_value, record) => (
-        <AgentReadinessCell agentId={record.id} onOpen={(agentId) => setReadinessTarget(agentId)} />
+        <AgentReadinessCell
+          agentId={record.id}
+          readiness={record.readiness}
+          onOpen={(agentId) => setReadinessTarget(agentId)}
+        />
       ),
     },
     {

--- a/frontend/src/components/agents/AgentSaveActions.tsx
+++ b/frontend/src/components/agents/AgentSaveActions.tsx
@@ -115,7 +115,7 @@ export default function AgentSaveActions({
         <DropdownMenuContent align="end" className="w-56">
           <DropdownMenuItem onSelect={() => onAction('test')}>
             <Beaker className={MENU_ICON_CLASS} />
-            Test
+            Readiness Check
           </DropdownMenuItem>
           <DropdownMenuItem disabled={busy} onSelect={() => onAction('create-version')}>
             {creatingVersion ? (

--- a/frontend/src/components/agents/readiness/AgentReadinessCell.tsx
+++ b/frontend/src/components/agents/readiness/AgentReadinessCell.tsx
@@ -1,66 +1,45 @@
 'use client';
 
-import { useAtom } from 'jotai';
-import { useEffect, useState } from 'react';
-
-import { fetchAgentReadinessSummaryAtom } from '@/atoms/ReadinessAtom';
-import type { ReadinessSummary } from '@/types/readiness';
+import type { AgentListReadiness } from '@/types/agent';
 
 import ReadinessBadge from './ReadinessBadge';
 
 interface AgentReadinessCellProps {
   agentId: string;
-  /** Click handler — receives the summary in case the parent wants to open a
+  /** Last-known readiness for this row, supplied by the list API. Null when the
+   * agent has no stored run yet — the badge then shows "unavailable" until the
+   * user opens the drawer (which computes a fresh check). */
+  readiness: AgentListReadiness | null;
+  /** Click handler — receives the row's readiness so the parent can open a
    * drawer scoped to this agent. */
-  onOpen?: (agentId: string, summary: ReadinessSummary | null) => void;
+  onOpen?: (agentId: string, readiness: AgentListReadiness | null) => void;
 }
 
 /**
- * One row in the agent list table. Fetches its own Shallow summary lazily so
- * the table can render immediately and populate rows as their responses come
- * in — avoiding a blocking bulk fetch. Non-critical UI: any failure just
- * shows an "unavailable" pill, never a toast.
+ * One row in the agent list table. Renders the readiness badge straight from
+ * the list-API payload — no per-row fetch. This replaces the old N+1 where
+ * every row fired its own `/readiness/summary` request. The value is
+ * last-known state (read from the stored snapshot, not recomputed); the editor
+ * drawer refreshes it live when opened.
  */
-export default function AgentReadinessCell({ agentId, onOpen }: AgentReadinessCellProps) {
-  const [, fetchSummary] = useAtom(fetchAgentReadinessSummaryAtom);
-  const [summary, setSummary] = useState<ReadinessSummary | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    setError(false);
-    (async () => {
-      try {
-        const next = await fetchSummary({ agentId, trigger: 'list_page' });
-        if (!cancelled) setSummary(next);
-      } catch {
-        if (!cancelled) setError(true);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [agentId, fetchSummary]);
-
-  const status = loading && !summary ? 'loading' : error ? 'error' : summary?.overall_status;
-
+export default function AgentReadinessCell({
+  agentId,
+  readiness,
+  onOpen,
+}: AgentReadinessCellProps) {
   return (
     <ReadinessBadge
-      status={status ?? 'error'}
-      blockerCount={summary?.blocker_count ?? 0}
-      warningCount={summary?.warning_count ?? 0}
+      status={readiness?.overall_status ?? 'error'}
+      blockerCount={readiness?.blocker_count ?? 0}
+      warningCount={readiness?.warning_count ?? 0}
       size="sm"
       onClick={
         onOpen
           ? (e) => {
-              // Stop propagation so the surrounding row-click (which opens
-              // the editor) doesn't fire in addition to the drawer.
+              // Stop propagation so the surrounding row-click (which opens the
+              // editor) doesn't fire in addition to the drawer.
               e.stopPropagation();
-              onOpen(agentId, summary);
+              onOpen(agentId, readiness);
             }
           : undefined
       }

--- a/frontend/src/components/agents/readiness/ReadinessDrawer.tsx
+++ b/frontend/src/components/agents/readiness/ReadinessDrawer.tsx
@@ -3,17 +3,29 @@
 import { useAtom } from 'jotai';
 import { Beaker, RefreshCw } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { fetchAgentReadinessAtom } from '@/atoms/ReadinessAtom';
-import { CustomButton, CustomDrawer } from '@/components/shared';
-import type { ReadinessCheckResult, ReadinessReport, ReadinessTrigger } from '@/types/readiness';
+import {
+  fetchAgentReadinessAtom,
+  fetchAgentReadinessRunAtom,
+  fetchAgentReadinessRunsAtom,
+} from '@/atoms/ReadinessAtom';
+import { CustomButton, CustomDrawer, SelectInput } from '@/components/shared';
+import type {
+  ReadinessCheckResult,
+  ReadinessReport,
+  ReadinessRunListItem,
+  ReadinessTrigger,
+} from '@/types/readiness';
 import { cn } from '@/utils/cn';
+import { formatDate, formatRelative } from '@/utils/date';
 import { handleApiError } from '@/utils/helpers';
 import { showToast } from '@/utils/toast';
 
 import ReadinessBadge from './ReadinessBadge';
 import ReadinessCheckList from './ReadinessCheckList';
+import { countLabel } from './readinessHelpers';
+import { useRunHistorySelect } from './useRunHistorySelect';
 
 interface ReadinessDrawerProps {
   open: boolean;
@@ -30,18 +42,17 @@ interface ReadinessDrawerProps {
    * of firing its own shallow fetch — keeps the drawer and the header badge
    * in agreement. */
   initialReport?: ReadinessReport | null;
-  /** Lets the drawer inform the parent when the report changes (Refresh /
-   * Run deep test) so the badge and the drawer stay in sync afterwards. */
+  /** Lets the drawer inform the parent when the LIVE report changes (Refresh /
+   * Run deep test) so the badge and the drawer stay in sync afterwards.
+   * Deliberately NOT called when viewing a historical run — the parent badge
+   * must keep reflecting the live report. */
   onReportChange?: (report: ReadinessReport | null) => void;
 }
 
 /**
- * Right-side drawer holding the full readiness report. Renders any
- * ``initialReport`` supplied by the parent on open (so the badge and the
- * drawer never disagree); falls back to a fresh Shallow fetch when the
- * parent has nothing to hand off. User can escalate to Deep via the "Run
- * deep test" button. Deep-links inside failing rows navigate the user to
- * the fix page.
+ * Right-side drawer holding the full readiness report. Adopts a parent-provided
+ * `initialReport` on open (else fetches Shallow), escalates to Deep via "Run
+ * deep test", and browses past deep runs (read-only) via the run-history select.
  */
 export default function ReadinessDrawer({
   open,
@@ -54,14 +65,30 @@ export default function ReadinessDrawer({
 }: ReadinessDrawerProps) {
   const router = useRouter();
   const [, runReadiness] = useAtom(fetchAgentReadinessAtom);
+  const [, fetchRuns] = useAtom(fetchAgentReadinessRunsAtom);
+  const [, fetchRun] = useAtom(fetchAgentReadinessRunAtom);
 
   const [report, setReport] = useState<ReadinessReport | null>(null);
   const [loading, setLoading] = useState(false);
   const [deepRunning, setDeepRunning] = useState(false);
 
-  /** Single point where local report state changes, so parent notification
-   * stays consistent across all update paths (initial-adopt / refresh /
-   * deep-test / close-clear). */
+  // ── run-history state ──────────────────────────────────────────────────
+  const [runs, setRuns] = useState<ReadinessRunListItem[]>([]);
+  const [runsLoading, setRunsLoading] = useState(false);
+  // Run-number + its report held as one unit so they can't drift (no stale
+  // report under a mismatched selection). null = live/latest report.
+  const [history, setHistory] = useState<{
+    runNumber: number;
+    report: ReadinessReport | null;
+  } | null>(null);
+  // Monotonic id so a slower, superseded history fetch can't land late.
+  const historyReqIdRef = useRef(0);
+
+  const viewingHistory = history !== null;
+  const selectedRunNumber = history?.runNumber ?? null;
+
+  // Sole entry point for LIVE report changes → keeps the parent badge in sync.
+  // Historical selection bypasses this so it never leaks into the parent badge.
   const applyReport = useCallback(
     (next: ReadinessReport | null) => {
       setReport(next);
@@ -70,8 +97,24 @@ export default function ReadinessDrawer({
     [onReportChange],
   );
 
+  const loadRuns = useCallback(async () => {
+    if (!agentId) return;
+    setRunsLoading(true);
+    try {
+      const res = await fetchRuns({ agentId, limit: 20 });
+      setRuns(res.items);
+    } catch (err) {
+      // Keep any already-loaded runs visible on a transient refresh failure
+      // (don't blank the dropdown), and surface the error per repo convention
+      // rather than swallowing it.
+      handleApiError(err);
+    } finally {
+      setRunsLoading(false);
+    }
+  }, [agentId, fetchRuns]);
+
   const load = useCallback(
-    async (depth: 'shallow' | 'deep', why: ReadinessTrigger | string = trigger) => {
+    async (depth: 'shallow' | 'deep', why: ReadinessTrigger | string = trigger, force = false) => {
       if (!agentId) return;
       const isDeep = depth === 'deep';
       if (isDeep) setDeepRunning(true);
@@ -82,8 +125,12 @@ export default function ReadinessDrawer({
           depth,
           configId: configId ?? undefined,
           trigger: why,
+          force,
         });
         applyReport(next);
+        // A fresh deep run just landed a new event row — refresh the history
+        // list so it shows up in the dropdown.
+        if (isDeep) void loadRuns();
       } catch (err) {
         // 429 = deep rate-limit → soft toast, don't wipe the drawer.
         const status = (err as { response?: { status?: number } })?.response?.status;
@@ -100,14 +147,11 @@ export default function ReadinessDrawer({
         else setLoading(false);
       }
     },
-    [agentId, applyReport, configId, runReadiness, trigger],
+    [agentId, applyReport, configId, loadRuns, runReadiness, trigger],
   );
 
-  // Open: adopt the parent-provided report when present (matches the badge);
-  // else fetch a fresh Shallow report. Close: clear ONLY local state so the
-  // parent keeps its report for the next open; if we nulled the parent too,
-  // close-and-reopen would lose the deep report from a preceding save and
-  // fall back to a shallow refetch that disagrees with the badge again.
+  // Open: adopt the parent report (matches the badge) or fetch Shallow. Close:
+  // clear only local state so the parent keeps its report for the next open.
   useEffect(() => {
     if (open && agentId) {
       if (initialReport) {
@@ -120,6 +164,53 @@ export default function ReadinessDrawer({
     if (!open) setReport(null);
   }, [open, agentId, configId, load, initialReport]);
 
+  // Load the history list + reset selection on open/close. NOT scoped to
+  // configId — history spans all versions, so a version switch mustn't refetch
+  // the list or eject the user from the run they're viewing.
+  useEffect(() => {
+    if (open && agentId) {
+      historyReqIdRef.current += 1; // invalidate any in-flight history fetch
+      setHistory(null);
+      void loadRuns();
+      return;
+    }
+    if (!open) {
+      historyReqIdRef.current += 1;
+      setRuns([]);
+      setHistory(null);
+    }
+  }, [open, agentId, loadRuns]);
+
+  const handleSelectRun = useCallback(
+    (id: string | number | null) => {
+      // Every selection (including the "Latest" sentinel) bumps the request id
+      // so a slower fetch from a previous pick can't land late and clobber it.
+      const reqId = (historyReqIdRef.current += 1);
+      // Sentinel → back to the live report.
+      if (id === null) {
+        setHistory(null);
+        return;
+      }
+      if (!agentId) return;
+      const runNumber = Number(id);
+      // Clear the prior report immediately (report: null) so the drawer shows a
+      // loader — never the previous run's checks under the new run's label.
+      setHistory({ runNumber, report: null });
+      void (async () => {
+        try {
+          const r = await fetchRun({ agentId, runNumber });
+          if (historyReqIdRef.current !== reqId) return; // superseded by a newer pick
+          setHistory({ runNumber, report: r });
+        } catch (err) {
+          if (historyReqIdRef.current !== reqId) return;
+          handleApiError(err);
+          setHistory(null);
+        }
+      })();
+    },
+    [agentId, fetchRun],
+  );
+
   const handleFix = useCallback(
     (check: ReadinessCheckResult) => {
       if (!check.deep_link) return;
@@ -129,7 +220,21 @@ export default function ReadinessDrawer({
     [onClose, router],
   );
 
-  const overallStatus = report?.overall_status;
+  // The report actually rendered: the selected past run, or the live report.
+  const shown = viewingHistory ? (history?.report ?? null) : report;
+  const overallStatus = shown?.overall_status;
+  // In history view the report is null until the fetch resolves → show the loader.
+  const showingLoader = viewingHistory ? !history?.report : loading && !report;
+
+  // Run-history select props (options + rich renderers) live in a hook so this
+  // component stays JSX-only.
+  const runSelect = useRunHistorySelect({
+    runs,
+    selectedRunNumber,
+    liveReport: report,
+    configId,
+    onSelect: handleSelectRun,
+  });
 
   return (
     <CustomDrawer
@@ -141,13 +246,13 @@ export default function ReadinessDrawer({
     >
       <div className="space-y-4">
         <div className="flex items-center justify-between gap-2">
-          {loading && !report ? (
+          {showingLoader ? (
             <ReadinessBadge status="loading" size="md" />
-          ) : report && overallStatus ? (
+          ) : shown && overallStatus ? (
             <ReadinessBadge
               status={overallStatus}
-              blockerCount={report.summary.blockers}
-              warningCount={report.summary.warnings}
+              blockerCount={shown.summary.blockers}
+              warningCount={shown.summary.warnings}
               size="md"
             />
           ) : (
@@ -155,12 +260,33 @@ export default function ReadinessDrawer({
           )}
 
           <div className="flex items-center gap-1.5">
+            {(runsLoading || runs.length > 0) && (
+              <SelectInput
+                name="readiness-run-history"
+                loading={runsLoading}
+                size="sm"
+                className="w-32"
+                // `!h-7` beats SelectTrigger's `data-[size=sm]:h-8`; the rest
+                // matches the adjacent toolbar buttons (h-7 · px-2 · 11px).
+                triggerClassName="!h-7 gap-1 px-2 text-[11px]"
+                // popper (not the default item-aligned) so the menu anchors
+                // below the trigger and isn't mis-positioned inside the drawer's
+                // scroll container.
+                position="popper"
+                {...runSelect}
+              />
+            )}
             <CustomButton
               type="text"
               size="xs"
               icon={<RefreshCw className={cn('size-3.5', loading && 'animate-spin')} />}
+              // Not forced: re-reads the newest snapshot (the deep one, via the
+              // shallow-accepts-deep fast-path) and only re-runs when the
+              // dependency stamp changed. Forcing here would persist a shallow
+              // event that never shows in the deep-only history and would
+              // supersede a fresh deep result, resetting the badge to "ready".
               onClick={() => void load('shallow', 'editor_load')}
-              disabled={loading || deepRunning || !agentId}
+              disabled={loading || deepRunning || viewingHistory || !agentId}
               className="h-7 px-2 text-[11px]"
             >
               Refresh
@@ -169,9 +295,9 @@ export default function ReadinessDrawer({
               type="default"
               size="xs"
               icon={<Beaker className="size-3.5" />}
-              onClick={() => void load('deep', 'test_button')}
+              onClick={() => void load('deep', 'test_button', true)}
               loading={deepRunning}
-              disabled={loading || !agentId}
+              disabled={loading || viewingHistory || !agentId}
               className="h-7 px-2 text-[11px]"
             >
               Run deep test
@@ -179,22 +305,44 @@ export default function ReadinessDrawer({
           </div>
         </div>
 
-        {report && (
-          <div className="flex gap-3 text-[11px] text-muted-foreground">
-            <span>
-              {countLabel(report.summary.blockers, 'blocker', 'blockers')} ·{' '}
-              {countLabel(report.summary.warnings, 'warning', 'warnings')} ·{' '}
-              {countLabel(report.summary.passed, 'pass', 'passing')}
-            </span>
-            <span aria-hidden>·</span>
-            <span title={report.generated_at}>Checked just now</span>
+        {viewingHistory && (
+          <div className="flex items-center justify-between gap-2 rounded-md border border-border/60 bg-muted/30 px-2.5 py-1.5 text-[11px] text-muted-foreground">
+            <span>Viewing run #{selectedRunNumber} (read-only)</span>
+            <CustomButton
+              type="text"
+              size="xs"
+              onClick={() => handleSelectRun(null)}
+              className="h-6 px-2 text-[11px]"
+            >
+              Back to latest
+            </CustomButton>
           </div>
         )}
 
-        {loading && !report ? (
+        {shown && (
+          <div className="flex gap-3 text-[11px] text-muted-foreground">
+            <span>
+              {countLabel(shown.summary.blockers, 'blocker', 'blockers')} ·{' '}
+              {countLabel(shown.summary.warnings, 'warning', 'warnings')} ·{' '}
+              {countLabel(shown.summary.passed, 'pass', 'passing')}
+              {shown.summary.skipped > 0 && ` · ${shown.summary.skipped} skipped`}
+            </span>
+            <span aria-hidden>·</span>
+            <span title={shown.generated_at ? formatDate(shown.generated_at) : undefined}>
+              {viewingHistory
+                ? `Checked ${formatRelative(shown.generated_at)}`
+                : 'Checked just now'}
+            </span>
+          </div>
+        )}
+
+        {showingLoader ? (
           <p className="py-8 text-center text-[13px] text-muted-foreground">Checking…</p>
-        ) : report ? (
-          <ReadinessCheckList checks={report.checks} onFix={handleFix} />
+        ) : shown ? (
+          <ReadinessCheckList
+            checks={shown.checks}
+            onFix={viewingHistory ? undefined : handleFix}
+          />
         ) : (
           <div className="space-y-3 py-4 text-center">
             <p className="text-[13px] text-muted-foreground">Readiness unavailable.</p>
@@ -206,8 +354,4 @@ export default function ReadinessDrawer({
       </div>
     </CustomDrawer>
   );
-}
-
-function countLabel(n: number, one: string, many: string): string {
-  return `${n} ${n === 1 ? one : many}`;
 }

--- a/frontend/src/components/agents/readiness/readinessConstants.ts
+++ b/frontend/src/components/agents/readiness/readinessConstants.ts
@@ -48,3 +48,6 @@ export const SEVERITY_TEXT_CLASS: Record<ReadinessSeverity, string> = {
   warning: 'text-amber-600 dark:text-amber-400',
   info: 'text-muted-foreground',
 };
+
+/** Sentinel value for the "Latest run" option in the run-history select. */
+export const RUN_HISTORY_LATEST_VALUE = 'latest';

--- a/frontend/src/components/agents/readiness/readinessHelpers.ts
+++ b/frontend/src/components/agents/readiness/readinessHelpers.ts
@@ -1,0 +1,21 @@
+/**
+ * Pure presentation helpers for the readiness UI. Kept out of the components so
+ * the drawer/list stay JSX-only and this logic is reusable and unit-testable.
+ */
+
+/** Human label for a run's trigger string, shown in the run-history select. */
+export function triggerLabelFor(trigger: string): string {
+  switch (trigger) {
+    case 'test_button':
+      return 'Deep test';
+    case 'publish_gate':
+      return 'Publish check';
+    default:
+      return 'Readiness check';
+  }
+}
+
+/** Pluralised "N thing" label, e.g. `countLabel(1, 'blocker', 'blockers')`. */
+export function countLabel(n: number, one: string, many: string): string {
+  return `${n} ${n === 1 ? one : many}`;
+}

--- a/frontend/src/components/agents/readiness/useRunHistorySelect.tsx
+++ b/frontend/src/components/agents/readiness/useRunHistorySelect.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+
+import type { SelectOption } from '@/components/shared';
+import type { ReadinessReport, ReadinessRunListItem } from '@/types/readiness';
+import { formatRelative } from '@/utils/date';
+
+import ReadinessBadge from './ReadinessBadge';
+import { RUN_HISTORY_LATEST_VALUE } from './readinessConstants';
+import { triggerLabelFor } from './readinessHelpers';
+
+interface UseRunHistorySelectArgs {
+  runs: ReadinessRunListItem[];
+  /** null = viewing the live/latest report. */
+  selectedRunNumber: number | null;
+  /** The live report — its run number labels the "Latest run" row. */
+  liveReport: ReadinessReport | null;
+  /** Config currently open, so cross-version runs can be flagged. */
+  configId?: string | null;
+  /** Fires with null for "Latest", or the picked run number. */
+  onSelect: (id: string | number | null) => void;
+}
+
+/**
+ * Builds the props the run-history {@link SelectInput} needs: options, the
+ * selected value, the change handler, and the rich option/trigger renderers.
+ * Extracted from the drawer so the component stays JSX-only.
+ */
+export function useRunHistorySelect({
+  runs,
+  selectedRunNumber,
+  liveReport,
+  configId,
+  onSelect,
+}: UseRunHistorySelectArgs) {
+  const liveRunNumber = liveReport?.run_number ?? null;
+
+  // Drop the live run from the history rows — it's already surfaced (editable)
+  // as the "Latest run" option, so listing it again as a read-only "Run #N"
+  // row would duplicate the same run.
+  const historyRuns = useMemo(
+    () => runs.filter((run) => run.run_number !== liveRunNumber),
+    [runs, liveRunNumber],
+  );
+
+  // `label` stays a plain string (typeahead / accessibility); rich rows come
+  // from `renderOption`.
+  const options: SelectOption[] = useMemo(
+    () => [
+      { value: RUN_HISTORY_LATEST_VALUE, label: 'Latest run' },
+      ...historyRuns.map((run) => ({
+        value: String(run.run_number),
+        label: `Run #${run.run_number}`,
+      })),
+    ],
+    [historyRuns],
+  );
+
+  const runByValue = useMemo(
+    () => new Map(historyRuns.map((run) => [String(run.run_number), run])),
+    [historyRuns],
+  );
+
+  const value = selectedRunNumber != null ? String(selectedRunNumber) : RUN_HISTORY_LATEST_VALUE;
+
+  const onValueChange = useCallback(
+    (next: string) => onSelect(next === RUN_HISTORY_LATEST_VALUE ? null : next),
+    [onSelect],
+  );
+
+  const renderOption = useCallback(
+    (option: SelectOption) => {
+      if (option.value === RUN_HISTORY_LATEST_VALUE) {
+        return (
+          <span className="flex min-w-0 flex-col">
+            <span className="text-[12px] font-medium leading-tight">Latest run</span>
+            {liveRunNumber != null && (
+              <span className="mt-0.5 text-[11px] leading-tight text-muted-foreground">
+                Run #{liveRunNumber}
+              </span>
+            )}
+          </span>
+        );
+      }
+      const run = runByValue.get(option.value);
+      if (!run) return option.label;
+      return (
+        <span className="flex min-w-0 flex-col">
+          <span className="text-[12px] font-medium leading-tight">
+            {triggerLabelFor(run.trigger)} · {formatRelative(run.computed_at)}
+          </span>
+          <span className="mt-0.5 flex items-center gap-1.5 text-[11px] leading-tight text-muted-foreground">
+            <ReadinessBadge status={run.overall_status} size="sm" iconOnly />
+            Run #{run.run_number}
+            {run.config_id && configId && run.config_id !== configId && (
+              <span className="text-amber-600 dark:text-amber-400">· other version</span>
+            )}
+          </span>
+        </span>
+      );
+    },
+    [liveRunNumber, runByValue, configId],
+  );
+
+  const renderValue = useCallback(
+    (v: string | undefined) => (!v || v === RUN_HISTORY_LATEST_VALUE ? 'Latest run' : `Run #${v}`),
+    [],
+  );
+
+  return { options, value, onValueChange, renderOption, renderValue };
+}

--- a/frontend/src/components/shared/SelectInput.tsx
+++ b/frontend/src/components/shared/SelectInput.tsx
@@ -44,6 +44,8 @@ const PlainSelectInput = forwardRef<HTMLButtonElement, SelectInputBaseProps>(
       triggerClassName,
       size = 'default',
       position,
+      renderOption,
+      renderValue,
     },
     ref,
   ) => {
@@ -130,14 +132,28 @@ const PlainSelectInput = forwardRef<HTMLButtonElement, SelectInputBaseProps>(
               >
                 {isLoading ? (
                   <span className="text-sm text-muted-foreground">Loading...</span>
+                ) : renderValue ? (
+                  // Mark the custom value as the Select's value slot so the
+                  // trigger's `*:data-[slot=select-value]:flex-1/truncate` rules
+                  // apply — otherwise it packs left and the chevron floats mid-row.
+                  <span data-slot="select-value" className="min-w-0 flex-1 truncate text-left">
+                    {renderValue(value)}
+                  </span>
                 ) : (
                   <SelectValue placeholder={placeholder} />
                 )}
               </SelectTrigger>
               <SelectContent position={position}>
                 {options.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value} disabled={opt.disabled}>
-                    {opt.label}
+                  <SelectItem
+                    key={opt.value}
+                    value={opt.value}
+                    disabled={opt.disabled}
+                    // Keep the plain label as the accessible / typeahead text
+                    // even when a rich custom row is rendered.
+                    textValue={opt.label}
+                  >
+                    {renderOption ? renderOption(opt) : opt.label}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -61,7 +61,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -70,7 +70,10 @@ function SelectContent({
           className={cn(
             'p-1',
             position === 'popper' &&
-              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1',
+              // NB: no `h-[var(--radix-select-trigger-height)]` — pinning the
+              // viewport to the trigger height clips the menu to a sliver. The
+              // Content's `max-h` + `overflow-y-auto` already bound it.
+              'w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1',
           )}
         >
           {children}
@@ -100,7 +103,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-pointer items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}

--- a/frontend/src/services/readinessService.ts
+++ b/frontend/src/services/readinessService.ts
@@ -3,6 +3,7 @@ import type {
   ReadinessCategory,
   ReadinessDepth,
   ReadinessReport,
+  ReadinessRunList,
   ReadinessSummary,
   ReadinessTrigger,
 } from '@/types/readiness';
@@ -17,6 +18,10 @@ interface ReadinessRequestBody {
    * only these categories live; the rest return SKIPPED. Used by save flows
    * that know exactly which resources changed. */
   categories?: ReadinessCategory[];
+  /** Force a fresh run + persisted event, bypassing the backend read-through
+   * caches. Set by the "Run deep test" button so each explicit run appears as a
+   * new entry in the run-history list. */
+  force?: boolean;
 }
 
 /** Derive a badge-shaped {@link ReadinessSummary} from a full report. Kept
@@ -113,11 +118,13 @@ export const getAgentReadiness = async (
   configId?: string,
   trigger?: ReadinessTrigger | string,
   categories?: ReadinessCategory[],
+  force?: boolean,
 ): Promise<ReadinessReport> => {
   const body: ReadinessRequestBody = { depth };
   if (configId) body.config_id = configId;
   if (trigger) body.trigger = trigger;
   if (categories && categories.length > 0) body.categories = categories;
+  if (force) body.force = true;
   const res = await axiosInstance.post<ReadinessReport>(`/agent/${agentId}/readiness`, body);
   return res.data;
 };
@@ -135,5 +142,30 @@ export const getAgentReadinessSummary = async (
   const res = await axiosInstance.get<ReadinessSummary>(`/agent/${agentId}/readiness/summary`, {
     params: { ...(configId ? { config_id: configId } : {}), trigger },
   });
+  return res.data;
+};
+
+/**
+ * List past deep readiness runs (newest first) for the run-history dropdown.
+ * Metadata only — call {@link getAgentReadinessRun} to load one run's checks.
+ */
+export const listAgentReadinessRuns = async (
+  agentId: string,
+  limit = 20,
+): Promise<ReadinessRunList> => {
+  const res = await axiosInstance.get<ReadinessRunList>(`/agent/${agentId}/readiness/runs`, {
+    params: { limit },
+  });
+  return res.data;
+};
+
+/** Fetch the full stored report (with checks) for one past run. */
+export const getAgentReadinessRun = async (
+  agentId: string,
+  runNumber: number,
+): Promise<ReadinessReport> => {
+  const res = await axiosInstance.get<ReadinessReport>(
+    `/agent/${agentId}/readiness/runs/${runNumber}`,
+  );
   return res.data;
 };

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -1,3 +1,5 @@
+import type { ReadinessOverallStatus } from '@/types/readiness';
+
 export type AgentType = 'inbound' | 'outbound' | 'both';
 
 export type AgentStatus = 'active' | 'inactive' | 'draft';
@@ -171,6 +173,18 @@ export interface AgentDetail {
   versions?: AgentVersionSummary[];
 }
 
+/** Last-known readiness attached to each list row by POST /agent/list. Read
+ * from the stored snapshot (no recompute), so it can lag the editor until a
+ * fresh check runs. Null when the agent has no stored run yet. */
+export interface AgentListReadiness {
+  overall_status: ReadinessOverallStatus;
+  blocker_count: number;
+  warning_count: number;
+  info_count: number;
+  run_number: number | null;
+  computed_at: string | null;
+}
+
 /** Lightweight listing row (POST /agent/list). `phone_number` is the legacy
  * shape returned by the list endpoint — kept as-is for now. */
 export interface AgentListItem {
@@ -181,6 +195,7 @@ export interface AgentListItem {
   agent_type: AgentDirection;
   is_active: boolean;
   phone_number: { type: string; no: string }[];
+  readiness: AgentListReadiness | null;
   created_at: number;
   updated_at: number;
 }

--- a/frontend/src/types/components.ts
+++ b/frontend/src/types/components.ts
@@ -171,6 +171,14 @@ export interface SelectInputBaseProps {
   triggerClassName?: string;
   size?: 'sm' | 'default';
   position?: 'item-aligned' | 'popper';
+  /** Optional custom renderer for each option row — lets callers render rich
+   * content (icons, two-line rows) in the list. Falls back to the plain string
+   * `label` when omitted. The string `label` is still used as the Radix
+   * typeahead / accessible text value. */
+  renderOption?: (option: SelectOption) => React.ReactNode;
+  /** Optional custom renderer for the selected value shown in the trigger.
+   * Receives the current value; falls back to the default text when omitted. */
+  renderValue?: (value: string | undefined) => React.ReactNode;
 }
 
 export interface SelectOption {

--- a/frontend/src/types/readiness.ts
+++ b/frontend/src/types/readiness.ts
@@ -67,6 +67,32 @@ export interface ReadinessReport {
   summary: ReadinessSummaryCounts;
   checks: ReadinessCheckResult[];
   generated_at: string;
+  /** Wall-clock start of the run (ISO-8601). Null on older reports. */
+  started_at?: string | null;
+  /** Per-agent monotonically increasing run counter. Null when not persisted. */
+  run_number?: number | null;
+}
+
+/** One row in the readiness run-history dropdown. Metadata only — the full
+ * `checks` list is fetched per-run via GET /agent/{id}/readiness/runs/{n}. */
+export interface ReadinessRunListItem {
+  run_number: number;
+  depth: ReadinessDepth;
+  overall_status: ReadinessOverallStatus;
+  config_id: string | null;
+  trigger: string;
+  blocker_count: number;
+  warning_count: number;
+  info_count: number;
+  passed_count: number;
+  skipped_count: number;
+  started_at: string | null;
+  computed_at: string;
+  duration_ms: number | null;
+}
+
+export interface ReadinessRunList {
+  items: ReadinessRunListItem[];
 }
 
 export interface ReadinessSummary {

--- a/test-cases/core/test_agent_readiness.py
+++ b/test-cases/core/test_agent_readiness.py
@@ -8,6 +8,10 @@ admin/owner access, force_warnings gate behaviour.
 """
 
 import uuid
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import HTTPException
 
 
 # ─── Helpers ───
@@ -77,6 +81,17 @@ class TestPostReadiness:
             json={"depth": "shallow", "trigger": "test_button"},
         )
         assert resp.status_code == 200
+
+    def test_force_deep_accepted(self, client_as_member):
+        """`force` (used by the Run-deep-test button to always append a new
+        history event) is accepted alongside depth=deep."""
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.post(
+            f"/api/v1/agent/{agent['id']}/readiness",
+            json={"depth": "deep", "force": True},
+        )
+        # 200 on success; 429 if the rate limiter fires from a prior deep run.
+        assert resp.status_code in (200, 429)
 
     def test_with_explicit_config_id(self, client_as_member):
         """Caller can request a specific config version to check."""
@@ -386,3 +401,206 @@ class TestSwitchActiveVersionForceWarnings:
             json={"config_id": _SENTINEL_UUID},
         )
         assert resp.status_code in (401, 403)
+
+
+# ─── GET /api/v1/agent/{agent_id}/readiness/runs ───
+
+class TestListReadinessRuns:
+    """Tests for GET /api/v1/agent/{agent_id}/readiness/runs (run-history list)."""
+
+    def test_empty_history_returns_list(self, client_as_member):
+        """A fresh agent has no deep runs yet → an empty items list, not a 404."""
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.get(f"/api/v1/agent/{agent['id']}/readiness/runs")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "items" in data
+        assert isinstance(data["items"], list)
+
+    def test_limit_below_min_rejected(self, client_as_member):
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.get(f"/api/v1/agent/{agent['id']}/readiness/runs?limit=0")
+        assert resp.status_code == 422
+
+    def test_limit_above_max_rejected(self, client_as_member):
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.get(f"/api/v1/agent/{agent['id']}/readiness/runs?limit=101")
+        assert resp.status_code == 422
+
+    def test_limit_within_range_accepted(self, client_as_member):
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.get(f"/api/v1/agent/{agent['id']}/readiness/runs?limit=5")
+        assert resp.status_code == 200
+
+    def test_unknown_agent(self, client_as_member):
+        resp = client_as_member.get(f"/api/v1/agent/{_SENTINEL_UUID}/readiness/runs")
+        assert resp.status_code == 404
+
+    def test_as_admin(self, client_as_admin):
+        agent = _create_agent(client_as_admin)
+        resp = client_as_admin.get(f"/api/v1/agent/{agent['id']}/readiness/runs")
+        assert resp.status_code == 200
+
+    def test_as_owner(self, client_as_owner):
+        agent = _create_agent(client_as_owner)
+        resp = client_as_owner.get(f"/api/v1/agent/{agent['id']}/readiness/runs")
+        assert resp.status_code == 200
+
+    def test_unauthenticated(self, client_unauthenticated):
+        resp = client_unauthenticated.get(f"/api/v1/agent/{_SENTINEL_UUID}/readiness/runs")
+        assert resp.status_code in (401, 403)
+
+
+# ─── GET /api/v1/agent/{agent_id}/readiness/runs/{run_number} ───
+
+class TestGetReadinessRun:
+    """Tests for GET /api/v1/agent/{agent_id}/readiness/runs/{run_number}."""
+
+    def test_unknown_run_returns_404(self, client_as_member):
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.get(f"/api/v1/agent/{agent['id']}/readiness/runs/999")
+        assert resp.status_code == 404
+
+    def test_unknown_agent_returns_404(self, client_as_member):
+        resp = client_as_member.get(f"/api/v1/agent/{_SENTINEL_UUID}/readiness/runs/1")
+        assert resp.status_code == 404
+
+    def test_unauthenticated(self, client_unauthenticated):
+        resp = client_unauthenticated.get(f"/api/v1/agent/{_SENTINEL_UUID}/readiness/runs/1")
+        assert resp.status_code in (401, 403)
+
+
+# ─── ReadinessService.list_runs / get_run — seeded, deterministic ───
+
+def _seed_event(db, *, org_id, agent_id, run_number, depth, checks=None):
+    """Insert one AgentReadinessEvent row directly so run-history behaviour can
+    be asserted deterministically (deep runs are rate-limited + probe live
+    providers, so driving them through the API is flaky)."""
+    from core.models.agent_readiness_event import AgentReadinessEvent
+
+    now = datetime.now(timezone.utc)
+    row = AgentReadinessEvent(
+        organization_id=org_id,
+        agent_id=agent_id,
+        config_id=None,
+        depth=depth,
+        overall_status="ready",
+        counts={"blockers": 0, "warnings": 0, "info": 0, "passed": 1, "skipped": 0},
+        checks=checks if checks is not None else [],
+        trigger="test_button" if depth == "deep" else "editor_load",
+        triggered_by_user_id=None,
+        duration_ms=12,
+        started_at=now,
+        computed_at=now,
+        run_number=run_number,
+        dependency_stamp="seed-stamp",
+        error=None,
+    )
+    db.add(row)
+    return row
+
+
+class TestReadinessRunsService:
+    """Direct service-level tests for the run-history query logic."""
+
+    def _agent_and_service(self, db_session, client_as_member):
+        from core.models.agent import Agent
+        from core.services.readiness import ReadinessService
+
+        agent = _create_agent(client_as_member)
+        agent_row = (
+            db_session.query(Agent).filter(Agent.id == uuid.UUID(agent["id"])).first()
+        )
+        assert agent_row is not None
+        org_id = agent_row.organization_id
+        svc = ReadinessService(db_session, user_id=None, org_id=org_id)
+        return agent, agent_row, org_id, svc
+
+    def test_list_runs_deep_only_descending_no_checks(self, db_session, client_as_member):
+        agent, agent_row, org_id, svc = self._agent_and_service(db_session, client_as_member)
+        # Interleave a shallow run between two deep runs.
+        _seed_event(db_session, org_id=org_id, agent_id=agent_row.id, run_number=1, depth="shallow")
+        _seed_event(db_session, org_id=org_id, agent_id=agent_row.id, run_number=2, depth="deep")
+        _seed_event(db_session, org_id=org_id, agent_id=agent_row.id, run_number=3, depth="deep")
+        db_session.flush()
+
+        result = svc.list_runs(agent["id"], limit=20)
+        run_numbers = [item.run_number for item in result.items]
+        # Deep runs only (shallow #1 excluded), newest first.
+        assert run_numbers == [3, 2]
+        # Metadata only — no heavy checks blob on list items.
+        for item in result.items:
+            assert "checks" not in item.model_dump()
+            assert item.depth.value == "deep"
+
+    def test_list_runs_respects_limit(self, db_session, client_as_member):
+        agent, agent_row, org_id, svc = self._agent_and_service(db_session, client_as_member)
+        _seed_event(db_session, org_id=org_id, agent_id=agent_row.id, run_number=2, depth="deep")
+        _seed_event(db_session, org_id=org_id, agent_id=agent_row.id, run_number=3, depth="deep")
+        db_session.flush()
+
+        result = svc.list_runs(agent["id"], limit=1)
+        assert len(result.items) == 1
+        assert result.items[0].run_number == 3
+
+    def test_get_run_returns_full_report_with_checks(self, db_session, client_as_member):
+        agent, agent_row, org_id, svc = self._agent_and_service(db_session, client_as_member)
+        checks = [
+            {
+                "check_id": "llm.provider",
+                "category": "llm",
+                "severity": "info",
+                "status": "pass",
+                "message": "LLM provider configured",
+            }
+        ]
+        _seed_event(
+            db_session,
+            org_id=org_id,
+            agent_id=agent_row.id,
+            run_number=7,
+            depth="deep",
+            checks=checks,
+        )
+        db_session.flush()
+
+        report = svc.get_run(agent["id"], 7)
+        assert report.run_number == 7
+        assert report.depth.value == "deep"
+        assert len(report.checks) == 1
+        assert report.checks[0].check_id == "llm.provider"
+
+    def test_get_run_unknown_raises_404(self, db_session, client_as_member):
+        agent, _agent_row, _org_id, svc = self._agent_and_service(db_session, client_as_member)
+        with pytest.raises(HTTPException) as exc:
+            svc.get_run(agent["id"], 999)
+        assert exc.value.status_code == 404
+
+    def test_get_run_shallow_run_not_found(self, db_session, client_as_member):
+        """get_run is deep-only (mirrors list_runs) — a shallow run's number,
+        which never appears in the dropdown, must 404 rather than return it."""
+        agent, agent_row, org_id, svc = self._agent_and_service(db_session, client_as_member)
+        _seed_event(db_session, org_id=org_id, agent_id=agent_row.id, run_number=4, depth="shallow")
+        db_session.flush()
+        with pytest.raises(HTTPException) as exc:
+            svc.get_run(agent["id"], 4)
+        assert exc.value.status_code == 404
+
+    def test_list_runs_skips_unmappable_row(self, db_session, client_as_member):
+        """One legacy/partial event row with an out-of-enum overall_status must
+        be skipped, not 500 the whole history list."""
+        agent, agent_row, org_id, svc = self._agent_and_service(db_session, client_as_member)
+        good = _seed_event(
+            db_session, org_id=org_id, agent_id=agent_row.id, run_number=6, depth="deep"
+        )
+        bad = _seed_event(
+            db_session, org_id=org_id, agent_id=agent_row.id, run_number=5, depth="deep"
+        )
+        # Corrupt the enum-backed column to a value outside OverallStatus.
+        bad.overall_status = "some_retired_status"
+        db_session.flush()
+
+        result = svc.list_runs(agent["id"], limit=20)
+        run_numbers = [item.run_number for item in result.items]
+        assert run_numbers == [6]  # bad row (5) skipped, good row (6) survives
+        assert good.run_number == 6

--- a/test-cases/core/test_agents.py
+++ b/test-cases/core/test_agents.py
@@ -921,3 +921,126 @@ class TestDeleteAgentVersion:
             f"/api/v1/agent/delete_version?agent_id={_SENTINEL_UUID}&config_id={_SENTINEL_UUID}",
         )
         assert resp.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/agent/list — readiness badge is embedded per row (no N+1)
+# ---------------------------------------------------------------------------
+
+def _seed_snapshot(
+    db,
+    *,
+    org_id,
+    agent_id,
+    depth,
+    overall_status="not_ready",
+    counts=None,
+    run_number=1,
+    computed_at=None,
+):
+    """Insert one AgentReadinessSnapshot row so the list endpoint's embedded
+    readiness field can be asserted deterministically without running a live
+    check. The (agent_id, config_id, depth) uniqueness constraint means each
+    depth is its own slot for a config_id=None agent."""
+    from datetime import datetime, timezone
+
+    from core.models.agent_readiness_snapshot import AgentReadinessSnapshot
+
+    now = computed_at or datetime.now(timezone.utc)
+    row = AgentReadinessSnapshot(
+        organization_id=org_id,
+        agent_id=agent_id,
+        config_id=None,
+        depth=depth,
+        overall_status=overall_status,
+        counts=counts if counts is not None else {"blockers": 2, "warnings": 1, "info": 0},
+        checks=[],
+        trigger="list_page",
+        triggered_by_user_id=None,
+        duration_ms=5,
+        started_at=now,
+        computed_at=now,
+        run_number=run_number,
+        dependency_stamp="seed-stamp",
+        error=None,
+    )
+    db.add(row)
+    return row
+
+
+def _org_and_agent(db_session, client):
+    """Create an agent via the API and return (agent_json, agent_row, org_id)."""
+    from core.models.agent import Agent
+
+    agent = _create_agent(client)
+    agent_row = db_session.query(Agent).filter(Agent.id == uuid.UUID(agent["id"])).first()
+    assert agent_row is not None
+    return agent, agent_row, agent_row.organization_id
+
+
+class TestListAgentsReadiness:
+    """The list endpoint embeds last-known readiness on each row so the badge
+    needs no per-row fetch (replaces the old N+1)."""
+
+    def _find(self, items, agent_id):
+        return next((it for it in items if it["id"] == agent_id), None)
+
+    def test_readiness_field_present_and_null_without_a_run(self, db_session, client_as_member):
+        """A brand-new agent has no stored run → readiness is present but null."""
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.post("/api/v1/agent/list", json={})
+        assert resp.status_code == 200
+        item = self._find(resp.json()["items"], agent["id"])
+        assert item is not None
+        assert "readiness" in item
+        assert item["readiness"] is None
+
+    def test_readiness_reflects_stored_snapshot(self, db_session, client_as_member):
+        agent, agent_row, org_id = _org_and_agent(db_session, client_as_member)
+        _seed_snapshot(
+            db_session,
+            org_id=org_id,
+            agent_id=agent_row.id,
+            depth="shallow",
+            overall_status="not_ready",
+            counts={"blockers": 3, "warnings": 1, "info": 2},
+            run_number=4,
+        )
+        db_session.flush()
+
+        resp = client_as_member.post("/api/v1/agent/list", json={})
+        item = self._find(resp.json()["items"], agent["id"])
+        assert item is not None
+        r = item["readiness"]
+        assert r["overall_status"] == "not_ready"
+        assert r["blocker_count"] == 3
+        assert r["warning_count"] == 1
+        assert r["info_count"] == 2
+        assert r["run_number"] == 4
+        assert r["computed_at"] is not None
+
+    def test_readiness_uses_newest_snapshot_across_depths(self, db_session, client_as_member):
+        """When an agent has both a shallow and a deep snapshot, the row shows
+        the most recently computed one regardless of depth."""
+        from datetime import datetime, timedelta, timezone
+
+        agent, agent_row, org_id = _org_and_agent(db_session, client_as_member)
+        older = datetime.now(timezone.utc) - timedelta(minutes=5)
+        newer = datetime.now(timezone.utc)
+        _seed_snapshot(
+            db_session, org_id=org_id, agent_id=agent_row.id, depth="shallow",
+            overall_status="ready", counts={"blockers": 0, "warnings": 0, "info": 0},
+            run_number=1, computed_at=older,
+        )
+        _seed_snapshot(
+            db_session, org_id=org_id, agent_id=agent_row.id, depth="deep",
+            overall_status="not_ready", counts={"blockers": 5, "warnings": 0, "info": 0},
+            run_number=2, computed_at=newer,
+        )
+        db_session.flush()
+
+        resp = client_as_member.post("/api/v1/agent/list", json={})
+        item = self._find(resp.json()["items"], agent["id"])
+        assert item["readiness"]["overall_status"] == "not_ready"  # newer deep wins
+        assert item["readiness"]["blocker_count"] == 5
+        assert item["readiness"]["run_number"] == 2

--- a/test-cases/ee/test_agent_readiness.py
+++ b/test-cases/ee/test_agent_readiness.py
@@ -59,6 +59,14 @@ class TestPostReadiness:
         assert resp.status_code == 200
         assert resp.json()["depth"] == "shallow"
 
+    def test_force_deep_accepted(self, client_as_member):
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.post(
+            f"/api/v1/agent/{agent['id']}/readiness",
+            json={"depth": "deep", "force": True},
+        )
+        assert resp.status_code in (200, 429)
+
     def test_explicit_deep(self, client_as_member):
         agent = _create_agent(client_as_member)
         resp = client_as_member.post(
@@ -298,4 +306,65 @@ class TestSwitchActiveVersionForceWarnings:
             f"?agent_id={_SENTINEL_UUID}&force_warnings=true",
             json={"config_id": _SENTINEL_UUID},
         )
+        assert resp.status_code in (401, 403)
+
+
+# ─── GET /api/v1/agent/{agent_id}/readiness/runs ───
+
+class TestListReadinessRuns:
+    """Tests for GET /api/v1/agent/{agent_id}/readiness/runs (EE edition)."""
+
+    def test_empty_history_returns_list(self, client_as_member):
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.get(f"/api/v1/agent/{agent['id']}/readiness/runs")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "items" in data
+        assert isinstance(data["items"], list)
+
+    def test_limit_below_min_rejected(self, client_as_member):
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.get(f"/api/v1/agent/{agent['id']}/readiness/runs?limit=0")
+        assert resp.status_code == 422
+
+    def test_limit_above_max_rejected(self, client_as_member):
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.get(f"/api/v1/agent/{agent['id']}/readiness/runs?limit=101")
+        assert resp.status_code == 422
+
+    def test_limit_within_range_accepted(self, client_as_member):
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.get(f"/api/v1/agent/{agent['id']}/readiness/runs?limit=5")
+        assert resp.status_code == 200
+
+    def test_unknown_agent(self, client_as_member):
+        resp = client_as_member.get(f"/api/v1/agent/{_SENTINEL_UUID}/readiness/runs")
+        assert resp.status_code == 404
+
+    def test_as_admin(self, client_as_admin):
+        agent = _create_agent(client_as_admin)
+        resp = client_as_admin.get(f"/api/v1/agent/{agent['id']}/readiness/runs")
+        assert resp.status_code == 200
+
+    def test_unauthenticated(self, client_unauthenticated):
+        resp = client_unauthenticated.get(f"/api/v1/agent/{_SENTINEL_UUID}/readiness/runs")
+        assert resp.status_code in (401, 403)
+
+
+# ─── GET /api/v1/agent/{agent_id}/readiness/runs/{run_number} ───
+
+class TestGetReadinessRun:
+    """Tests for GET /api/v1/agent/{agent_id}/readiness/runs/{run_number} (EE)."""
+
+    def test_unknown_run_returns_404(self, client_as_member):
+        agent = _create_agent(client_as_member)
+        resp = client_as_member.get(f"/api/v1/agent/{agent['id']}/readiness/runs/999")
+        assert resp.status_code == 404
+
+    def test_unknown_agent_returns_404(self, client_as_member):
+        resp = client_as_member.get(f"/api/v1/agent/{_SENTINEL_UUID}/readiness/runs/1")
+        assert resp.status_code == 404
+
+    def test_unauthenticated(self, client_unauthenticated):
+        resp = client_unauthenticated.get(f"/api/v1/agent/{_SENTINEL_UUID}/readiness/runs/1")
         assert resp.status_code in (401, 403)


### PR DESCRIPTION
…(#822) (#823)

* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817) (#818)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(readiness): add run-history browsing + force-run flag

Backend:
- New GET /agent/{id}/readiness/runs (deep-only, newest first, metadata) and /runs/{run_number} (full stored report) on core + EE routers, org-scoped via _require_agent; unmappable legacy rows are skipped/404'd with tracebacks.
- ReadinessRequest gains `force` to bypass the read-through snapshot + coalesce caches for explicit user-initiated deep runs so each appends a fresh event.
- _read_fresh_snapshot: a shallow read now accepts the newest deep snapshot (deep is a superset) so a deep result survives page reloads.
- Unify snapshot/event mapping (_row_to_report, _counts_from_row).

Frontend:
- Run-history select in ReadinessDrawer (read-only past runs) backed by a useRunHistorySelect hook + readinessHelpers; SelectInput gains renderOption/ renderValue for rich rows.
- Header badge stays in sync with the drawer's live report.

Review fixes:
- Exclude the live run_number from history options (no duplicate row).
- Refresh no longer forces a persisted shallow run (avoids spurious events and silent badge reset); force stays on the deep "Run deep test" button.

Tests: run-history list/get, limit bounds, auth denial, deep-only filtering, unmappable-row skip (core + EE).



* refactor(readiness): move list-badge lookup into ReadinessService

Embed last-known readiness on each agent-list row (removes the old per-row /readiness/summary N+1) and keep the data access in the service layer:

- Add ReadinessService.latest_for_agents(agent_ids): batch, org-scoped, projected-column lookup for the list badge (skips the heavy checks blob).
- Single-source the count-fallback set via _counts_from_mapping; both the row mappers and the list-badge lookup reuse it.
- Router now calls the service instead of a raw AgentReadinessSnapshot query; drop the redundant function-local ReadinessService import.
- Frontend: AgentReadinessCell renders the embedded readiness (no per-row fetch); add AgentListReadiness type + regression tests.



---------