### PR TITLE
Run WS test-bridge on outbound voice pods via intra-cluster hand-off …

### DIFF
--- a/core/services/call_engines/websocket_engine.py
+++ b/core/services/call_engines/websocket_engine.py
@@ -50,8 +50,13 @@ class WebSocketCallEngine(CallEngine):
         agent_id: str,
         callback_base_url: str,
         scheduled_call_id: Optional[str] = None,
+        ws_run_id: Optional[str] = None,
+        ws_scenario_id: Optional[str] = None,
     ) -> CallInfo:
         """Pick an outbound voice pod and hand the bridge off to it; return immediately.
+
+        ``ws_run_id``/``ws_scenario_id`` (test-case fan-out) ride the hand-off so the remote runs THAT
+        scenario's persona and records the result into its TestRun mapping.
 
         Raises ``NoOutboundCapacity`` when no pod is live or the picked pod is full (429), so the
         caller queues. Raises other exceptions on a genuine hand-off failure (marked ``failed``)."""
@@ -64,6 +69,12 @@ class WebSocketCallEngine(CallEngine):
             pod = picker.pick()
             base = picker.internal_base_for(pod)
         if pod is None or not base:
+            # No dedicated outbound-call-worker pod. In a single-process / local deployment there is
+            # no such pool, so (opt-in) run the bridge IN-PROCESS instead of holding the row forever.
+            if settings.WS_BRIDGE_ALLOW_INLINE:
+                return self._initiate_inline(
+                    to_number, from_number, agent_id, scheduled_call_id, ws_run_id, ws_scenario_id
+                )
             raise NoOutboundCapacity(
                 "no live outbound voice pod to run the WS bridge (is the outbound-call-worker "
                 "pool up and registered via pod_sync?)"
@@ -74,6 +85,8 @@ class WebSocketCallEngine(CallEngine):
             "to_number": (to_number or "").strip(),
             "from_number": (from_number or "").strip(),
             "scheduled_call_id": str(scheduled_call_id) if scheduled_call_id else None,
+            "ws_run_id": str(ws_run_id) if ws_run_id else None,
+            "ws_scenario_id": str(ws_scenario_id) if ws_scenario_id else None,
         }
         headers = {}
         if settings.WS_BRIDGE_INTERNAL_TOKEN:
@@ -107,6 +120,47 @@ class WebSocketCallEngine(CallEngine):
         call_id = (resp.json() or {}).get("call_id")
         if not call_id:
             raise RuntimeError("ws-bridge-start returned no call_id")
