### PR TITLE
FIx pipecat submodule in .gitmodules and notes for deployment 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,186 @@
+# Tone — example environment file.
+#
+# Copy to `.env` and fill in the values you need:
+#
+#     cp .env.example .env
+#
+# Every key below is read by `shared/config.py` (the single Settings object).
+# Defaults shown in comments are the ones baked into that file — a key you
+# leave out falls back to them. Only the keys marked REQUIRED must be set.
+#
+# Precedence: Infisical (when INFISICAL_TOKEN + INFISICAL_PROJECT_ID are set)
+# wins over the value here; otherwise plain env / this file is used. Infisical
+# is optional — `get_infisical_secrets()` returns {} without those two vars and
+# every lookup falls through to os.getenv.
+
+
+# ── Core (required) ──────────────────────────────────────────────────
+# Postgres must have the pgvector extension available: the initial migration
+# runs `CREATE EXTENSION IF NOT EXISTS vector`. `docker compose up -d` starts a
+# pgvector-enabled Postgres and a Redis matching the defaults below.
+
+# REQUIRED — no default.
+DATABASE_URL=postgresql://tone:tone@localhost:5432/tone
+
+# REQUIRED in practice — defaults to the placeholder "your-secret-key-here".
+# NOTE: this key is not only for JWTs. `core/utils/encryption.py` derives the
+# Fernet key for provider-API-key encryption from it via PBKDF2, so changing it
+# makes every previously encrypted secret in the DB undecryptable.
+JWT_SECRET_KEY=change-me
+
+# development | local | dev | test | staging | production   (default: development)
+ENV=development
+
+
+# ── Optional infrastructure ──────────────────────────────────────────
+REDIS_URL=redis://localhost:6379/0
+LOG_LEVEL=INFO
+DEFAULT_ORG_ID=00000000-0000-0000-0000-000000000001
+APPLICATION_URL=http://localhost:3000
+BASE_API_URL=http://localhost:8000/api/v1
+AUTH_TOKEN=
+
+
+# ── Auth cookies ─────────────────────────────────────────────────────
+# Blank COOKIE_DOMAIN = host-only cookie, which is what localhost needs.
+# COOKIE_SECURE defaults to false for local-ish ENV values, true otherwise —
+# a Secure cookie cannot be stored over http://localhost.
+COOKIE_DOMAIN=
+COOKIE_SECURE=false
+# lax | strict | none   ("none" requires COOKIE_SECURE=true)
+COOKIE_SAMESITE=lax
+
+
+# ── CORS ─────────────────────────────────────────────────────────────
+CORS_ALLOW_ORIGINS=http://localhost:3000,http://localhost:3001
+CORS_ALLOW_ORIGIN_REGEX=https://([a-z0-9-]+\.)*trytone\.ai
+
+
+# ── Infisical (optional) ─────────────────────────────────────────────
+# Set all three to pull secrets from Infisical instead of this file.
+# bootstrap/dev-bootstrap.sh additionally requires PROJECT_ID + ENV and a
+# logged-in CLI; the manual setup path in the README does not.
+INFISICAL_TOKEN=
+INFISICAL_PROJECT_ID=
+INFISICAL_ENV=
+# INFISICAL_HOST=https://secrets.trytone.ai
+
+
+# ── Private package index (build-time, not read by the app) ──────────
+# `tone-pipecat` (requirements.txt) is not published on public PyPI; pip needs
+# the Cloudsmith entitlement URL for the tonehq/tone repo or the install fails.
+# PIP_EXTRA_INDEX_URL=https://<user>:<token>@dl.cloudsmith.io/<entitlement>/tonehq/tone/python/simple/
+
+
+# ── Licensing (Enterprise edition) ───────────────────────────────────
+TONE_LICENSE_KEY=
+SKIP_LICENSE_CHECK=false
+
+
+# ── LLM / helper provider keys ───────────────────────────────────────
+# Per-org provider keys are stored encrypted in the DB and managed in the UI.
+# The keys here are global fallbacks / ingestion-time credentials.
+OPENAI_API_KEY=
+LLAMA_CLOUD_API_KEY=
+
+
+# ── Telephony & transports ───────────────────────────────────────────
+# Public URL Twilio can reach for outbound TwiML + status callbacks (an ngrok
+# URL locally). Required for outbound dialing.
+BASE_CALL_URL=
+LIVEKIT_URL=
+LIVEKIT_API_KEY=
+LIVEKIT_API_SECRET=
+DAILY_API_KEY=
+WEBRTC_CLIENT_BASE_URL=
+SEND_SMS_DEFAULT_TO_NUMBER=
+
+
+# ── Voice-pod topology (Kubernetes deployments) ──────────────────────
+# Irrelevant for a single-process local run; listed for completeness.
+POD_PINNING_ENABLED=false
+CALL_SERVER_HOST=
+CALL_WORKER_PREFIX=staging-tone-call-worker
+CALL_WORKER_INTERNAL_URL=
+POD_SYNC_NAMESPACE=staging
+OUTBOUND_CALL_WORKER_PREFIX=staging-tone-outbound-call-worker
+OUTBOUND_CALL_HEADLESS_SERVICE=staging-tone-outbound-call-headless
+OUTBOUND_CALL_WORKER_PORT=8080
+MAX_CONCURRENT_CALLS=2
+WS_BRIDGE_INTERNAL_TOKEN=
+
+# Telephony-free WebSocket test endpoint (/ws/test). Runs a real, paid pipeline
+# and takes no auth — keep OFF in production.
+ENABLE_WS_TEST_ENDPOINT=false
+WS_CALL_TARGET_URL=
+WS_CALL_TARGET_AGENT_ID=
+# Run the WS bridge in-process instead of handing off to a voice pod. Needed
+# for a single-process local run; leave false in staging/prod.
+WS_BRIDGE_ALLOW_INLINE=false
+
+
+# ── Outbound concurrency ─────────────────────────────────────────────
+# Per scheduling batch, not global. 0 = unset (no cap, no UI ceiling).
+MAX_CONCURRENT_OUTBOUND_CALLS=0
+OUTBOUND_BG_WORKERS=0
+
+
+# ── Object storage (Cloudflare R2) ───────────────────────────────────
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET_NAME=
+R2_ENDPOINT_URL=
+
+
+# ── OAuth / integrations ─────────────────────────────────────────────
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+# HubSpot's MCP server does not support Dynamic Client Registration, so a
+# pre-registered "MCP Auth App" client is needed.
+HUBSPOT_MCP_CLIENT_ID=
+HUBSPOT_MCP_CLIENT_SECRET=
+
+
+# ── Email ────────────────────────────────────────────────────────────
+RESEND_API_KEY=
+
+
+# ── RAG ingestion defaults ───────────────────────────────────────────
+DEFAULT_PARSER=docling
+DEFAULT_TOKENISER=docling_hybrid
+DEFAULT_EMBEDDING_PROVIDER=openai
+DEFAULT_EMBEDDING_MODEL=text-embedding-3-small
+DEFAULT_EMBEDDING_DIMENSIONS=1536
+# pgvector | pinecone
+DEFAULT_VECTOR_STORE=pgvector
+PINECONE_API_KEY=
+
+
+# ── RAG evaluation harness ───────────────────────────────────────────
+EVAL_AUTO_RUN_ENABLED=true
+EVAL_GENERATION_MODEL=gpt-4o
+EVAL_ANSWER_MODEL=gpt-4o
+EVAL_JUDGE_MODEL=gpt-4o
+EVAL_TOP_K=8
+EVAL_MAX_CONTEXT_CHARS=60000
+
+
+# ── Grafana Loki (log egress + per-call read-back) ───────────────────
+# All blank locally, which makes loki_read_configured() False and the per-call
+# log sync a safe no-op.
+LOKI_URL=
+LOKI_USER=
+GRAFANA_API_KEY=
+# Defaults to LOKI_URL with /push swapped for /query_range.
+LOKI_QUERY_URL=
+# Default to the push credentials above when blank.
+LOKI_QUERY_USER=
+LOKI_QUERY_TOKEN=
+LOKI_SYNC_APP_LABEL=
+LOKI_SYNC_DELAY_SECONDS=120
+LOKI_SYNC_PRE_BUFFER_SECONDS=30
+LOKI_SYNC_POST_BUFFER_SECONDS=60
+LOKI_SYNC_PAGE_LIMIT=5000
+LOKI_SYNC_MAX_PAGES=50
+LOKI_SYNC_HTTP_TIMEOUT=30
+LOKI_SYNC_MAX_RETRIES=5

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "pipecat"]
-	path = pipecat
+[submodule "src/pipecat-ai"]
+	path = src/pipecat-ai
 	url = https://github.com/tonehq/pipecat.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,9 @@ docker build -f core/Dockerfile -t tone .
 
 ### Pipecat Integration
 
-The `pipecat/` directory is a custom fork (`tonehq/pipecat`) of the Pipecat AI framework. It provides the actual voice pipeline runtime with 55+ provider integrations across LLM, STT, and TTS categories.
+The `src/pipecat-ai/` submodule is a custom fork (`tonehq/pipecat`) of the Pipecat AI framework. It provides the actual voice pipeline runtime with 55+ provider integrations across LLM, STT, and TTS categories. Fetch it with `git submodule update --init`.
+
+Note that the submodule is the fork's *source*, checked out for reference. What the application actually imports is the built `tone-pipecat` package from `requirements.txt`, which is published to a private Cloudsmith index and needs `PIP_EXTRA_INDEX_URL` to install.
 
 ### Data Seeding
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,21 +33,40 @@ services:
       POSTGRES_USER: tone
       POSTGRES_PASSWORD: tone
       POSTGRES_DB: tone
+    # The image defaults to max_connections=100, which the app exhausts on its
+    # own: core/database/base.py builds an engine with pool_size=50 and
+    # max_overflow=70, so a single process can ask for 120 connections, and the
+    # call/ingestion workers open pools of their own on top of that.
+    command:
+      - postgres
+      - -c
+      - max_connections=200
     ports:
-      - "5432:5432"
+      # Loopback only — the credentials here are tone/tone.
+      - "127.0.0.1:5432:5432"
+    # Docker gives a container 64MB of /dev/shm. Parallel query workers and
+    # large sorts spill into it and fail with "could not resize shared memory
+    # segment ... No space left on device".
+    shm_size: 256mb
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U tone -d tone"]
+      # -h 127.0.0.1 matters: during first-run initdb the entrypoint starts a
+      # temporary server that listens on the unix socket only. A socket probe
+      # reports healthy several seconds before anything can connect on 5432,
+      # then flaps back to unhealthy while the real server starts.
+      test: ["CMD-SHELL", "pg_isready -U tone -d tone -h 127.0.0.1"]
       interval: 5s
       timeout: 5s
       retries: 10