+
+        return CallInfo(
+            call_id=call_id,
+            session_id=str(scheduled_call_id or agent_id),
+            status="dialing",
+            provider="websocket",
+        )
+
+    def _initiate_inline(
+        self,
+        to_number: str,
+        from_number: str,
+        agent_id: str,
+        scheduled_call_id: Optional[str],
+        ws_run_id: Optional[str] = None,
+        ws_scenario_id: Optional[str] = None,
+    ) -> CallInfo:
+        """Run the WS bridge IN-PROCESS (local/single-process fallback, gated by
+        ``WS_BRIDGE_ALLOW_INLINE``). Reuses the exact same pod-local runner the hand-off target
+        uses, so the per-process ``MAX_CONCURRENT_CALLS`` cap and the ``scheduled_calls`` terminal
+        lifecycle behave identically — a full cap raises ``AtCapacity`` → ``NoOutboundCapacity`` so
+        the row holds and the drain retries, matching the pod's 429 path."""
+        from core.services.call_engines.ws_bridge_runner import (AtCapacity,
+                                                                start_local_bridge)
+
+        logger.info(
+            "[outbound][ws] no outbound pod — running bridge INLINE (WS_BRIDGE_ALLOW_INLINE) "
+            "agent={} to={} scheduled_call_id={} ws_scenario_id={}",
+            agent_id, (to_number or "").strip(), scheduled_call_id, ws_scenario_id,
+        )
+        try:
+            call_id = start_local_bridge(
+                agent_id=str(agent_id),
+                to_number=(to_number or "").strip(),
+                from_number=(from_number or "").strip(),
+                scheduled_call_id=str(scheduled_call_id) if scheduled_call_id else None,
+                ws_run_id=str(ws_run_id) if ws_run_id else None,
+                ws_scenario_id=str(ws_scenario_id) if ws_scenario_id else None,
+            )
+        except AtCapacity as exc:
+            raise NoOutboundCapacity(f"inline bridge at capacity: {exc}") from exc
 
         return CallInfo(
             call_id=call_id,

--- a/core/services/call_engines/ws_bridge_runner.py
+++ b/core/services/call_engines/ws_bridge_runner.py
@@ -25,11 +25,15 @@ from shared.config import settings
 _SESSIONS: Dict[str, Dict[str, Any]] = {}
 _SESSIONS_LOCK = threading.Lock()
 
-# The one PCM rate for the whole bridge. We DECLARE it in the /ws/test URL so the remote tags
-# inbound audio at exactly this rate — the two sides can never disagree (a mismatch is what makes
-# ASR return empty transcripts while VAD still fires). 24 kHz = Cartesia's native TTS rate on both
-# ends, so there is also no resampling anywhere on the TTS→wire→STT path.
-_BRIDGE_SAMPLE_RATE = 24000
+# The one PCM rate for the whole bridge — single-sourced from the transport builder (which
+# assembles the client transport at the same rate). We DECLARE it in the /ws/test URL so the
+# remote tags inbound audio at exactly this rate; the two sides can never disagree (a mismatch
+# is what makes ASR return empty transcripts while VAD still fires). 24 kHz = Cartesia's native
+# TTS rate on both ends, so there is also no resampling on the TTS→wire→STT path.
+from core.services.transport import (BRIDGE_SAMPLE_RATE,
+                                    build_ws_bridge_transport)
+
+_BRIDGE_SAMPLE_RATE = BRIDGE_SAMPLE_RATE
 
 
 class AtCapacity(RuntimeError):
@@ -42,10 +46,18 @@ def active_count() -> int:
         return len(_SESSIONS)
 
 
-def _remote_uri(to_number: str, agent_id: str) -> str:
+def _remote_uri(
+    to_number: str,
+    agent_id: str,
+    ws_run_id: Optional[str] = None,
+    ws_scenario_id: Optional[str] = None,
+) -> str:
     """Build the remote ``/ws/test`` URI. Routing mirrors a real call: the remote resolves ITS
     agent by the dialed number (``?phone_number=…``); ``WS_CALL_TARGET_AGENT_ID`` is only a
-    fallback when there is no number. Raises if the WS target host is unset."""
+    fallback when there is no number. Raises if the WS target host is unset.
+
+    When ``ws_run_id`` + ``ws_scenario_id`` are supplied (test-case fan-out), they ride the URL so
+    the remote runs THAT scenario's persona and records the result into its TestRun mapping."""
     target_url = (settings.WS_CALL_TARGET_URL or "").rstrip("/")
     if not target_url:
         raise ValueError(
@@ -64,7 +76,10 @@ def _remote_uri(to_number: str, agent_id: str) -> str:
             "remote) or set WS_CALL_TARGET_AGENT_ID as a fallback."
         )
     # Declare our PCM rate so the remote tags inbound audio identically (no rate disagreement).
-    return f"{target_url}/ws/test?{remote_query}&sample_rate={_BRIDGE_SAMPLE_RATE}"
+    uri = f"{target_url}/ws/test?{remote_query}&sample_rate={_BRIDGE_SAMPLE_RATE}"
+    if ws_run_id and ws_scenario_id:
+        uri += f"&run_id={quote(str(ws_run_id))}&scenario_id={quote(str(ws_scenario_id))}"
+    return uri
 
 
 def start_local_bridge(
@@ -72,13 +87,17 @@ def start_local_bridge(
     to_number: str,
     from_number: str = "",
     scheduled_call_id: Optional[str] = None,
+    ws_run_id: Optional[str] = None,
+    ws_scenario_id: Optional[str] = None,
 ) -> str:
     """Start the WS bridge in a detached daemon thread ON THIS POD and return its call_id.
 
     Enforces the per-pod ``MAX_CONCURRENT_CALLS`` ceiling atomically under the sessions lock:
     if the pod is already at the limit, raises ``AtCapacity`` and starts nothing — the caller
-    (the ``/internal/ws-bridge/start`` route) turns that into a 429 so the originator queues."""
-    remote_uri = _remote_uri(to_number, agent_id)  # validate BEFORE claiming a slot
+    (the ``/internal/ws-bridge/start`` route) turns that into a 429 so the originator queues.
+
+    ``ws_run_id``/``ws_scenario_id`` (test-case fan-out) ride the remote ``/ws/test`` URL."""
+    remote_uri = _remote_uri(to_number, agent_id, ws_run_id, ws_scenario_id)  # validate BEFORE claiming a slot
     call_id = uuid.uuid4().hex
     cap = settings.MAX_CONCURRENT_CALLS
     stop = threading.Event()
@@ -123,26 +142,16 @@ def _bridge_thread(call_id, remote_uri, agent_id, scheduled_call_id) -> None:
 
 async def _run_bridge(call_id, remote_uri, agent_id) -> None:
     """Open the outbound WS client to the remote ``/ws/test`` and run our outbound agent
-    bridged to it. Blocks until the media session ends."""
+    bridged to it. Blocks until the media session ends.
+
+    The client transport is assembled by the shared transport-module builder
+    (``core.services.transport.ws_bridge``), the mirror of the inbound
+    ``TelephonyTransport`` — same pipeline, opposite socket direction."""
     from pipecat.runner.types import RunnerArguments
-    from pipecat.transports.websocket.client import (WebsocketClientParams,
-                                                     WebsocketClientTransport)
 
     from core.bot import run_bot
-    from core.serializers.raw_pcm import RawPCMSerializer
 
-    # Raw-PCM bridge at 24 kHz BOTH ways — must match the remote /ws/test rate (Cartesia native),
-    # so there is ZERO resampling on the TTS→wire→STT path (a 24→16 kHz resample keeps enough
-    # energy for VAD but degrades audio enough that Deepgram transcribes NOTHING).
-    params = WebsocketClientParams(
-        audio_in_enabled=True,
-        audio_out_enabled=True,
-        audio_in_sample_rate=_BRIDGE_SAMPLE_RATE,
-        audio_out_sample_rate=_BRIDGE_SAMPLE_RATE,
-        add_wav_header=False,
-        serializer=RawPCMSerializer(sample_rate=_BRIDGE_SAMPLE_RATE, num_channels=1),
-    )
-    transport = WebsocketClientTransport(uri=remote_uri, params=params)
+    transport = build_ws_bridge_transport(remote_uri, _BRIDGE_SAMPLE_RATE)
 
     with _SESSIONS_LOCK:
         sess = _SESSIONS.get(call_id)
@@ -189,7 +198,8 @@ def _finalize_scheduled_call(scheduled_call_id, terminal_status: str) -> None:
                 )
             batch_id = sc.batch_id
             has_limit = sc.batch_id is not None and bool(sc.max_concurrency)
-        # Free the batch slot so the next held row dials (safety-net drain also covers this).
+        # Free the batch slot so the next held row dials — enqueue a refill job that the Procrastinate
+        # worker consumes (a worker must be running; the periodic drain is the safety net).
         if has_limit:
             _get_refill_executor().submit(_refill_batch_job, batch_id)
     except Exception:

--- a/core/services/call_engines/ws_test_client.py
+++ b/core/services/call_engines/ws_test_client.py
@@ -1,0 +1,68 @@
+"""Client for the remote tone-test WS-bridge test-run API.
+
+Before fanning out WebSocket-bridge calls, havana asks the remote deployment (the same one whose
+``/ws/test`` the bridge dials) to PREPARE a tracked test run for the dialed number: the remote resolves
+the agent, creates one ``TestRun`` + N pending scenario mappings over that agent's cases, and returns
+``{run_id, scenarios:[{scenario_id, name}]}``. havana then dials ``/ws/test`` once per scenario, so each
+case runs its own persona and is recorded — appearing in the remote's Test Runs UI.
+
+The HTTP base is derived from ``WS_CALL_TARGET_URL`` (ws→http, wss→https); the endpoint is
+unauthenticated + org-agnostic (the dialed number carries its own org on the remote).
+"""
+
+from typing import Any, Dict, List, Optional
+
+import httpx
+from loguru import logger
+
+from shared.config import settings
+
+_PREPARE_TIMEOUT_SECONDS = 10.0
+
+
+def _http_base() -> Optional[str]:
+    """Derive the remote HTTP base from ``WS_CALL_TARGET_URL`` (ws→http, wss→https)."""
+    target = (settings.WS_CALL_TARGET_URL or "").strip().rstrip("/")
+    if not target:
+        return None
+    if target.startswith("wss://"):
+        return "https://" + target[len("wss://"):]
+    if target.startswith("ws://"):
+        return "http://" + target[len("ws://"):]
+    return target
+
+
+def prepare_bridge_run(to_number: str) -> Optional[Dict[str, Any]]:
+    """Ask the remote to prepare a tracked test run for ``to_number``.
+
+    Returns ``{run_id, agent_id, scenarios:[{scenario_id, name, execution_order}]}`` on success, or
+    ``None`` when the number maps to no agent/scenarios (404) or the remote is unreachable — the caller
+    then falls back to an untracked bridge fan-out. Never raises."""
+    base = _http_base()
+    if not base:
+        return None
+    url = f"{base}/api/v1/ws-test/prepare"
+    try:
+        resp = httpx.post(
+            url, json={"phone_number": (to_number or "").strip()}, timeout=_PREPARE_TIMEOUT_SECONDS
+        )
+    except httpx.HTTPError as exc:
+        logger.warning("[outbound][ws] prepare call to {} failed: {}", url, exc)
+        return None
+    if resp.status_code == 404:
+        logger.info("[outbound][ws] no tracked scenarios for {} (remote 404) — untracked fan-out", to_number)
+        return None
+    if resp.status_code >= 400:
+        logger.warning("[outbound][ws] prepare returned {} for {}", resp.status_code, to_number)
+        return None
+    try:
+        data = resp.json() or {}
+    except ValueError as exc:
+        # 2xx with a non-JSON body (e.g. an HTML error page from a proxy/LB). Honor the
+        # "Never raises" contract so the caller falls back to an untracked fan-out.
+        logger.warning("[outbound][ws] prepare returned non-JSON body for {}: {}", to_number, exc)
+        return None
+    scenarios: List[Dict[str, Any]] = data.get("scenarios") or []
+    if not data.get("run_id") or not scenarios:
+        return None
+    return data

--- a/core/services/outbound_call_service.py
+++ b/core/services/outbound_call_service.py
@@ -583,22 +583,52 @@ class OutboundCallService(BaseService):
         orchestrator's Procrastinate poll) means an immediate test call triggers on create rather
         than sitting in 'scheduled'. Rows a pod refuses (429) / with no pod free stay 'scheduled' and
         the enqueued Procrastinate jobs + the drain retry the hand-off as pods free."""
-        try:
-            count = int(max_concurrency) if max_concurrency else 0
-        except (TypeError, ValueError):
-            count = 0
-        # No explicit count → one bridge per destination; else exactly `count` bridges.
-        count = count if count > 0 else len(valid)
-        if count > self._MAX_PARALLEL_WS:
-            logger.warning(
-                "[outbound][ws] requested {} parallel bridges; capping to {}",
-                count, self._MAX_PARALLEL_WS,
-            )
-            count = self._MAX_PARALLEL_WS
+        from core.services.call_engines.ws_test_client import prepare_bridge_run
 
-        # One batch id groups the fan-out; max_concurrency = count makes dispatch admit all N (the
-        # per-pod cap is the real throttle) AND enables the completion-refill fast path so a held
-        # row dials the instant a pod frees. batch_id also lets drain_outbound_capacity retry holds.
+        # Resolve each destination to its remote test scenarios (test-case fan-out). A number assigned
+        # to a remote agent with scenarios → one bridge PER scenario, each tracked as a TestRun case
+        # (metadata carries run_id + scenario_id); a number with no scenarios / an unreachable remote
+        # → a single untracked bridge. If NO destination resolves, fall back to the load-test fan-out
+        # (N = max_concurrency, cycling `valid`) so existing behavior is preserved.
+        specs: List[tuple] = []  # (to_number, metadata_dict)
+        tracked = False
+        for num in valid:
+            prep = prepare_bridge_run(num)
+            if prep and prep.get("scenarios"):
+                tracked = True
+                run_id = prep["run_id"]
+                for sc in prep["scenarios"]:
+                    specs.append(
+                        (num, {"ws_run_id": run_id, "ws_scenario_id": sc["scenario_id"]})
+                    )
+            else:
+                specs.append((num, {}))
+
+        if not tracked:
+            try:
+                count = int(max_concurrency) if max_concurrency else 0
+            except (TypeError, ValueError):
+                count = 0
+            count = count if count > 0 else len(valid)
+            specs = [(valid[i % len(valid)], {}) for i in range(count)]
+
+        if len(specs) > self._MAX_PARALLEL_WS:
+            logger.warning(
+                "[outbound][ws] {} bridges requested; capping to {}",
+                len(specs), self._MAX_PARALLEL_WS,
+            )
+            specs = specs[: self._MAX_PARALLEL_WS]
+        count = len(specs)
+
+        # Per-batch concurrency (the row's ``max_concurrency``):
+        # - TRACKED test-case run → honor the user's requested value (dial K cases at a time; the rest
+        #   stay 'scheduled' and refill as each finishes). This is what the modal's "Concurrent calls"
+        #   selector controls for a per-case fan-out.
+        # - UNTRACKED load-test → admit all N (max_concurrency = count) and let the per-pod
+        #   MAX_CONCURRENT_CALLS be the throttle (existing behavior).
+        # A batch_id + a non-null limit also enable the completion-refill fast path so a held row dials
+        # the instant a slot frees, and let drain_outbound_capacity retry holds.
+        batch_limit = resolve_batch_concurrency(max_concurrency) if tracked else count
         batch_id = uuid.uuid4()
         now = datetime.now(timezone.utc)
         rows: List[ScheduledCall] = [
@@ -607,16 +637,16 @@ class OutboundCallService(BaseService):
                 organization_id=self.org_id,
                 channel_id=None,
                 from_number=from_number,
-                to_number=valid[i % len(valid)],
+                to_number=to_num,
                 scheduled_at=now,
                 status="scheduled",
                 provider="websocket",
                 created_by_user_id=None,
                 batch_id=batch_id,
-                max_concurrency=count,
-                metadata_={},
+                max_concurrency=batch_limit,
+                metadata_=meta,
             )
-            for i in range(count)
+            for (to_num, meta) in specs
         ]
         self._persist_and_enqueue_rows(rows)
 
@@ -891,6 +921,15 @@ class OutboundCallService(BaseService):
         # an outbound voice pod), so it must NOT require the Twilio BASE_CALL_URL gate.
         base = "" if sc.provider == "websocket" else self._public_base()
         engine = get_call_engine(sc.provider, org_id=sc.organization_id)
+        # Test-case fan-out: a websocket row carries its remote run_id/scenario_id in metadata so the
+        # bridge runs THAT scenario and the remote records it. Only the websocket engine accepts
+        # these; Twilio's signature is untouched.
+        _meta = getattr(sc, "metadata_", None) or {}
+        _ws_extra = (
+            {"ws_run_id": _meta.get("ws_run_id"), "ws_scenario_id": _meta.get("ws_scenario_id")}
+            if sc.provider == "websocket"
+            else {}
+        )
         try:
             info = engine.initiate_call(
                 to_number=sc.to_number,
@@ -898,6 +937,7 @@ class OutboundCallService(BaseService):
                 agent_id=str(sc.agent_id),
                 callback_base_url=base,
                 scheduled_call_id=str(sc.id),
+                **_ws_extra,
             )
         except NoOutboundCapacity as exc:
             # No outbound voice pod free right now — HOLD the row (revert the claim to 'scheduled')

--- a/core/services/pipeline/runner/pipecat.py
+++ b/core/services/pipeline/runner/pipecat.py
@@ -24,6 +24,48 @@ from core.services.pipeline.call_end_events import (
 from core.services.pipeline.runner.base import PipelineRunner
 from core.services.pipeline.tool_call_timing import merge_and_synthesize
 
+# Different transport families announce connect/disconnect under different event names.
+# We map each (connect, disconnect) pair onto the SAME session start/end, so the runner has
+# one provider-agnostic lifecycle hookup — only the transport's data-receive layer differs,
+# never the runner. The third element says whether the disconnect event's payload is a real
+# participant identifier worth logging (telephony/LiveKit) or an opaque object we drop to None
+# (the WS bridge fires the websocket, not a participant). Ordered most-common first.
+_SESSION_EVENT_PAIRS = (
+    ("on_client_connected", "on_client_disconnected", True),              # telephony (FastAPIWebsocket), Daily, SmallWebRTC
+    ("on_first_participant_joined", "on_participant_disconnected", True),  # LiveKit
+    ("on_connected", "on_disconnected", False),                          # outbound WS bridge (WebsocketClientTransport)
+)
+
+
+def _wire_session_events(transport, on_start, on_end) -> None:
+    """Wire a transport's connect/disconnect events to ``on_start``/``on_end``.
+
+    Registers only the ONE event pair the transport actually fires (checked against the
+    transport's registered handlers), replacing per-transport ``type(...).__name__`` checks.
+    This is what lets the OUTBOUND ws-client agent greet on connect exactly like an inbound
+    placed call — ``WebsocketClientTransport`` fires ``on_connected`` (not
+    ``on_client_connected``), and this maps it to the same ``_start_session``.
+    """
+    supported = getattr(transport, "_event_handlers", {}) or {}
+    for connect_event, disconnect_event, carries_participant in _SESSION_EVENT_PAIRS:
+        if connect_event not in supported:
+            continue
+
+        @transport.event_handler(connect_event)
+        async def _on_connect(_transport, *_args, _cb=on_start):
+            await _cb()
+
+        if disconnect_event in supported:
+
+            @transport.event_handler(disconnect_event)
+            async def _on_disconnect(_transport, *args, _cb=on_end, _carries=carries_participant):
+                await _cb(args[0] if (_carries and args) else None)
+        return
+
+    logger.warning(
+        "[runner] no known session connect event on transport {}", type(transport).__name__
+    )
+
 
 class PipecatPipelineRunner(PipelineRunner):
     """Run a Pipecat pipeline built by `PipecatPipelineBuilder`."""
@@ -468,43 +510,16 @@ class PipecatPipelineRunner(PipelineRunner):
                 )
                 logger.exception("task.cancel() failed during client disconnect")
 
-        @transport.event_handler("on_client_connected")
-        async def on_client_connected(transport, client):
-            await _start_session()
-
         @rtvi.event_handler("on_client_ready")
         async def on_client_ready(rtvi):
             logger.debug("Client ready event received")
             await rtvi.set_bot_ready()
 
-        @transport.event_handler("on_client_disconnected")
-        async def on_client_disconnected(transport, participant):
-            await _end_session(participant)
-
-        if type(transport).__name__ == "LiveKitTransport":
-
-            @transport.event_handler("on_first_participant_joined")
-            async def on_first_participant_joined(transport, participant_id):
-                await _start_session()
-
-            @transport.event_handler("on_participant_disconnected")
-            async def on_participant_disconnected(transport, participant_id):
-                await _end_session(participant_id)
-
-        # Outbound WebSocket bridge (WebSocketCallEngine → remote /ws/test): the dial-out
-        # client transport fires on_connected/on_disconnected (NOT on_client_connected), so
-        # the greeting/first_message would never fire and the agent would sit silent until the
-        # remote's own fallback speaks. Wire the client-transport events to the same session
-        # start/end so the OUTBOUND agent greets on connect, like a real placed call.
-        if type(transport).__name__ == "WebsocketClientTransport":
-
-            @transport.event_handler("on_connected")
-            async def on_ws_client_connected(transport, websocket):
-                await _start_session()
-
-            @transport.event_handler("on_disconnected")
-            async def on_ws_client_disconnected(transport, websocket):
-                await _end_session(None)
+        # Map whichever connect/disconnect pair this transport fires onto the same session
+        # start/end (telephony on_client_*, LiveKit participant events, or the outbound WS
+        # bridge's on_connected/on_disconnected) — one provider-agnostic hookup, no
+        # transport-class string-typing. See _wire_session_events.
+        _wire_session_events(transport, _start_session, _end_session)
 
         logger.info("[TIMING] runner setup complete, total: {:.3f}s — starting runner.run()", _time.monotonic() - _t_comp_start)
         runner = PipecatRunner(handle_sigint=getattr(runner_args, "handle_sigint", False))

--- a/core/services/transport/__init__.py
+++ b/core/services/transport/__init__.py
@@ -12,6 +12,10 @@ Layout:
 
     twilio / telnyx / plivo / exotel -> TelephonyProvider per telephony engine
     daily / smallwebrtc              -> CallTransport per WebRTC engine
+    ws_bridge                        -> build_ws_bridge_transport (the OUTBOUND-client mirror
+                                        of TelephonyTransport; dialed by remote URI, not selected
+                                        from RunnerArguments, so it is exported as a builder here
+                                        rather than registered in the RunnerArguments-keyed registry)
 
 To add a new engine: implement the class and register it below — no changes in bot.py.
 """
@@ -36,6 +40,8 @@ from core.services.transport.smallwebrtc import SmallWebRTCCallTransport
 from core.services.transport.telnyx import TelnyxTransport
 from core.services.transport.test_provider import TestTransport
 from core.services.transport.twilio import TwilioTransport
+from core.services.transport.ws_bridge import (BRIDGE_SAMPLE_RATE,
+                                              build_ws_bridge_transport)
 
 # Telephony providers — all ride the shared TelephonyTransport dispatcher.
 register_telephony_provider(TwilioTransport())
@@ -56,6 +62,8 @@ __all__ = [
     "TelephonyProvider",
     "TelephonyTransport",
     "build_transport",
+    "build_ws_bridge_transport",
+    "BRIDGE_SAMPLE_RATE",
     "get_transport",
     "get_telephony_provider",
     "register_transport",

--- a/core/services/transport/ws_bridge.py
+++ b/core/services/transport/ws_bridge.py
@@ -1,0 +1,45 @@
+"""Outbound WebSocket-bridge transport builder.
+
+The inbound telephony path assembles a **server-side** ``FastAPIWebsocketTransport``
+via ``TelephonyTransport`` (``base.py``) — the provider dials us and connects its media
+stream INTO our socket. The outbound WS "test bridge" is its mirror image: a
+**client-side** ``WebsocketClientTransport`` we dial OUT to the remote ``/ws/test``.
+
+Both directions now live in this transport module so they differ only in the socket
+source (server-accepted vs client-dialed) and the serializer; everything downstream of
+``run_bot`` is identical. This construction used to be inline in
+``call_engines/ws_bridge_runner.py::_run_bridge`` — it lives here so there is exactly one
+place that assembles the outbound media transport.
+"""
+
+from pipecat.transports.base_transport import BaseTransport
+from pipecat.transports.websocket.client import (WebsocketClientParams,
+                                                 WebsocketClientTransport)
+
+from core.serializers.raw_pcm import RawPCMSerializer
+
+# The one PCM rate for the whole bridge, raw PCM both ways. It MUST match the remote
+# /ws/test rate (24 kHz = Cartesia's native TTS rate on both ends), so there is ZERO
+# resampling on the TTS→wire→STT path — a 24→16 kHz resample keeps enough energy for VAD
+# but degrades audio enough that Deepgram transcribes NOTHING. The bridge also declares
+# this rate in the /ws/test URL so the two sides can never disagree.
+BRIDGE_SAMPLE_RATE = 24000
+
+
+def build_ws_bridge_transport(
+    remote_uri: str, sample_rate: int = BRIDGE_SAMPLE_RATE
+) -> BaseTransport:
+    """Build the outbound-client media transport that dials the remote ``/ws/test``.
+
+    Mirror of the inbound ``TelephonyTransport`` assembly: same pipeline, opposite socket
+    direction — raw PCM at ``sample_rate`` both ways, no WAV header.
+    """
+    params = WebsocketClientParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+        audio_in_sample_rate=sample_rate,
+        audio_out_sample_rate=sample_rate,
+        add_wav_header=False,
+        serializer=RawPCMSerializer(sample_rate=sample_rate, num_channels=1),
+    )
+    return WebsocketClientTransport(uri=remote_uri, params=params)

--- a/frontend/src/components/agents/AgentEditorShell.tsx
+++ b/frontend/src/components/agents/AgentEditorShell.tsx
@@ -1003,7 +1003,7 @@ export default function AgentEditorShell({ agentType, agentId, children }: Agent
               {/* Body — the routed section */}
               <main className="min-h-0 flex-1 overflow-auto px-5 py-5 lg:px-8 lg:py-6">
                 {loading ? (
-                  <AppLoader className="h-full" />
+                  <AppLoader className="min-h-0 h-full" />
                 ) : (
                   <div
                     className={cn(

--- a/frontend/src/components/outbound-calls/NewOutboundCallModal.tsx
+++ b/frontend/src/components/outbound-calls/NewOutboundCallModal.tsx
@@ -336,17 +336,22 @@ export default function NewOutboundCallModal({
         }
         onClose();
         // parallel_websocket (immediate WS test-bridge fan-out) dials right away, same as immediate.
-        if (res?.mode === 'immediate' || res?.mode === 'parallel_websocket') {
+        const isImmediate = res?.mode === 'immediate' || res?.mode === 'parallel_websocket';
+        if (isImmediate) {
           showToast.success('Calling now', 'The call will appear in Call History.');
-          router.push('/call-history');
         } else {
           showToast.success(
             res?.mode === 'bulk' ? `${res.count} calls queued` : 'Call scheduled',
             'Track them on the agent’s Schedule tab.',
           );
-          // The Schedule view always passes onScheduled to refresh in place; there is no
-          // global scheduled-calls route to navigate to anymore.
-          onScheduled?.();
+        }
+        // Honor the caller's contract: when onScheduled is provided (the agent Schedule tab),
+        // refresh in place and STAY on the page — for every mode, immediate included. Only when
+        // it's omitted (standalone use) do we navigate to Call History.
+        if (onScheduled) {
+          onScheduled();
+        } else {
+          router.push('/call-history');
         }
       } catch (err) {
         // Keep the modal open so the user can correct + retry (error-recovery).

--- a/main.py
+++ b/main.py
@@ -432,6 +432,8 @@ async def ws_bridge_start(request: Request):
             to_number=body.get("to_number") or "",
             from_number=body.get("from_number") or "",
             scheduled_call_id=body.get("scheduled_call_id") or None,
+            ws_run_id=body.get("ws_run_id") or None,
+            ws_scenario_id=body.get("ws_scenario_id") or None,
         )
     except AtCapacity:
         # Expected under load — the originator turns this into a queued (held) scheduled row.

--- a/shared/config.py
+++ b/shared/config.py
@@ -130,6 +130,15 @@ class Settings:
         # call carries no number to route on.
         self.WS_CALL_TARGET_URL: str = get_secret("WS_CALL_TARGET_URL", "").rstrip("/")
         self.WS_CALL_TARGET_AGENT_ID: str = get_secret("WS_CALL_TARGET_AGENT_ID", "")
+        # Single-process / local-dev escape hatch. The WS bridge is normally handed off to a
+        # dedicated outbound-call-worker pod (keeps media OFF the API/orchestrator pod). When no such
+        # pod is registered — e.g. a local `uvicorn main:app` with no WORKER_MODE=voice sibling —
+        # PodPicker.for_outbound finds nothing and the row would hold forever. With this flag ON the
+        # originator runs the bridge IN-PROCESS instead. OFF by default so staging/prod keep the pod
+        # hand-off; set true only for local/single-node runs.
+        self.WS_BRIDGE_ALLOW_INLINE: bool = (
+            get_secret("WS_BRIDGE_ALLOW_INLINE", "false").lower() == "true"
+        )
         # NB: access to the WebSocket ("test bridge") trigger is limited to users whose
         # ``members.role == 'super_admin'`` — see OutboundCallService.is_ws_trigger_allowed. The
         # role is assigned via SQL only (no UI/API), so the allowlist changes without a redeploy.

--- a/test-cases/core/test_call_engines.py
+++ b/test-cases/core/test_call_engines.py
@@ -154,8 +154,47 @@ class TestWebSocketEngine:
         assert posted["json"]["scheduled_call_id"] == "sc-1"
 
     def test_initiate_no_pod_raises_no_capacity(self, monkeypatch):
+        import core.services.call_engines.websocket_engine as we
         from core.services.call_engines.websocket_engine import NoOutboundCapacity
         _patch_outbound_picker(monkeypatch, None, None)  # no live pod
+        monkeypatch.setattr(we.settings, "WS_BRIDGE_ALLOW_INLINE", False)  # default: no inline fallback
+        with pytest.raises(NoOutboundCapacity):
+            get_call_engine("websocket").initiate_call("+1", "+1", agent_id="ag-1", callback_base_url="")
+
+    def test_initiate_no_pod_runs_inline_when_allowed(self, monkeypatch):
+        # WS_BRIDGE_ALLOW_INLINE=true + no pod → run the bridge IN-PROCESS instead of holding.
+        import core.services.call_engines.websocket_engine as we
+        import core.services.call_engines.ws_bridge_runner as r
+        _patch_outbound_picker(monkeypatch, None, None)  # no live pod
+        monkeypatch.setattr(we.settings, "WS_BRIDGE_ALLOW_INLINE", True)
+        called = {}
+
+        def fake_start_local_bridge(agent_id, to_number, from_number="", scheduled_call_id=None,
+                                    ws_run_id=None, ws_scenario_id=None):
+            called.update(agent_id=agent_id, to_number=to_number, scheduled_call_id=scheduled_call_id)
+            return "INLINE-CALL"
+
+        monkeypatch.setattr(r, "start_local_bridge", fake_start_local_bridge)
+        info = get_call_engine("websocket").initiate_call(
+            "+19894742667", "+1", agent_id="ag-1", callback_base_url="", scheduled_call_id="sc-9",
+        )
+        assert info.provider == "websocket" and info.status == "dialing"
+        assert info.call_id == "INLINE-CALL"
+        assert called["agent_id"] == "ag-1" and called["to_number"] == "+19894742667"
+        assert called["scheduled_call_id"] == "sc-9"
+
+    def test_initiate_inline_at_capacity_raises_no_capacity(self, monkeypatch):
+        # Inline bridge already at MAX_CONCURRENT_CALLS → AtCapacity → NoOutboundCapacity (row holds).
+        import core.services.call_engines.websocket_engine as we
+        import core.services.call_engines.ws_bridge_runner as r
+        from core.services.call_engines.websocket_engine import NoOutboundCapacity
+        _patch_outbound_picker(monkeypatch, None, None)
+        monkeypatch.setattr(we.settings, "WS_BRIDGE_ALLOW_INLINE", True)
+
+        def fake_at_capacity(*a, **k):
+            raise r.AtCapacity("full")
+
+        monkeypatch.setattr(r, "start_local_bridge", fake_at_capacity)
         with pytest.raises(NoOutboundCapacity):
             get_call_engine("websocket").initiate_call("+1", "+1", agent_id="ag-1", callback_base_url="")
 
@@ -250,3 +289,94 @@ class TestWsBridgeRunner:
                 r.start_local_bridge(agent_id="ag-1", to_number="+1")
         finally:
             r._SESSIONS.clear()
+
+
+class TestWsBridgeTransportBuilder:
+    """The outbound-client transport is assembled by the shared transport module (B1),
+    the mirror of the inbound TelephonyTransport — same pipeline, opposite socket source."""
+
+    def test_builds_ws_client_with_raw_pcm(self):
+        from core.serializers.raw_pcm import RawPCMSerializer
+        from core.services.transport.ws_bridge import (BRIDGE_SAMPLE_RATE,
+                                                      build_ws_bridge_transport)
+
+        t = build_ws_bridge_transport("wss://remote/ws/test?phone_number=1&sample_rate=24000")
+        assert type(t).__name__ == "WebsocketClientTransport"
+        params = t._params
+        assert isinstance(params.serializer, RawPCMSerializer)
+        assert params.add_wav_header is False
+        assert params.audio_in_sample_rate == BRIDGE_SAMPLE_RATE
+        assert params.audio_out_sample_rate == BRIDGE_SAMPLE_RATE
+
+    def test_runner_single_sources_rate_and_builder(self):
+        # ws_bridge_runner no longer builds the transport inline — it delegates to the
+        # shared builder and single-sources the rate from the transport module.
+        import core.services.call_engines.ws_bridge_runner as r
+        from core.services.transport.ws_bridge import BRIDGE_SAMPLE_RATE
+
+        assert r._BRIDGE_SAMPLE_RATE == BRIDGE_SAMPLE_RATE
+        assert r.build_ws_bridge_transport is not None
+
+
+class TestSessionEventWiring:
+    """_wire_session_events (B2) maps each transport family's connect/disconnect onto ONE
+    session start/end — no transport-class string-typing; the outbound WS client's
+    on_connected drives the same greeting as an inbound on_client_connected."""
+
+    class _EH:
+        def __init__(self):
+            self.handlers = []
+
+    def _fake_transport(self, events):
+        from types import SimpleNamespace
+        reg: dict = {}
+        eh = {e: self._EH() for e in events}
+
+        def event_handler(name):
+            def deco(fn):
+                eh.setdefault(name, self._EH()).handlers.append(fn)
+                reg.setdefault(name, []).append(fn)
+                return fn
+            return deco
+
+        return SimpleNamespace(_event_handlers=eh, event_handler=event_handler, registered=reg)
+
+    # expected_participant: telephony/LiveKit carry a real participant id; the WS bridge fires
+    # the websocket object, which is dropped to None (preserving the prior on_disconnected behavior).
+    @pytest.mark.parametrize("events,connect,disconnect,expected_participant", [
+        (["on_client_connected", "on_client_disconnected"],
+         "on_client_connected", "on_client_disconnected", "participant-x"),
+        (["on_first_participant_joined", "on_participant_disconnected"],
+         "on_first_participant_joined", "on_participant_disconnected", "participant-x"),
+        (["on_connected", "on_disconnected"], "on_connected", "on_disconnected", None),
+    ])
+    def test_wires_correct_pair_and_fires(self, events, connect, disconnect, expected_participant):
+        import asyncio
+
+        from core.services.pipeline.runner.pipecat import _wire_session_events
+
+        started, ended = [], []
+
+        async def on_start():
+            started.append(1)
+
+        async def on_end(p):
+            ended.append(p)
+
+        t = self._fake_transport(events)
+        _wire_session_events(t, on_start, on_end)
+        assert set(t.registered) == {connect, disconnect}
+        asyncio.run(t.registered[connect][0](t))
+        asyncio.run(t.registered[disconnect][0](t, "participant-x"))
+        assert started == [1]
+        assert ended == [expected_participant]
+
+    def test_unknown_transport_warns_no_crash(self):
+        from core.services.pipeline.runner.pipecat import _wire_session_events
+
+        async def noop(*a):
+            pass
+
+        t = self._fake_transport(["on_nonsense"])
+        _wire_session_events(t, noop, noop)  # must not raise
+        assert t.registered == {}

--- a/test-cases/core/test_ws_bridge_testcases.py
+++ b/test-cases/core/test_ws_bridge_testcases.py
@@ -1,0 +1,109 @@
+"""Unit tests for the WS-bridge test-case fan-out plumbing (havana side).
+
+Covers the two pure seams that carry a remote TestRun scenario through the bridge:
+- ``ws_test_client._http_base`` (ws→http / wss→https derivation).
+- ``ws_bridge_runner._remote_uri`` appending run_id + scenario_id.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import core.services.call_engines.ws_bridge_runner as r
+import core.services.call_engines.ws_test_client as client
+import core.services.call_engines.ws_test_client as _ws_client_mod
+import core.services.outbound_call_service as ocs
+
+
+class TestHttpBaseDerivation:
+    def test_ws_becomes_http(self, monkeypatch):
+        monkeypatch.setattr(client.settings, "WS_CALL_TARGET_URL", "ws://localhost:8000")
+        assert client._http_base() == "http://localhost:8000"
+
+    def test_wss_becomes_https(self, monkeypatch):
+        monkeypatch.setattr(client.settings, "WS_CALL_TARGET_URL", "wss://staging-test.trytone.ai/")
+        assert client._http_base() == "https://staging-test.trytone.ai"
+
+    def test_empty_is_none(self, monkeypatch):
+        monkeypatch.setattr(client.settings, "WS_CALL_TARGET_URL", "")
+        assert client._http_base() is None
+
+
+class TestRemoteUriCarriesScenario:
+    def test_plain_uri_no_scenario(self, monkeypatch):
+        monkeypatch.setattr(r.settings, "WS_CALL_TARGET_URL", "ws://remote")
+        monkeypatch.setattr(r.settings, "WS_CALL_TARGET_AGENT_ID", "")
+        uri = r._remote_uri("+13186201704", "ag-1")
+        assert uri == "ws://remote/ws/test?phone_number=%2B13186201704&sample_rate=24000"
+        assert "run_id" not in uri and "scenario_id" not in uri
+
+    def test_uri_carries_run_and_scenario(self, monkeypatch):
+        monkeypatch.setattr(r.settings, "WS_CALL_TARGET_URL", "ws://remote")
+        monkeypatch.setattr(r.settings, "WS_CALL_TARGET_AGENT_ID", "")
+        uri = r._remote_uri("+13186201704", "ag-1", "RUN-9", "SCEN-7")
+        assert "run_id=RUN-9" in uri and "scenario_id=SCEN-7" in uri
+        assert uri.startswith("ws://remote/ws/test?phone_number=%2B13186201704&sample_rate=24000")
+
+    def test_partial_ids_are_ignored(self, monkeypatch):
+        # Both must be present to be appended (a run without a scenario is meaningless).
+        monkeypatch.setattr(r.settings, "WS_CALL_TARGET_URL", "ws://remote")
+        monkeypatch.setattr(r.settings, "WS_CALL_TARGET_AGENT_ID", "")
+        uri = r._remote_uri("+1", "ag-1", "RUN-9", None)
+        assert "run_id" not in uri and "scenario_id" not in uri
+
+
+class TestTrackedFanout:
+    """The test-case fan-out: one row PER scenario, honoring the requested concurrency (not the
+    scenario count) as the per-batch limit, each row tagged with run_id + scenario_id."""
+
+    def test_fanout_one_row_per_scenario_respects_concurrency(self, monkeypatch):
+        svc = ocs.OutboundCallService(MagicMock(), org_id=uuid4())
+        agent = SimpleNamespace(id=uuid4())
+
+        # Remote resolves the number to a run with 5 scenarios.
+        monkeypatch.setattr(
+            _ws_client_mod,
+            "prepare_bridge_run",
+            lambda num: {
+                "run_id": "RUN-1",
+                "scenarios": [{"scenario_id": f"S{i}"} for i in range(5)],
+            },
+        )
+        # No env ceiling → resolve_batch_concurrency(2) == 2 (used as-is).
+        monkeypatch.setattr(ocs, "get_env_outbound_ceiling", lambda: None)
+        import core.services.outbound_capacity as cap
+        monkeypatch.setattr(cap, "get_env_outbound_ceiling", lambda: None)
+
+        captured = {}
+        monkeypatch.setattr(svc, "_persist_and_enqueue_rows", lambda rows: captured.update(rows=rows))
+        monkeypatch.setattr(svc, "dispatch_scheduled_call", lambda _id: None)
+
+        svc._dial_parallel_ws(agent, "+1000", ["+13186201704"], max_concurrency=2, invalid=[])
+
+        rows = captured["rows"]
+        # 5 scenarios → 5 rows (one per case), NOT capped to the requested 2.
+        assert len(rows) == 5
+        # Per-batch limit is the REQUESTED concurrency (2), not the scenario count (5).
+        assert {row.max_concurrency for row in rows} == {2}
+        # One shared batch, each row carries its scenario + the run.
+        assert len({row.batch_id for row in rows}) == 1
+        assert sorted(row.metadata_["ws_scenario_id"] for row in rows) == [
+            "S0", "S1", "S2", "S3", "S4",
+        ]
+        assert {row.metadata_["ws_run_id"] for row in rows} == {"RUN-1"}
+
+    def test_untracked_fanout_falls_back_to_count(self, monkeypatch):
+        # Number with no remote scenarios → untracked load-test fan-out: N = requested, no metadata.
+        svc = ocs.OutboundCallService(MagicMock(), org_id=uuid4())
+        agent = SimpleNamespace(id=uuid4())
+        monkeypatch.setattr(_ws_client_mod, "prepare_bridge_run", lambda num: None)
+        captured = {}
+        monkeypatch.setattr(svc, "_persist_and_enqueue_rows", lambda rows: captured.update(rows=rows))
+        monkeypatch.setattr(svc, "dispatch_scheduled_call", lambda _id: None)
+
+        svc._dial_parallel_ws(agent, "+1000", ["+19998887777"], max_concurrency=3, invalid=[])
+
+        rows = captured["rows"]
+        assert len(rows) == 3  # untracked: N = requested count
+        assert all(not row.metadata_ for row in rows)  # no scenario metadata
+        assert {row.max_concurrency for row in rows} == {3}  # admit-all (count)


### PR DESCRIPTION
…(#914)

* feat(contacts): Contact Directories module + scheduled/outbound call wiring

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage



* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817) (#818)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(readiness): agent readiness run-history browsing + force re-run (#822) (#823)

* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817) (#818)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(readiness): add run-history browsing + force-run flag

Backend:
- New GET /agent/{id}/readiness/runs (deep-only, newest first, metadata) and /runs/{run_number} (full stored report) on core + EE routers, org-scoped via _require_agent; unmappable legacy rows are skipped/404'd with tracebacks.
- ReadinessRequest gains `force` to bypass the read-through snapshot + coalesce caches for explicit user-initiated deep runs so each appends a fresh event.
- _read_fresh_snapshot: a shallow read now accepts the newest deep snapshot (deep is a superset) so a deep result survives page reloads.
- Unify snapshot/event mapping (_row_to_report, _counts_from_row).

Frontend:
- Run-history select in ReadinessDrawer (read-only past runs) backed by a useRunHistorySelect hook + readinessHelpers; SelectInput gains renderOption/ renderValue for rich rows.
- Header badge stays in sync with the drawer's live report.

Review fixes:
- Exclude the live run_number from history options (no duplicate row).
- Refresh no longer forces a persisted shallow run (avoids spurious events and silent badge reset); force stays on the deep "Run deep test" button.

Tests: run-history list/get, limit bounds, auth denial, deep-only filtering, unmappable-row skip (core + EE).



* refactor(readiness): move list-badge lookup into ReadinessService

Embed last-known readiness on each agent-list row (removes the old per-row /readiness/summary N+1) and keep the data access in the service layer:

- Add ReadinessService.latest_for_agents(agent_ids): batch, org-scoped, projected-column lookup for the list badge (skips the heavy checks blob).
- Single-source the count-fallback set via _counts_from_mapping; both the row mappers and the list-badge lookup reuse it.
- Router now calls the service instead of a raw AgentReadinessSnapshot query; drop the redundant function-local ReadinessService import.
- Frontend: AgentReadinessCell renders the embedded readiness (no per-row fetch); add AgentListReadiness type + regression tests.



---------




* feat(readiness): agent readiness run-history browsing + force re-run (#822) (#823) (#825)

* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817) (#818)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(readiness): add run-history browsing + force-run flag

Backend:
- New GET /agent/{id}/readiness/runs (deep-only, newest first, metadata) and /runs/{run_number} (full stored report) on core + EE routers, org-scoped via _require_agent; unmappable legacy rows are skipped/404'd with tracebacks.
- ReadinessRequest gains `force` to bypass the read-through snapshot + coalesce caches for explicit user-initiated deep runs so each appends a fresh event.
- _read_fresh_snapshot: a shallow read now accepts the newest deep snapshot (deep is a superset) so a deep result survives page reloads.
- Unify snapshot/event mapping (_row_to_report, _counts_from_row).

Frontend:
- Run-history select in ReadinessDrawer (read-only past runs) backed by a useRunHistorySelect hook + readinessHelpers; SelectInput gains renderOption/ renderValue for rich rows.
- Header badge stays in sync with the drawer's live report.

Review fixes:
- Exclude the live run_number from history options (no duplicate row).
- Refresh no longer forces a persisted shallow run (avoids spurious events and silent badge reset); force stays on the deep "Run deep test" button.

Tests: run-history list/get, limit bounds, auth denial, deep-only filtering, unmappable-row skip (core + EE).



* refactor(readiness): move list-badge lookup into ReadinessService

Embed last-known readiness on each agent-list row (removes the old per-row /readiness/summary N+1) and keep the data access in the service layer:

- Add ReadinessService.latest_for_agents(agent_ids): batch, org-scoped, projected-column lookup for the list badge (skips the heavy checks blob).
- Single-source the count-fallback set via _counts_from_mapping; both the row mappers and the list-badge lookup reuse it.
- Router now calls the service instead of a raw AgentReadinessSnapshot query; drop the redundant function-local ReadinessService import.
- Frontend: AgentReadinessCell renders the embedded readiness (no per-row fetch); add AgentListReadiness type + regression tests.



---------




* feat(contacts): date/datetime metadata handling + review fixes

Contacts Directories + scheduled/outbound-call delta, plus the fixes from the PR review and the grilled date/datetime design.

Correctness / review fixes:
- Guard ragged-CSV rows in the shared row mapper so a trailing comma / extra column no longer crashes the whole import (500) — regression test.
- update_contact merges submitted metadata over existing UNMANAGED keys so an edit can't wipe metadata owned by another schema — regression test.
- contact sync: count metadata-validation failures under counts.failed (was always 0), distinct from structural skips.
- outbound: correct the caller-id "spreads evenly" docstring (per-batch resolution is by design).
- FE: DateRangePicker reuses shared TimezoneSelect; ContactSchemaSection reads role from the single useAuthStore; ContactDirectoryRail row is a role="button" element; NewOutboundCallModal drops the redundant toIso.

Date/datetime manual entry (Hybrid design):
- New shared normalize_contact_metadata_dates() reuses parse_datetime_value so manual create/update store the same UTC-ISO shape as the CSV sync path; manual entry rejects unparseable values (400 / failed row).
- SchemaDrivenContactForm renders the shared DateTimePicker for date/datetime fields (repo mandate); datetime_format/timezone metadata is CSV-only.

Docs: add a code-review note on CONCURRENTLY for indexes on populated columns (with the empty-new-column exception).

* Feature/staging aws/contacts scheduled calls (#837) (#838)

* feat(contacts): Contact Directories module + scheduled/outbound call wiring

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage



* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817) (#818)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(readiness): agent readiness run-history browsing + force re-run (#822) (#823)

* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817) (#818)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(readiness): add run-history browsing + force-run flag

Backend:
- New GET /agent/{id}/readiness/runs (deep-only, newest first, metadata) and /runs/{run_number} (full stored report) on core + EE routers, org-scoped via _require_agent; unmappable legacy rows are skipped/404'd with tracebacks.
- ReadinessRequest gains `force` to bypass the read-through snapshot + coalesce caches for explicit user-initiated deep runs so each appends a fresh event.
- _read_fresh_snapshot: a shallow read now accepts the newest deep snapshot (deep is a superset) so a deep result survives page reloads.
- Unify snapshot/event mapping (_row_to_report, _counts_from_row).

Frontend:
- Run-history select in ReadinessDrawer (read-only past runs) backed by a useRunHistorySelect hook + readinessHelpers; SelectInput gains renderOption/ renderValue for rich rows.
- Header badge stays in sync with the drawer's live report.

Review fixes:
- Exclude the live run_number from history options (no duplicate row).
- Refresh no longer forces a persisted shallow run (avoids spurious events and silent badge reset); force stays on the deep "Run deep test" button.

Tests: run-history list/get, limit bounds, auth denial, deep-only filtering, unmappable-row skip (core + EE).



* refactor(readiness): move list-badge lookup into ReadinessService

Embed last-known readiness on each agent-list row (removes the old per-row /readiness/summary N+1) and keep the data access in the service layer:

- Add ReadinessService.latest_for_agents(agent_ids): batch, org-scoped, projected-column lookup for the list badge (skips the heavy checks blob).
- Single-source the count-fallback set via _counts_from_mapping; both the row mappers and the list-badge lookup reuse it.
- Router now calls the service instead of a raw AgentReadinessSnapshot query; drop the redundant function-local ReadinessService import.
- Frontend: AgentReadinessCell renders the embedded readiness (no per-row fetch); add AgentListReadiness type + regression tests.



---------




* feat(readiness): agent readiness run-history browsing + force re-run (#822) (#823) (#825)

* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817) (#818)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(readiness): add run-history browsing + force-run flag

Backend:
- New GET /agent/{id}/readiness/runs (deep-only, newest first, metadata) and /runs/{run_number} (full stored report) on core + EE routers, org-scoped via _require_agent; unmappable legacy rows are skipped/404'd with tracebacks.
- ReadinessRequest gains `force` to bypass the read-through snapshot + coalesce caches for explicit user-initiated deep runs so each appends a fresh event.
- _read_fresh_snapshot: a shallow read now accepts the newest deep snapshot (deep is a superset) so a deep result survives page reloads.
- Unify snapshot/event mapping (_row_to_report, _counts_from_row).

Frontend:
- Run-history select in ReadinessDrawer (read-only past runs) backed by a useRunHistorySelect hook + readinessHelpers; SelectInput gains renderOption/ renderValue for rich rows.
- Header badge stays in sync with the drawer's live report.

Review fixes:
- Exclude the live run_number from history options (no duplicate row).
- Refresh no longer forces a persisted shallow run (avoids spurious events and silent badge reset); force stays on the deep "Run deep test" button.

Tests: run-history list/get, limit bounds, auth denial, deep-only filtering, unmappable-row skip (core + EE).



* refactor(readiness): move list-badge lookup into ReadinessService

Embed last-known readiness on each agent-list row (removes the old per-row /readiness/summary N+1) and keep the data access in the service layer:

- Add ReadinessService.latest_for_agents(agent_ids): batch, org-scoped, projected-column lookup for the list badge (skips the heavy checks blob).
- Single-source the count-fallback set via _counts_from_mapping; both the row mappers and the list-badge lookup reuse it.
- Router now calls the service instead of a raw AgentReadinessSnapshot query; drop the redundant function-local ReadinessService import.
- Frontend: AgentReadinessCell renders the embedded readiness (no per-row fetch); add AgentListReadiness type + regression tests.



---------




* feat(contacts): date/datetime metadata handling + review fixes

Contacts Directories + scheduled/outbound-call delta, plus the fixes from the PR review and the grilled date/datetime design.

Correctness / review fixes:
- Guard ragged-CSV rows in the shared row mapper so a trailing comma / extra column no longer crashes the whole import (500) — regression test.
- update_contact merges submitted metadata over existing UNMANAGED keys so an edit can't wipe metadata owned by another schema — regression test.
- contact sync: count metadata-validation failures under counts.failed (was always 0), distinct from structural skips.
- outbound: correct the caller-id "spreads evenly" docstring (per-batch resolution is by design).
- FE: DateRangePicker reuses shared TimezoneSelect; ContactSchemaSection reads role from the single useAuthStore; ContactDirectoryRail row is a role="button" element; NewOutboundCallModal drops the redundant toIso.

Date/datetime manual entry (Hybrid design):
- New shared normalize_contact_metadata_dates() reuses parse_datetime_value so manual create/update store the same UTC-ISO shape as the CSV sync path; manual entry rejects unparseable values (400 / failed row).
- SchemaDrivenContactForm renders the shared DateTimePicker for date/datetime fields (repo mandate); datetime_format/timezone metadata is CSV-only.

Docs: add a code-review note on CONCURRENTLY for indexes on populated columns (with the empty-new-column exception).

---------





* Feature/staging aws/contacts scheduled calls (#837) (#838) (#839)

* feat(contacts): Contact Directories module + scheduled/outbound call wiring

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage



* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817) (#818)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(readiness): agent readiness run-history browsing + force re-run (#822) (#823)

* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817) (#818)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(readiness): add run-history browsing + force-run flag

Backend:
- New GET /agent/{id}/readiness/runs (deep-only, newest first, metadata) and /runs/{run_number} (full stored report) on core + EE routers, org-scoped via _require_agent; unmappable legacy rows are skipped/404'd with tracebacks.
- ReadinessRequest gains `force` to bypass the read-through snapshot + coalesce caches for explicit user-initiated deep runs so each appends a fresh event.
- _read_fresh_snapshot: a shallow read now accepts the newest deep snapshot (deep is a superset) so a deep result survives page reloads.
- Unify snapshot/event mapping (_row_to_report, _counts_from_row).

Frontend:
- Run-history select in ReadinessDrawer (read-only past runs) backed by a useRunHistorySelect hook + readinessHelpers; SelectInput gains renderOption/ renderValue for rich rows.
- Header badge stays in sync with the drawer's live report.

Review fixes:
- Exclude the live run_number from history options (no duplicate row).
- Refresh no longer forces a persisted shallow run (avoids spurious events and silent badge reset); force stays on the deep "Run deep test" button.

Tests: run-history list/get, limit bounds, auth denial, deep-only filtering, unmappable-row skip (core + EE).



* refactor(readiness): move list-badge lookup into ReadinessService

Embed last-known readiness on each agent-list row (removes the old per-row /readiness/summary N+1) and keep the data access in the service layer:

- Add ReadinessService.latest_for_agents(agent_ids): batch, org-scoped, projected-column lookup for the list badge (skips the heavy checks blob).
- Single-source the count-fallback set via _counts_from_mapping; both the row mappers and the list-badge lookup reuse it.
- Router now calls the service instead of a raw AgentReadinessSnapshot query; drop the redundant function-local ReadinessService import.
- Frontend: AgentReadinessCell renders the embedded readiness (no per-row fetch); add AgentListReadiness type + regression tests.



---------




* feat(readiness): agent readiness run-history browsing + force re-run (#822) (#823) (#825)

* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817) (#818)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(readiness): add run-history browsing + force-run flag

Backend:
- New GET /agent/{id}/readiness/runs (deep-only, newest first, metadata) and /runs/{run_number} (full stored report) on core + EE routers, org-scoped via _require_agent; unmappable legacy rows are skipped/404'd with tracebacks.
- ReadinessRequest gains `force` to bypass the read-through snapshot + coalesce caches for explicit user-initiated deep runs so each appends a fresh event.
- _read_fresh_snapshot: a shallow read now accepts the newest deep snapshot (deep is a superset) so a deep result survives page reloads.
- Unify snapshot/event mapping (_row_to_report, _counts_from_row).

Frontend:
- Run-history select in ReadinessDrawer (read-only past runs) backed by a useRunHistorySelect hook + readinessHelpers; SelectInput gains renderOption/ renderValue for rich rows.
- Header badge stays in sync with the drawer's live report.

Review fixes:
- Exclude the live run_number from history options (no duplicate row).
- Refresh no longer forces a persisted shallow run (avoids spurious events and silent badge reset); force stays on the deep "Run deep test" button.

Tests: run-history list/get, limit bounds, auth denial, deep-only filtering, unmappable-row skip (core + EE).



* refactor(readiness): move list-badge lookup into ReadinessService

Embed last-known readiness on each agent-list row (removes the old per-row /readiness/summary N+1) and keep the data access in the service layer:

- Add ReadinessService.latest_for_agents(agent_ids): batch, org-scoped, projected-column lookup for the list badge (skips the heavy checks blob).
- Single-source the count-fallback set via _counts_from_mapping; both the row mappers and the list-badge lookup reuse it.
- Router now calls the service instead of a raw AgentReadinessSnapshot query; drop the redundant function-local ReadinessService import.
- Frontend: AgentReadinessCell renders the embedded readiness (no per-row fetch); add AgentListReadiness type + regression tests.



---------




* feat(contacts): date/datetime metadata handling + review fixes

Contacts Directories + scheduled/outbound-call delta, plus the fixes from the PR review and the grilled date/datetime design.

Correctness / review fixes:
- Guard ragged-CSV rows in the shared row mapper so a trailing comma / extra column no longer crashes the whole import (500) — regression test.
- update_contact merges submitted metadata over existing UNMANAGED keys so an edit can't wipe metadata owned by another schema — regression test.
- contact sync: count metadata-validation failures under counts.failed (was always 0), distinct from structural skips.
- outbound: correct the caller-id "spreads evenly" docstring (per-batch resolution is by design).
- FE: DateRangePicker reuses shared TimezoneSelect; ContactSchemaSection reads role from the single useAuthStore; ContactDirectoryRail row is a role="button" element; NewOutboundCallModal drops the redundant toIso.

Date/datetime manual entry (Hybrid design):
- New shared normalize_contact_metadata_dates() reuses parse_datetime_value so manual create/update store the same UTC-ISO shape as the CSV sync path; manual entry rejects unparseable values (400 / failed row).
- SchemaDrivenContactForm renders the shared DateTimePicker for date/datetime fields (repo mandate); datetime_format/timezone metadata is CSV-only.

Docs: add a code-review note on CONCURRENTLY for indexes on populated columns (with the empty-new-column exception).

---------





* fix(contacts/outbound): address PR review comments + land scheduled-calls WIP

Review-comment fixes:
- row_mapping: sort by stringified key when hashing external_id so a ragged CSV row (None restkey, no phone/external_id) no longer crashes the import; add regression test for the no-phone hash branch.
- contact_directory_service: fix loguru %s -> {} in the provisioning log.
- ContactDirectory: add partial unique index (one live "Global" per org) + new migration e5a2c9d4f1b8 (CONCURRENTLY, idempotent); make get_or_create_default_directory race-tolerant (rollback + return winner).
- contact_schema_service: strip non [a-z0-9-] from the sample-file slug so an odd schema name can't corrupt the Content-Disposition filename.
- NewOutboundCallModal: gate useSchemasList/useDirectoriesList on open && uploadMode (add enabled option to useSchemasList) to avoid eager fetches for manual-number users.
- SchemaFieldsEditor: map legacy `date` format to `datetime` in openEdit so the Type selector resolves instead of rendering blank.

Also lands the remaining contacts + scheduled-calls feature WIP (per-batch outbound concurrency, file-upload ingestion path, org scheduling timezone).



* Feature/staging aws/contacts scheduled calls (#852) (#853)

* feat(contacts): Contact Directories module + scheduled/outbound call wiring

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage



* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817) (#818)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(readiness): agent readiness run-history browsing + force re-run (#822) (#823)

* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817) (#818)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(readiness): add run-history browsing + force-run flag

Backend:
- New GET /agent/{id}/readiness/runs (deep-only, newest first, metadata) and /runs/{run_number} (full stored report) on core + EE routers, org-scoped via _require_agent; unmappable legacy rows are skipped/404'd with tracebacks.
- ReadinessRequest gains `force` to bypass the read-through snapshot + coalesce caches for explicit user-initiated deep runs so each appends a fresh event.
- _read_fresh_snapshot: a shallow read now accepts the newest deep snapshot (deep is a superset) so a deep result survives page reloads.
- Unify snapshot/event mapping (_row_to_report, _counts_from_row).

Frontend:
- Run-history select in ReadinessDrawer (read-only past runs) backed by a useRunHistorySelect hook + readinessHelpers; SelectInput gains renderOption/ renderValue for rich rows.
- Header badge stays in sync with the drawer's live report.

Review fixes:
- Exclude the live run_number from history options (no duplicate row).
- Refresh no longer forces a persisted shallow run (avoids spurious events and silent badge reset); force stays on the deep "Run deep test" button.

Tests: run-history list/get, limit bounds, auth denial, deep-only filtering, unmappable-row skip (core + EE).



* refactor(readiness): move list-badge lookup into ReadinessService

Embed last-known readiness on each agent-list row (removes the old per-row /readiness/summary N+1) and keep the data access in the service layer:

- Add ReadinessService.latest_for_agents(agent_ids): batch, org-scoped, projected-column lookup for the list badge (skips the heavy checks blob).
- Single-source the count-fallback set via _counts_from_mapping; both the row mappers and the list-badge lookup reuse it.
- Router now calls the service instead of a raw AgentReadinessSnapshot query; drop the redundant function-local ReadinessService import.
- Frontend: AgentReadinessCell renders the embedded readiness (no per-row fetch); add AgentListReadiness type + regression tests.



---------




* feat(readiness): agent readiness run-history browsing + force re-run (#822) (#823) (#825)

* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817) (#818)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(readiness): add run-history browsing + force-run flag

Backend:
- New GET /agent/{id}/readiness/runs (deep-only, newest first, metadata) and /runs/{run_number} (full stored report) on core + EE routers, org-scoped via _require_agent; unmappable legacy rows are skipped/404'd with tracebacks.
- ReadinessRequest gains `force` to bypass the read-through snapshot + coalesce caches for explicit user-initiated deep runs so each appends a fresh event.
- _read_fresh_snapshot: a shallow read now accepts the newest deep snapshot (deep is a superset) so a deep result survives page reloads.
- Unify snapshot/event mapping (_row_to_report, _counts_from_row).

Frontend:
- Run-history select in ReadinessDrawer (read-only past runs) backed by a useRunHistorySelect hook + readinessHelpers; SelectInput gains renderOption/ renderValue for rich rows.
- Header badge stays in sync with the drawer's live report.

Review fixes:
- Exclude the live run_number from history options (no duplicate row).
- Refresh no longer forces a persisted shallow run (avoids spurious events and silent badge reset); force stays on the deep "Run deep test" button.

Tests: run-history list/get, limit bounds, auth denial, deep-only filtering, unmappable-row skip (core + EE).



* refactor(readiness): move list-badge lookup into ReadinessService

Embed last-known readiness on each agent-list row (removes the old per-row /readiness/summary N+1) and keep the data access in the service layer:

- Add ReadinessService.latest_for_agents(agent_ids): batch, org-scoped, projected-column lookup for the list badge (skips the heavy checks blob).
- Single-source the count-fallback set via _counts_from_mapping; both the row mappers and the list-badge lookup reuse it.
- Router now calls the service instead of a raw AgentReadinessSnapshot query; drop the redundant function-local ReadinessService import.
- Frontend: AgentReadinessCell renders the embedded readiness (no per-row fetch); add AgentListReadiness type + regression tests.



---------




* feat(contacts): date/datetime metadata handling + review fixes

Contacts Directories + scheduled/outbound-call delta, plus the fixes from the PR review and the grilled date/datetime design.

Correctness / review fixes:
- Guard ragged-CSV rows in the shared row mapper so a trailing comma / extra column no longer crashes the whole import (500) — regression test.
- update_contact merges submitted metadata over existing UNMANAGED keys so an edit can't wipe metadata owned by another schema — regression test.
- contact sync: count metadata-validation failures under counts.failed (was always 0), distinct from structural skips.
- outbound: correct the caller-id "spreads evenly" docstring (per-batch resolution is by design).
- FE: DateRangePicker reuses shared TimezoneSelect; ContactSchemaSection reads role from the single useAuthStore; ContactDirectoryRail row is a role="button" element; NewOutboundCallModal drops the redundant toIso.

Date/datetime manual entry (Hybrid design):
- New shared normalize_contact_metadata_dates() reuses parse_datetime_value so manual create/update store the same UTC-ISO shape as the CSV sync path; manual entry rejects unparseable values (400 / failed row).
- SchemaDrivenContactForm renders the shared DateTimePicker for date/datetime fields (repo mandate); datetime_format/timezone metadata is CSV-only.

Docs: add a code-review note on CONCURRENTLY for indexes on populated columns (with the empty-new-column exception).

* Feature/staging aws/contacts scheduled calls (#837) (#838)

* feat(contacts): Contact Directories module + scheduled/outbound call wiring

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage



* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/standards:
- Reuse & service-layer single-source-of-truth rule (frontend rules.md §13 + CLAUDE.md code-review blockers); shared-components doc entry for CollapsibleSection

Tests: contacts/directories/datasources/schemas/syncs coverage




* feat(contacts): Contact Directories module + scheduled/outbound call wiring (#816) (#817) (#818)

Backend:
- Contact Directories, datasources, org schemas (schema_fields), contacts, agent_contacts, and contact_syncs models + thin routers under /api/v1
- Service layer: contact CRUD/upsert, metadata validation, ingestion/mapping, sync pipeline (Procrastinate), directory delete impact/hard-delete
- Shared helpers: list_query, require_admin_or_owner guard, BaseService.get_or_404
- Alembic: create contacts/syncs tables (6ab783e9080f) + merge head (0cf24b3d86dc); contact_syncs gains optional app_id/connection_id columns
- create_contacts optionally assigns created contacts to an agent in the service

Frontend:
- Contacts pages (directories, sync history) + Agent Contacts tab
- Reusable lib/api clients, queryKeys, usePaginatedList; contacts shared components
- New shared CollapsibleSection primitive; Advanced-configuration directory override in the agent Add/Sync modals (defaults to Global by name)
- DateTimePicker + download util

Docs/sta…