+      start_period: 30s
     restart: unless-stopped
 
   redis:
     image: redis:7-alpine
     ports:
-      - "6379:6379"
+      # Loopback only — this Redis takes no password.
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis-data:/data
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,62 @@
+# Local development backing services for Tone.
+#
+#     docker compose up -d
+#
+# Brings up the two stateful dependencies the app expects on localhost, with
+# credentials matching the defaults in .env.example:
+#
+#     DATABASE_URL=postgresql://tone:tone@localhost:5432/tone
+#     REDIS_URL=redis://localhost:6379/0
+#
+# Then, in your virtualenv:
+#
+#     alembic upgrade head
+#     PYTHONPATH=. python -m procrastinate --app=core.services.ingestion_queue.app schema --apply
+#     python dev/seed.py
+#     uvicorn main:app --reload --host 0.0.0.0 --port 8000
+#
+# There is deliberately no `api` service here. The application image cannot be
+# built without credentials for the private Cloudsmith index that hosts
+# `tone-pipecat` (see PIP_EXTRA_INDEX_URL in .env.example), so a compose file
+# that claimed to build it would just fail for anyone without an entitlement
+# token. These two services are the part that does work unauthenticated.
+
+name: tone
+
+services:
+  postgres:
+    # pgvector, not plain postgres: the initial migration runs
+    # `CREATE EXTENSION IF NOT EXISTS vector`, and the knowledge-base embedding
+    # columns use the `vector` / `halfvec` types.
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_USER: tone
+      POSTGRES_PASSWORD: tone
+      POSTGRES_DB: tone
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U tone -d tone"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  postgres-data:
+  redis-data:


### PR DESCRIPTION
I cloned the repository from scratch, ran the standard initialization, and got this:
```
$ git submodule update --init
fatal: No url found for submodule path 'src/pipecat-ai' in .gitmodules
```
.gitmodules defines a submodule at the pipecat path, but that module doesn't exist (or isn't public).
As a result, you end up with an empty src/pipecat-ai directory and no indication of where to obtain the source code.
I found that redirecting the src/pipecat-ai entry to tonehq/pipecat works.

I also came across two minor issues:

1. No .env.example.shared/config.py contains around 80 configuration keys, while the README only mentions three.
Very hard for deploy.

2. Postgres requires pgvector.The very first migration failed on:
```
CREATE EXTENSION IF NOT EXISTS vector;
```
this PR facilitates the deployment. Take a look for an example. Thank you for the interesting project and your time.