### PR TITLE
Add cluster-bootstrap workflow (dispatchable on dev)

### DIFF
--- a/.github/workflows/cluster-bootstrap.yaml
+++ b/.github/workflows/cluster-bootstrap.yaml
@@ -1,0 +1,118 @@
+name: Cluster bootstrap (operators + namespace + secrets)
+
+# ONE-TIME per-cluster setup — run this BEFORE the first app deploy.
+# Installs the cluster-wide operators the app manifests depend on and creates the
+# app namespace + its secrets. Idempotent (safe to re-run), but not part of the
+# per-push app pipeline: cluster lifecycle != app lifecycle.
+#
+# Driven entirely by build/kubernetes/envs/<target>.env. That file names WHICH
+# GitHub secret holds each value (NAMESPACE + *_SECRET keys); the values live in
+# GitHub secrets and are resolved at run time via toJSON(secrets). So the GitHub
+# secrets you must create are whatever the env file's *_SECRET keys point to, e.g.
+# for staging-do:
+#   STAGING_DO_KUBE_CONFIG_JSON      (kubeconfig)
+#   STAGING_DO_INFISICAL_TOKEN       + STAGING_DO_INFISICAL_PROJECT_ID
+#   GHCR_PULL_TOKEN                  (PAT with read:packages, for ghcr-auth)
+#   STAGING_DO_KEDA_POSTGRES         (postgresql://…?sslmode=require)
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Environment / cluster (matches build/kubernetes/envs/<target>.env)"
+        type: choice
+        options:
+          - staging-do
+          # - staging-aws
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve env file
+        run: echo "ENV_FILE=build/kubernetes/envs/${{ inputs.target }}.env" >> "$GITHUB_ENV"
+
+      - name: Load NAMESPACE
+        run: grep -E '^NAMESPACE=' "$ENV_FILE" >> "$GITHUB_ENV"
+
+      - name: Set up kubeconfig from env file
+        env:
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+        run: |
+          SRC=$(grep -E '^KUBE_CONFIG_SECRET=' "$ENV_FILE" | cut -d= -f2)
+          test -n "$SRC" || { echo "::error::KUBE_CONFIG_SECRET missing in $ENV_FILE"; exit 1; }
+          mkdir -p "$HOME/.kube"
+          printf '%s' "$ALL_SECRETS" | jq -r --arg k "$SRC" '.[$k] // empty' > "$HOME/.kube/config"
+          test -s "$HOME/.kube/config" || { echo "::error::secret $SRC is empty/undefined"; exit 1; }
+          chmod 600 "$HOME/.kube/config"
+          echo "KUBECONFIG=$HOME/.kube/config" >> "$GITHUB_ENV"
+
+      # ── Cluster-wide operators the app manifests depend on ──
+      - name: Install cert-manager (ClusterIssuer / Certificate CRDs)
+        run: |
+          helm repo add jetstack https://charts.jetstack.io
+          helm repo update
+          helm upgrade --install cert-manager jetstack/cert-manager \
+            -n cert-manager --create-namespace --set crds.enabled=true --wait
+
+      - name: Install KEDA (ScaledObject / TriggerAuthentication CRDs)
+        run: |
+          helm repo add kedacore https://kedacore.github.io/charts
+          helm repo update
+          helm upgrade --install keda kedacore/keda -n keda --create-namespace --wait
+
+      - name: Install ingress-nginx (DigitalOcean Load Balancer)
+        run: |
+          helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+          helm repo update
+          helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
+            -n ingress-nginx --create-namespace --wait
+
+      # ── App namespace + its secrets ──
+      # Each value is resolved from the GitHub secret NAMED in the env file
+      # (*_SECRET keys). Values stay local to this step — never written to
+      # $GITHUB_ENV — and GitHub masks them in logs (they are registered secrets).
+      - name: Create app namespace + secrets
+        env:
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+        run: |
+          # get <ENV_FILE_KEY> -> prints the value of the GitHub secret it names
+          get() {
+            local name val
+            name=$(grep -E "^$1=" "$ENV_FILE" | cut -d= -f2)
+            test -n "$name" || { echo "::error::$1 missing in $ENV_FILE"; exit 1; }
+            val=$(printf '%s' "$ALL_SECRETS" | jq -r --arg k "$name" '.[$k] // empty')
+            test -n "$val" || { echo "::error::GitHub secret '$name' (from $1) is empty/undefined"; exit 1; }
+            printf '%s' "$val"
+          }
+
+          kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+          kubectl create secret generic infisical-credentials -n "$NAMESPACE" \
+            --from-literal=token="$(get INFISICAL_TOKEN_SECRET)" \
+            --from-literal=project_id="$(get INFISICAL_PROJECT_ID_SECRET)" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+          kubectl create secret docker-registry ghcr-auth -n "$NAMESPACE" \
+            --docker-server=ghcr.io \
+            --docker-username="${{ github.actor }}" \
+            --docker-password="$(get GHCR_PULL_TOKEN_SECRET)" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+          kubectl create secret generic keda-postgres -n "$NAMESPACE" \
+            --from-literal=connectionString="$(get KEDA_POSTGRES_SECRET)" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Show ingress Load Balancer IP (point DNS here)
+        run: |
+          echo "Waiting for the ingress-nginx external IP…"
+          for i in $(seq 1 30); do
+            IP=$(kubectl get svc -n ingress-nginx ingress-nginx-controller \
+                  -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+            [ -n "$IP" ] && break
+            sleep 10
+          done
+          echo "Ingress LB IP: ${IP:-<pending — check DigitalOcean networking>}"
+          echo "Point do-api.trytone.ai and do-call.trytone.ai at that IP."

--- a/.github/workflows/monitoring.yaml
+++ b/.github/workflows/monitoring.yaml
@@ -1,0 +1,81 @@
+name: Monitoring (Grafana Alloy) — any cluster
+
+# ONE reusable monitoring workflow for ALL environments, driven ENTIRELY by the
+# build/kubernetes/envs/<target>.env file the app also uses. Pick a target and it
+# reads that file for CLUSTER_NAME + which secret holds the kubeconfig
+# (KUBE_CONFIG_SECRET) — no per-target wiring in this workflow.
+#
+# Per target you need:
+#   1. build/kubernetes/envs/<target>.env  → CLUSTER_NAME + KUBE_CONFIG_SECRET
+#   2. the GitHub secret named by KUBE_CONFIG_SECRET (the kubeconfig value)
+#   3. add <target> to the `options` list below
+#
+# Repo-level shared secrets (one Grafana Cloud stack, keyed by `cluster` label):
+#   GRAFANA_LOKI_URL, GRAFANA_LOKI_USER, GRAFANA_PROM_URL, GRAFANA_PROM_USER,
+#   GRAFANA_CLOUD_API_KEY
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Environment / cluster (matches build/kubernetes/envs/<target>.env)"
+        type: choice
+        options:
+          - staging-do
+          # - staging-aws
+          # - staging
+
+env:
+  RENDER_DIR: build/kubernetes/.rendered/monitoring
+
+jobs:
+  deploy-monitoring:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve env file
+        run: echo "ENV_FILE=build/kubernetes/envs/${{ inputs.target }}.env" >> "$GITHUB_ENV"
+
+      # CLUSTER_NAME (non-secret) straight from the env file.
+      - name: Load CLUSTER_NAME
+        run: grep -E '^CLUSTER_NAME=' "$ENV_FILE" >> "$GITHUB_ENV"
+
+      # Kubeconfig from the secret NAMED in the env file (same pattern as the app).
+      - name: Set up kubeconfig from env file
+        env:
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+        run: |
+          SRC=$(grep -E '^KUBE_CONFIG_SECRET=' "$ENV_FILE" | cut -d= -f2)
+          test -n "$SRC" || { echo "::error::KUBE_CONFIG_SECRET missing in $ENV_FILE"; exit 1; }
+          mkdir -p "$HOME/.kube"
+          printf '%s' "$ALL_SECRETS" | jq -r --arg k "$SRC" '.[$k] // empty' > "$HOME/.kube/config"
+          test -s "$HOME/.kube/config" || { echo "::error::secret $SRC is empty/undefined"; exit 1; }
+          chmod 600 "$HOME/.kube/config"
+          echo "KUBECONFIG=$HOME/.kube/config" >> "$GITHUB_ENV"
+
+      - name: Render monitoring for this cluster
+        run: ./build/kubernetes/render-monitoring.sh "$CLUSTER_NAME" "$RENDER_DIR"
+
+      - name: Create monitoring namespace
+        run: kubectl apply -f "$RENDER_DIR/namespace.yaml"
+
+      - name: Create Grafana Cloud credentials secret
+        run: |
+          kubectl create secret generic grafana-cloud-credentials \
+            --namespace=monitoring \
+            --from-literal=loki-url="${{ secrets.GRAFANA_LOKI_URL }}" \
+            --from-literal=loki-user="${{ secrets.GRAFANA_LOKI_USER }}" \
+            --from-literal=prom-url="${{ secrets.GRAFANA_PROM_URL }}" \
+            --from-literal=prom-user="${{ secrets.GRAFANA_PROM_USER }}" \
+            --from-literal=api-key="${{ secrets.GRAFANA_CLOUD_API_KEY }}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Apply monitoring manifests
+        run: |
+          kubectl apply -f "$RENDER_DIR/rbac.yaml"
+          kubectl apply -f "$RENDER_DIR/configmap.yaml"
+          kubectl apply -f "$RENDER_DIR/daemonset.yaml"
+
+      - name: Wait for Alloy rollout
+        run: kubectl rollout status daemonset/alloy -n monitoring --timeout=180s

--- a/.github/workflows/staging-do.yaml
+++ b/.github/workflows/staging-do.yaml
@@ -1,0 +1,110 @@
+name: Staging DO (DigitalOcean DOKS) CI/CD
+
+on:
+  push:
+    branches: ["staging-do"]
+  workflow_dispatch:
+
+# Deploys by rendering build/kubernetes/_base with build/kubernetes/envs/staging-do.env.
+# EVERYTHING env-specific — namespace, resource names, capacity, AND which GitHub
+# secret holds the kubeconfig (KUBE_CONFIG_SECRET) — lives in that one env file.
+env:
+  ENV_FILE: build/kubernetes/envs/staging-do.env
+  RENDER_DIR: build/kubernetes/.rendered/staging-do
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ghcr.io/tonehq/tone:staging-do-latest
+            ghcr.io/tonehq/tone:${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/tonehq/tone:staging-do-buildcache
+          cache-to: type=registry,ref=ghcr.io/tonehq/tone:staging-do-buildcache,mode=max
+          secrets: |
+            pip_extra_index=${{ secrets.PIP_EXTRA_INDEX_URL }}
+
+      # Resolve NAMESPACE + RESOURCE_PREFIX (non-secret) from the env file.
+      - name: Load env config
+        run: grep -E '^(NAMESPACE|RESOURCE_PREFIX)=' "$ENV_FILE" >> "$GITHUB_ENV"
+
+      # Resolve the kubeconfig from the secret NAMED in the env file
+      # (KUBE_CONFIG_SECRET). toJSON(secrets) lets us index by that name.
+      - name: Set up kubeconfig from env file
+        env:
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+        run: |
+          SRC=$(grep -E '^KUBE_CONFIG_SECRET=' "$ENV_FILE" | cut -d= -f2)
+          test -n "$SRC" || { echo "::error::KUBE_CONFIG_SECRET missing in $ENV_FILE"; exit 1; }
+          mkdir -p "$HOME/.kube"
+          printf '%s' "$ALL_SECRETS" | jq -r --arg k "$SRC" '.[$k] // empty' > "$HOME/.kube/config"
+          test -s "$HOME/.kube/config" || { echo "::error::secret $SRC is empty/undefined"; exit 1; }
+          chmod 600 "$HOME/.kube/config"
+          echo "KUBECONFIG=$HOME/.kube/config" >> "$GITHUB_ENV"
+
+      - name: Render app manifests from shared templates
+        run: ./build/kubernetes/render.sh "$ENV_FILE" "$RENDER_DIR"
+
+      - name: Create namespace
+        run: kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Substitute IMAGE_TAG in rendered manifests
+        run: |
+          for m in api/deployment call/inbound-call-worker call/outbound-call-worker \
+                   worker/doc-worker worker/orchestrator; do
+            sed -i "s|\${IMAGE_TAG}|${{ github.sha }}|g" "$RENDER_DIR/$m.yaml"
+          done
+
+      - name: Apply all manifests
+        run: |
+          kubectl apply -f "$RENDER_DIR/letsencrypt-prod.yaml"
+          kubectl apply -f "$RENDER_DIR/api/service.yaml"
+          kubectl apply -f "$RENDER_DIR/api/deployment.yaml"
+          kubectl apply -f "$RENDER_DIR/api/certificate.yaml"
+          kubectl apply -f "$RENDER_DIR/api/ingress.yaml"
+          kubectl apply -f "$RENDER_DIR/call/pdb.yaml"
+          kubectl apply -f "$RENDER_DIR/call/service.yaml"
+          kubectl apply -f "$RENDER_DIR/call/inbound-call-worker.yaml"
+          kubectl apply -f "$RENDER_DIR/call/outbound-call-worker.yaml"
+          kubectl apply -f "$RENDER_DIR/call/certificate.yaml"
+          kubectl apply -f "$RENDER_DIR/call/ingress.yaml"
+          kubectl apply -f "$RENDER_DIR/call/pod-routing.yaml"
+          kubectl apply -f "$RENDER_DIR/worker/rbac.yaml"
+          kubectl apply -f "$RENDER_DIR/worker/doc-worker.yaml"
+          kubectl apply -f "$RENDER_DIR/worker/orchestrator.yaml"
+          kubectl apply -f "$RENDER_DIR/keda/trigger-auth.yaml"
+          kubectl apply -f "$RENDER_DIR/keda/scaledobjects.yaml"
+
+      - name: Rollout restart deployments
+        run: |
+          kubectl rollout restart deployment/${RESOURCE_PREFIX}api-deployment -n "$NAMESPACE"
+          kubectl rollout restart statefulset/${RESOURCE_PREFIX}call-worker -n "$NAMESPACE"
+          kubectl rollout restart statefulset/${RESOURCE_PREFIX}outbound-call-worker -n "$NAMESPACE"
+          kubectl rollout restart deployment/${RESOURCE_PREFIX}worker -n "$NAMESPACE"
+          kubectl rollout restart deployment/${RESOURCE_PREFIX}orchestrator -n "$NAMESPACE"
+
+      - name: Wait for rollouts
+        run: |
+          kubectl rollout status deployment/${RESOURCE_PREFIX}api-deployment -n "$NAMESPACE" --timeout=180s
+          kubectl rollout status statefulset/${RESOURCE_PREFIX}call-worker -n "$NAMESPACE" --timeout=180s
+          kubectl rollout status statefulset/${RESOURCE_PREFIX}outbound-call-worker -n "$NAMESPACE" --timeout=420s
+          kubectl rollout status deployment/${RESOURCE_PREFIX}worker -n "$NAMESPACE" --timeout=180s
+          kubectl rollout status deployment/${RESOURCE_PREFIX}orchestrator -n "$NAMESPACE" --timeout=180s

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ files/
 .claude/skills/code-review
 # Keep infra/setup docs under build/docs (overrides the docs/ ignore)
 !build/docs/
+
+# Rendered k8s manifests (build artifact of build/kubernetes/render.sh)
+build/kubernetes/.rendered/

--- a/build/kubernetes/README.md
+++ b/build/kubernetes/README.md
@@ -1,0 +1,90 @@
+# Kubernetes deployment — reusable templates
+
+One shared, env-agnostic template set drives every environment. You do **not**
+copy manifests per environment; you add a small config file and render.
+
+## Layout
+
+```
+build/kubernetes/
+├── _base/            # ONE reusable app manifest set (${VAR} placeholders)
+│   ├── api/  call/  worker/  keda/  letsencrypt-prod.yaml
+├── monitoring/       # ONE reusable monitoring set (Grafana Alloy) — deployed SEPARATELY
+│   ├── namespace.yaml  rbac.yaml  configmap.yaml  daemonset.yaml
+├── envs/             # per-environment config — the ONLY thing that differs per env
+│   └── staging-do.env
+├── render.sh              # renders app (_base) + <env>.env -> .rendered/<env>/
+├── render-monitoring.sh   # renders monitoring/ for one cluster (CLUSTER_NAME only)
+└── .rendered/             # build artifact (gitignored) — never committed
+```
+
+Legacy per-env copies (`staging/`, `staging-aws/`, `dev/`, …) predate this and
+are still wired to their own workflows. Migrate them onto `_base` one at a time.
+
+## Two deploy units
+
+| Unit | Templates | Namespace | Workflow | Cadence | Config source |
+|------|-----------|-----------|----------|---------|---------------|
+| **App** (per env) | `_base/` | `staging-do` | `staging-do.yaml` (push) | every push | `envs/staging-do.env` |
+| **Monitoring** (per cluster) | `monitoring/` | `monitoring` | `monitoring.yaml` (manual, **all clusters**) | once per cluster | `envs/<target>.env` + repo secret |
+
+Monitoring is a per-cluster concern (own namespace + cluster-wide RBAC) and its
+manifests are identical everywhere, so **one** `monitoring.yaml` serves every
+cluster — pick the `target` on dispatch. It reads config from the SAME env files
+as the app.
+
+### One env file drives everything (app + monitoring)
+
+`envs/<target>.env` is the single "run file". It holds all non-secret config
+AND the *name* of the secret that holds the kubeconfig:
+
+```
+CLUSTER_NAME=tonedo-doks
+KUBE_CONFIG_SECRET=STAGING_DO_KUBE_CONFIG_JSON   # NAME, not value
+```
+
+Both workflows resolve the cluster the same way: they read `KUBE_CONFIG_SECRET`
+from the env file and pull that secret's value out of `toJSON(secrets)` (GitHub
+can't index secrets by a dynamic name directly; this is the standard way).
+The kubeconfig VALUE stays a GitHub secret — it must never be committed.
+
+Grafana Cloud creds (`GRAFANA_*`) are repo-level and shared — one stack ingests
+every cluster, keyed by the `cluster` label. Onboard a new cluster =
+1. add `envs/<target>.env` (with `CLUSTER_NAME` + `KUBE_CONFIG_SECRET`),
+2. add the GitHub secret named by `KUBE_CONFIG_SECRET`,
+3. add `<target>` to the `options` list in `monitoring.yaml`.
+No per-target secret wiring in the workflow.
+
+## Template variables (all set in `envs/<name>.env`)
+
+Identity/routing: `NAMESPACE`, `RESOURCE_PREFIX`, `ENVIRONMENT`, `APP_ENV`
+(app `ENV` → Infisical env/DB), `API_DOMAIN`, `CALL_DOMAIN`, `IMAGE_REPO`,
+`INFISICAL_HOST`, `CLUSTER_NAME` (monitoring label).
+
+Capacity/behaviour: `*_REPLICAS`, `INBOUND/OUTBOUND_MAX_CONCURRENT_CALLS`,
+per-workload `*_CPU/MEM_REQUEST/LIMIT`, KEDA `DOC/OUTBOUND_MIN/MAX_REPLICAS`,
+`LETSENCRYPT_EMAIL`.
+
+Two tokens are intentionally left unrendered: `${IMAGE_TAG}` (filled by CI with
+the build sha) and `$(POD_NAME)` (a Kubernetes downward-API fieldRef).
+
+## Add a new environment
+
+1. `cp build/kubernetes/envs/staging-do.env build/kubernetes/envs/<name>.env` and edit values.
+2. Copy `.github/workflows/staging-do.yaml` (and `-monitoring.yaml` if wanted) →
+   `<name>*.yaml`; change the branch, `ENV_FILE`, `RENDER_DIR`, image tags and
+   kubeconfig secret. Namespace + rollout names come from the env file automatically.
+3. Provision the cluster prereqs (ingress-nginx, cert-manager, KEDA) and the
+   namespace secrets (`infisical-credentials`, `ghcr-auth`, `keda-postgres`).
+
+## Render locally (dry run)
+
+```bash
+# App
+./build/kubernetes/render.sh build/kubernetes/envs/staging-do.env
+kubectl apply --dry-run=client -R -f build/kubernetes/.rendered/staging-do
+
+# Monitoring
+./build/kubernetes/render.sh build/kubernetes/envs/staging-do.env \
+    build/kubernetes/.rendered/staging-do-monitoring build/kubernetes/monitoring
+```

--- a/build/kubernetes/_base/api/certificate.yaml
+++ b/build/kubernetes/_base/api/certificate.yaml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${RESOURCE_PREFIX}api-certificate
+  namespace: ${NAMESPACE}
+spec:
+  secretName: ${RESOURCE_PREFIX}api-certificate
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  commonName: ${API_DOMAIN}
+  dnsNames:
+  - ${API_DOMAIN}
+  duration: 2160h # 90 days
+  renewBefore: 720h # 30 days
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048

--- a/build/kubernetes/_base/api/deployment.yaml
+++ b/build/kubernetes/_base/api/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${RESOURCE_PREFIX}api-deployment
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}api
+    environment: ${ENVIRONMENT}
+spec:
+  replicas: ${API_REPLICAS}
+  selector:
+    matchLabels:
+      app: ${RESOURCE_PREFIX}api
+  template:
+    metadata:
+      labels:
+        app: ${RESOURCE_PREFIX}api
+        environment: ${ENVIRONMENT}
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: ${RESOURCE_PREFIX}api
+          image: ${IMAGE_REPO}:${IMAGE_TAG}
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+          command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+          resources:
+            requests:
+              cpu: "${API_CPU_REQUEST}"
+              memory: "${API_MEM_REQUEST}"
+            limits:
+              cpu: "${API_CPU_LIMIT}"
+              memory: "${API_MEM_LIMIT}"
+          env:
+            - name: ENV
+              value: "${APP_ENV}"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DEPLOYMENT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.labels['app']"
+            - name: INFISICAL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-credentials
+                  key: token
+            - name: INFISICAL_PROJECT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-credentials
+                  key: project_id
+            - name: INFISICAL_HOST
+              value: "${INFISICAL_HOST}"
+      imagePullSecrets:
+        - name: ghcr-auth

--- a/build/kubernetes/_base/api/ingress.yaml
+++ b/build/kubernetes/_base/api/ingress.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ${RESOURCE_PREFIX}api-ingress
+  namespace: ${NAMESPACE}
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    # CORS Configuration
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, PUT, DELETE, OPTIONS, PATCH"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Range, Authorization, X-Auth-Token, X-Org-Id, X-Tenant-Id, tenant_id, Accept, Origin, Referer"
+    nginx.ingress.kubernetes.io/cors-expose-headers: "Content-Length, Content-Range, Content-Type, X-Request-Id"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    nginx.ingress.kubernetes.io/cors-max-age: "3600"
+    # TLS
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - ${API_DOMAIN}
+    secretName: ${RESOURCE_PREFIX}api-certificate
+  rules:
+  - host: ${API_DOMAIN}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: ${RESOURCE_PREFIX}api-service
+            port:
+              number: 80

--- a/build/kubernetes/_base/api/service.yaml
+++ b/build/kubernetes/_base/api/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${RESOURCE_PREFIX}api-service
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}api
+    environment: ${ENVIRONMENT}
+spec:
+  selector:
+    app: ${RESOURCE_PREFIX}api
+  ports:
+    - port: 80
+      targetPort: 8000
+      protocol: TCP
+  type: ClusterIP

--- a/build/kubernetes/_base/call/certificate.yaml
+++ b/build/kubernetes/_base/call/certificate.yaml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${RESOURCE_PREFIX}call-certificate
+  namespace: ${NAMESPACE}
+spec:
+  secretName: ${RESOURCE_PREFIX}call-certificate
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  commonName: ${CALL_DOMAIN}
+  dnsNames:
+  - ${CALL_DOMAIN}
+  duration: 2160h # 90 days
+  renewBefore: 720h # 30 days
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048

--- a/build/kubernetes/_base/call/inbound-call-worker.yaml
+++ b/build/kubernetes/_base/call/inbound-call-worker.yaml
@@ -1,0 +1,135 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ${RESOURCE_PREFIX}call-worker
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}call-worker
+    environment: ${ENVIRONMENT}
+    component: call
+spec:
+  serviceName: ${RESOURCE_PREFIX}call-headless
+  podManagementPolicy: Parallel
+  replicas: ${CALL_REPLICAS}
+  selector:
+    matchLabels:
+      app: ${RESOURCE_PREFIX}call-worker
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ${RESOURCE_PREFIX}call-worker
+        environment: ${ENVIRONMENT}
+        component: call
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      terminationGracePeriodSeconds: 2100
+      containers:
+        - name: ${RESOURCE_PREFIX}call-worker
+          image: ${IMAGE_REPO}:${IMAGE_TAG}
+          imagePullPolicy: Always
+          command:
+            - uvicorn
+            - "main:app"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "8080"
+            - "--workers"
+            - "1"
+            - "--timeout-keep-alive"
+            - "3600"
+            - "--log-level"
+            - "info"
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: "${CALL_CPU_REQUEST}"
+              memory: "${CALL_MEM_REQUEST}"
+            limits:
+              cpu: "${CALL_CPU_LIMIT}"
+              memory: "${CALL_MEM_LIMIT}"
+          env:
+            - name: ENV
+              value: "${APP_ENV}"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DEPLOYMENT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.labels['app']"
+            - name: WORKER_MODE
+              value: "voice"
+            - name: MAX_CONCURRENT_CALLS
+              value: "${INBOUND_MAX_CONCURRENT_CALLS}"
+            - name: INFISICAL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-credentials
+                  key: token
+            - name: INFISICAL_PROJECT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-credentials
+                  key: project_id
+            - name: INFISICAL_HOST
+              value: "${INFISICAL_HOST}"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            periodSeconds: 2
+            timeoutSeconds: 3
+            failureThreshold: 2
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - python
+                  - -c
+                  - |
+                    import urllib.request, json, time
+                    def call(path, method="GET"):
+                        req = urllib.request.Request("http://localhost:8080" + path, method=method)
+                        return json.load(urllib.request.urlopen(req, timeout=5))
+                    try:
+                        call("/drain", "POST")
+                    except Exception:
+                        pass
+                    for _ in range(360):
+                        try:
+                            if call("/status").get("active_calls", 0) == 0:
+                                break
+                        except Exception:
+                            pass
+                        time.sleep(5)
+      imagePullSecrets:
+        - name: ghcr-auth

--- a/build/kubernetes/_base/call/ingress.yaml
+++ b/build/kubernetes/_base/call/ingress.yaml
@@ -1,0 +1,57 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ${RESOURCE_PREFIX}call-ingress
+  namespace: ${NAMESPACE}
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    # Timeouts for long-lived voice connections
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "10"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    # CORS Configuration
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, PUT, DELETE, OPTIONS, PATCH"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Range, Authorization, X-Auth-Token, X-Org-Id, X-Tenant-Id, tenant_id, Accept, Origin, Referer, Sec-WebSocket-Extensions, Sec-WebSocket-Key, Sec-WebSocket-Protocol, Sec-WebSocket-Version"
+    nginx.ingress.kubernetes.io/cors-expose-headers: "Content-Length, Content-Range, Content-Type, X-Request-Id"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    nginx.ingress.kubernetes.io/cors-max-age: "3600"
+    # WebSocket support
+    nginx.ingress.kubernetes.io/websocket-services: "${RESOURCE_PREFIX}call-service"
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+    # TLS
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - ${CALL_DOMAIN}
+      secretName: ${RESOURCE_PREFIX}call-certificate
+  rules:
+    - host: ${CALL_DOMAIN}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ${RESOURCE_PREFIX}call-service
+                port:
+                  number: 80
+          - path: /health
+            pathType: Exact
+            backend:
+              service:
+                name: ${RESOURCE_PREFIX}call-service
+                port:
+                  number: 80
+          - path: /ready
+            pathType: Exact
+            backend:
+              service:
+                name: ${RESOURCE_PREFIX}call-service
+                port:
+                  number: 80

--- a/build/kubernetes/_base/call/outbound-call-worker.yaml
+++ b/build/kubernetes/_base/call/outbound-call-worker.yaml
@@ -1,0 +1,169 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${RESOURCE_PREFIX}outbound-call-headless
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}outbound-call-worker
+    environment: ${ENVIRONMENT}
+    component: call
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app: ${RESOURCE_PREFIX}outbound-call-worker
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: ${RESOURCE_PREFIX}outbound-call-worker-pdb
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}outbound-call-worker
+    environment: ${ENVIRONMENT}
+    component: call
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: ${RESOURCE_PREFIX}outbound-call-worker
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ${RESOURCE_PREFIX}outbound-call-worker
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}outbound-call-worker
+    environment: ${ENVIRONMENT}
+    component: call
+spec:
+  serviceName: ${RESOURCE_PREFIX}outbound-call-headless
+  podManagementPolicy: Parallel
+  replicas: ${OUTBOUND_REPLICAS}
+  selector:
+    matchLabels:
+      app: ${RESOURCE_PREFIX}outbound-call-worker
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ${RESOURCE_PREFIX}outbound-call-worker
+        environment: ${ENVIRONMENT}
+        component: call
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      terminationGracePeriodSeconds: 2100
+      containers:
+        - name: ${RESOURCE_PREFIX}outbound-call-worker
+          image: ${IMAGE_REPO}:${IMAGE_TAG}
+          imagePullPolicy: Always
+          command:
+            - uvicorn
+            - "main:app"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "8080"
+            - "--workers"
+            - "1"
+            - "--timeout-keep-alive"
+            - "3600"
+            - "--log-level"
+            - "info"
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: "${OUTBOUND_CPU_REQUEST}"
+              memory: "${OUTBOUND_MEM_REQUEST}"
+            limits:
+              cpu: "${OUTBOUND_CPU_LIMIT}"
+              memory: "${OUTBOUND_MEM_LIMIT}"
+          env:
+            - name: ENV
+              value: "${APP_ENV}"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DEPLOYMENT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.labels['app']"
+            - name: WORKER_MODE
+              value: "voice"
+            - name: MAX_CONCURRENT_CALLS
+              value: "${OUTBOUND_MAX_CONCURRENT_CALLS}"
+            - name: INFISICAL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-credentials
+                  key: token
+            - name: INFISICAL_PROJECT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-credentials
+                  key: project_id
+            - name: INFISICAL_HOST
+              value: "${INFISICAL_HOST}"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            periodSeconds: 2
+            timeoutSeconds: 2
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            periodSeconds: 2
+            timeoutSeconds: 3
+            failureThreshold: 2
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - python
+                  - -c
+                  - |
+                    import urllib.request, json, time
+                    def call(path, method="GET"):
+                        req = urllib.request.Request("http://localhost:8080" + path, method=method)
+                        return json.load(urllib.request.urlopen(req, timeout=5))
+                    try:
+                        call("/drain", "POST")
+                    except Exception:
+                        pass
+                    for _ in range(360):
+                        try:
+                            if call("/status").get("active_calls", 0) == 0:
+                                break
+                        except Exception:
+                            pass
+                        time.sleep(5)
+      imagePullSecrets:
+        - name: ghcr-auth

--- a/build/kubernetes/_base/call/pdb.yaml
+++ b/build/kubernetes/_base/call/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: ${RESOURCE_PREFIX}call-worker-pdb
+  namespace: ${NAMESPACE}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: ${RESOURCE_PREFIX}call-worker

--- a/build/kubernetes/_base/call/pod-routing.yaml
+++ b/build/kubernetes/_base/call/pod-routing.yaml
@@ -1,0 +1,264 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${RESOURCE_PREFIX}call-pod-0
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}call-worker
+    environment: ${ENVIRONMENT}
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: ${RESOURCE_PREFIX}call-worker-0
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${RESOURCE_PREFIX}call-pod-1
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}call-worker
+    environment: ${ENVIRONMENT}
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: ${RESOURCE_PREFIX}call-worker-1
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${RESOURCE_PREFIX}call-pod-2
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}call-worker
+    environment: ${ENVIRONMENT}
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: ${RESOURCE_PREFIX}call-worker-2
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${RESOURCE_PREFIX}call-pod-3
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}call-worker
+    environment: ${ENVIRONMENT}
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: ${RESOURCE_PREFIX}call-worker-3
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${RESOURCE_PREFIX}call-pod-4
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}call-worker
+    environment: ${ENVIRONMENT}
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: ${RESOURCE_PREFIX}call-worker-4
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${RESOURCE_PREFIX}call-pod-5
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}call-worker
+    environment: ${ENVIRONMENT}
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: ${RESOURCE_PREFIX}call-worker-5
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${RESOURCE_PREFIX}call-pod-6
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}call-worker
+    environment: ${ENVIRONMENT}
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: ${RESOURCE_PREFIX}call-worker-6
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${RESOURCE_PREFIX}call-pod-7
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}call-worker
+    environment: ${ENVIRONMENT}
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: ${RESOURCE_PREFIX}call-worker-7
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${RESOURCE_PREFIX}call-pod-8
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}call-worker
+    environment: ${ENVIRONMENT}
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: ${RESOURCE_PREFIX}call-worker-8
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${RESOURCE_PREFIX}call-pod-9
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}call-worker
+    environment: ${ENVIRONMENT}
+    component: call
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name: ${RESOURCE_PREFIX}call-worker-9
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ${RESOURCE_PREFIX}call-pod-ingress
+  namespace: ${NAMESPACE}
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "10"
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - ${CALL_DOMAIN}
+      secretName: ${RESOURCE_PREFIX}call-certificate
+  rules:
+    - host: ${CALL_DOMAIN}
+      http:
+        paths:
+          - path: /pod/0(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: ${RESOURCE_PREFIX}call-pod-0
+                port:
+                  number: 80
+          - path: /pod/1(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: ${RESOURCE_PREFIX}call-pod-1
+                port:
+                  number: 80
+          - path: /pod/2(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: ${RESOURCE_PREFIX}call-pod-2
+                port:
+                  number: 80
+          - path: /pod/3(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: ${RESOURCE_PREFIX}call-pod-3
+                port:
+                  number: 80
+          - path: /pod/4(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: ${RESOURCE_PREFIX}call-pod-4
+                port:
+                  number: 80
+          - path: /pod/5(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: ${RESOURCE_PREFIX}call-pod-5
+                port:
+                  number: 80
+          - path: /pod/6(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: ${RESOURCE_PREFIX}call-pod-6
+                port:
+                  number: 80
+          - path: /pod/7(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: ${RESOURCE_PREFIX}call-pod-7
+                port:
+                  number: 80
+          - path: /pod/8(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: ${RESOURCE_PREFIX}call-pod-8
+                port:
+                  number: 80
+          - path: /pod/9(/|$)(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: ${RESOURCE_PREFIX}call-pod-9
+                port:
+                  number: 80

--- a/build/kubernetes/_base/call/service.yaml
+++ b/build/kubernetes/_base/call/service.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${RESOURCE_PREFIX}call-service
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}call-worker
+    environment: ${ENVIRONMENT}
+    component: call
+spec:
+  selector:
+    app: ${RESOURCE_PREFIX}call-worker
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${RESOURCE_PREFIX}call-headless
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}call-worker
+    environment: ${ENVIRONMENT}
+    component: call
+spec:
+  clusterIP: None
+  selector:
+    app: ${RESOURCE_PREFIX}call-worker
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP

--- a/build/kubernetes/_base/keda/scaledobjects.yaml
+++ b/build/kubernetes/_base/keda/scaledobjects.yaml
@@ -1,0 +1,86 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: ${RESOURCE_PREFIX}doc-worker
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}worker
+    environment: ${ENVIRONMENT}
+    component: autoscaling
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    name: ${RESOURCE_PREFIX}worker
+  pollingInterval: 15
+  cooldownPeriod: 300
+  minReplicaCount: ${DOC_MIN_REPLICAS}
+  maxReplicaCount: ${DOC_MAX_REPLICAS}
+  advanced:
+    restoreToOriginalReplicaCount: true
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 300
+  triggers:
+    - type: postgresql
+      authenticationRef:
+        name: keda-postgres-auth
+      metadata:
+        targetQueryValue: "1"
+        activationTargetQueryValue: "0"
+        query: >-
+          SELECT count(*) FROM procrastinate_jobs
+          WHERE queue_name = 'ingestion'
+            AND (
+                  status = 'doing'
+               OR (status = 'todo' AND (scheduled_at IS NULL OR scheduled_at <= now()))
+            )
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: ${RESOURCE_PREFIX}outbound-call-worker
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}outbound-call-worker
+    environment: ${ENVIRONMENT}
+    component: autoscaling
+  annotations:
+    autoscaling.keda.sh/paused-replicas: "1"
+spec:
+  scaleTargetRef:
+    kind: StatefulSet
+    name: ${RESOURCE_PREFIX}outbound-call-worker
+  pollingInterval: 15
+  cooldownPeriod: 600
+  minReplicaCount: ${OUTBOUND_MIN_REPLICAS}
+  maxReplicaCount: ${OUTBOUND_MAX_REPLICAS}
+  advanced:
+    restoreToOriginalReplicaCount: true
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 600
+          policies:
+            - type: Pods
+              value: 1
+              periodSeconds: 120
+  triggers:
+    - type: postgresql
+      authenticationRef:
+        name: keda-postgres-auth
+      metadata:
+        targetQueryValue: "2"
+        activationTargetQueryValue: "0"
+        query: >-
+          SELECT
+            (SELECT count(*) FROM calls
+               WHERE ended_at IS NULL
+                 AND started_at IS NOT NULL
+                 AND started_at > now() - interval '2 hours'
+                 AND direction = 'outbound')
+          + (SELECT count(*) FROM scheduled_calls
+               WHERE status IN ('processing', 'dispatched'))
+          + (SELECT count(*) FROM scheduled_calls
+               WHERE status = 'scheduled'
+                 AND scheduled_at <= now() + interval '3 minutes')

--- a/build/kubernetes/_base/keda/trigger-auth.yaml
+++ b/build/kubernetes/_base/keda/trigger-auth.yaml
@@ -1,0 +1,13 @@
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-postgres-auth
+  namespace: ${NAMESPACE}
+  labels:
+    environment: ${ENVIRONMENT}
+    component: autoscaling
+spec:
+  secretTargetRef:
+    - parameter: connection
+      name: keda-postgres
+      key: connectionString

--- a/build/kubernetes/_base/letsencrypt-prod.yaml
+++ b/build/kubernetes/_base/letsencrypt-prod.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: ${LETSENCRYPT_EMAIL}
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+    - http01:
+        ingress:
+          class: nginx

--- a/build/kubernetes/_base/worker/doc-worker.yaml
+++ b/build/kubernetes/_base/worker/doc-worker.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${RESOURCE_PREFIX}worker
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}worker
+    environment: ${ENVIRONMENT}
+    component: worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${RESOURCE_PREFIX}worker
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: ${RESOURCE_PREFIX}worker
+        environment: ${ENVIRONMENT}
+        component: worker
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      terminationGracePeriodSeconds: 120
+      containers:
+        - name: ${RESOURCE_PREFIX}worker
+          image: ${IMAGE_REPO}:${IMAGE_TAG}
+          imagePullPolicy: Always
+          command:
+            - python
+            - "-m"
+            - procrastinate
+            - "--app=core.services.ingestion_queue.app"
+            - worker
+            - "--name=$(POD_NAME)"
+            - "--queues=ingestion,eval"
+            - "--concurrency=1"
+            - "--no-listen-notify"
+            - "--fetch-job-polling-interval=5"
+          resources:
+            requests:
+              cpu: "${DOCWORKER_CPU_REQUEST}"
+              memory: "${DOCWORKER_MEM_REQUEST}"
+            limits:
+              cpu: "${DOCWORKER_CPU_LIMIT}"
+              memory: "${DOCWORKER_MEM_LIMIT}"
+          env:
+            - name: ENV
+              value: "${APP_ENV}"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DEPLOYMENT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.labels['app']"
+            - name: DOCLING_NUM_THREADS
+              value: "2"
+            - name: OMP_NUM_THREADS
+              value: "2"
+            - name: OPENBLAS_NUM_THREADS
+              value: "2"
+            - name: MKL_NUM_THREADS
+              value: "2"
+            - name: INFISICAL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-credentials
+                  key: token
+            - name: INFISICAL_PROJECT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-credentials
+                  key: project_id
+            - name: INFISICAL_HOST
+              value: "${INFISICAL_HOST}"
+      imagePullSecrets:
+        - name: ghcr-auth

--- a/build/kubernetes/_base/worker/orchestrator.yaml
+++ b/build/kubernetes/_base/worker/orchestrator.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${RESOURCE_PREFIX}orchestrator
+  namespace: ${NAMESPACE}
+  labels:
+    app: ${RESOURCE_PREFIX}orchestrator
+    environment: ${ENVIRONMENT}
+    component: worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${RESOURCE_PREFIX}orchestrator
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: ${RESOURCE_PREFIX}orchestrator
+        environment: ${ENVIRONMENT}
+        component: worker
+    spec:
+      serviceAccountName: tone-worker
+      nodeSelector:
+        kubernetes.io/os: linux
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: ${RESOURCE_PREFIX}orchestrator
+          image: ${IMAGE_REPO}:${IMAGE_TAG}
+          imagePullPolicy: Always
+          command:
+            - python
+            - "-m"
+            - procrastinate
+            - "--app=core.services.ingestion_queue.app"
+            - worker
+            - "--name=$(POD_NAME)"
+            - "--queues=pod_sync,outbound_calls,call_overlaps,call_transcripts,call_metrics,log_sync,contact_import"
+            - "--concurrency=4"
+            - "--no-listen-notify"
+            - "--fetch-job-polling-interval=5"
+          resources:
+            requests:
+              cpu: "${ORCH_CPU_REQUEST}"
+              memory: "${ORCH_MEM_REQUEST}"
+            limits:
+              cpu: "${ORCH_CPU_LIMIT}"
+              memory: "${ORCH_MEM_LIMIT}"
+          env:
+            - name: ENV
+              value: "${APP_ENV}"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DEPLOYMENT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.labels['app']"
+            - name: OMP_NUM_THREADS
+              value: "2"
+            - name: OPENBLAS_NUM_THREADS
+              value: "2"
+            - name: MKL_NUM_THREADS
+              value: "2"
+            - name: INFISICAL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-credentials
+                  key: token
+            - name: INFISICAL_PROJECT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: infisical-credentials
+                  key: project_id
+            - name: INFISICAL_HOST
+              value: "${INFISICAL_HOST}"
+      imagePullSecrets:
+        - name: ghcr-auth

--- a/build/kubernetes/_base/worker/rbac.yaml
+++ b/build/kubernetes/_base/worker/rbac.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tone-worker
+  namespace: ${NAMESPACE}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tone-worker-pods
+  namespace: ${NAMESPACE}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tone-worker-pods
+  namespace: ${NAMESPACE}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tone-worker-pods
+subjects:
+  - kind: ServiceAccount
+    name: tone-worker
+    namespace: ${NAMESPACE}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tone-worker-nodes
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tone-worker-nodes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tone-worker-nodes
+subjects:
+  - kind: ServiceAccount
+    name: tone-worker
+    namespace: ${NAMESPACE}

--- a/build/kubernetes/envs/staging-do.env
+++ b/build/kubernetes/envs/staging-do.env
@@ -15,9 +15,20 @@ IMAGE_REPO=ghcr.io/tonehq/tone
 INFISICAL_HOST=https://secrets.trytone.ai
 # Grafana Cloud `cluster` label for this env (used only by monitoring.yaml).
 CLUSTER_NAME=tonedo-doks
-# NAME (not value) of the GitHub secret holding this cluster's kubeconfig.
-# The value stays a GitHub secret; both workflows resolve it from this name.
+# ── GitHub secret NAMES (not values) for this env ──
+# Only the NAMES live here; the VALUES stay in GitHub secrets and are resolved at
+# run time via toJSON(secrets). Point a different env at different secrets by
+# changing these names — no workflow edits.
 KUBE_CONFIG_SECRET=STAGING_DO_KUBE_CONFIG_JSON
+# Reuse the EXISTING shared GitHub secrets (staging-do shares staging's Infisical/DB).
+INFISICAL_TOKEN_SECRET=INFISICAL_TOKEN
+INFISICAL_PROJECT_ID_SECRET=INFISICAL_PROJECT_ID
+# NOT yet in GitHub secrets — staging created these directly on the cluster.
+# Create these two repo secrets before running cluster-bootstrap:
+#   GHCR_PULL_TOKEN  = a PAT with read:packages (to pull ghcr.io/tonehq/tone)
+#   KEDA_POSTGRES    = the same DB connection string staging uses (staging-do reuses it)
+GHCR_PULL_TOKEN_SECRET=GHCR_PULL_TOKEN
+KEDA_POSTGRES_SECRET=DO_KEDA_POSTGRES
 
 # ── TLS ──
 LETSENCRYPT_EMAIL=karthik@productfusion.co

--- a/build/kubernetes/envs/staging-do.env
+++ b/build/kubernetes/envs/staging-do.env
@@ -1,0 +1,64 @@
+# ─── DigitalOcean DOKS (cluster: tonedo-doks / nyc3) ───────────────────────
+# The ONLY file that differs per environment. Rendered into build/kubernetes/_base
+# (app) and build/kubernetes/monitoring (observability) by render.sh.
+
+# ── Identity / routing ──
+NAMESPACE=staging-do
+RESOURCE_PREFIX=do-tone-
+ENVIRONMENT=staging-do
+# APP_ENV = the ENV var the app reads to pick its Infisical env / DB.
+# Kept "staging" so this env reuses staging's secrets & database.
+APP_ENV=staging
+API_DOMAIN=do-api.trytone.ai
+CALL_DOMAIN=do-call.trytone.ai
+IMAGE_REPO=ghcr.io/tonehq/tone
+INFISICAL_HOST=https://secrets.trytone.ai
+# Grafana Cloud `cluster` label for this env (used only by monitoring.yaml).
+CLUSTER_NAME=tonedo-doks
+# NAME (not value) of the GitHub secret holding this cluster's kubeconfig.
+# The value stays a GitHub secret; both workflows resolve it from this name.
+KUBE_CONFIG_SECRET=STAGING_DO_KUBE_CONFIG_JSON
+
+# ── TLS ──
+LETSENCRYPT_EMAIL=karthik@productfusion.co
+
+# ── Replicas ──
+API_REPLICAS=1
+CALL_REPLICAS=3
+OUTBOUND_REPLICAS=1
+
+# ── Per-call concurrency ──
+INBOUND_MAX_CONCURRENT_CALLS=5
+OUTBOUND_MAX_CONCURRENT_CALLS=2
+
+# ── Resource requests → limits ──
+API_CPU_REQUEST=100m
+API_MEM_REQUEST=512Mi
+API_CPU_LIMIT=256m
+API_MEM_LIMIT=1Gi
+
+CALL_CPU_REQUEST=1
+CALL_MEM_REQUEST=1Gi
+CALL_CPU_LIMIT=2
+CALL_MEM_LIMIT=2Gi
+
+OUTBOUND_CPU_REQUEST=1
+OUTBOUND_MEM_REQUEST=1Gi
+OUTBOUND_CPU_LIMIT=2
+OUTBOUND_MEM_LIMIT=2Gi
+
+DOCWORKER_CPU_REQUEST=1
+DOCWORKER_MEM_REQUEST=3Gi
+DOCWORKER_CPU_LIMIT=2
+DOCWORKER_MEM_LIMIT=5Gi
+
+ORCH_CPU_REQUEST=250m
+ORCH_MEM_REQUEST=512Mi
+ORCH_CPU_LIMIT=1
+ORCH_MEM_LIMIT=1Gi
+
+# ── Autoscaling (KEDA) — min/max replica bounds ──
+DOC_MIN_REPLICAS=0
+DOC_MAX_REPLICAS=2
+OUTBOUND_MIN_REPLICAS=0
+OUTBOUND_MAX_REPLICAS=4

--- a/build/kubernetes/monitoring/configmap.yaml
+++ b/build/kubernetes/monitoring/configmap.yaml
@@ -1,0 +1,197 @@
+# Grafana Alloy pipeline configuration (Alloy syntax / "River").
+#
+# Collects pod logs + node metrics from the EKS cluster and pushes them to
+# Grafana Cloud (Loki for logs, Prometheus for metrics). This is a raw-manifest
+# port of the Vultr Helm values at
+#   .claude/skills/provisioning-cluster/provisioning-vultr/templates/alloy-values.yaml
+#
+# Grafana Cloud credentials and the cluster label are injected from the
+# `grafana-cloud-credentials` Secret via environment variables, read here with
+# sys.env(...). Nothing sensitive lives in this ConfigMap.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alloy-config
+  namespace: monitoring
+data:
+  config.alloy: |
+    // ──── Kubernetes Discovery ────
+    discovery.kubernetes "pods" {
+      role = "pod"
+    }
+
+    // ──── Relabel: extract K8s metadata as labels ────
+    discovery.relabel "pod_labels" {
+      targets = discovery.kubernetes.pods.targets
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app"]
+        target_label  = "app"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_environment"]
+        target_label  = "environment"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_component"]
+        target_label  = "component"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label  = "node"
+      }
+    }
+
+    // ──── Log Collection from the Kubernetes API ────
+    loki.source.kubernetes "pod_logs" {
+      targets    = discovery.relabel.pod_labels.output
+      forward_to = [loki.process.filter.receiver]
+    }
+
+    // ──── Log Processing: add cluster label + drop health-check noise ────
+    loki.process "filter" {
+      stage.static_labels {
+        values = {
+          cluster = sys.env("CLUSTER_NAME"),
+        }
+      }
+
+      stage.drop {
+        expression          = "GET /health"
+        drop_counter_reason = "health_check"
+      }
+      stage.drop {
+        expression          = "GET /ready"
+        drop_counter_reason = "readiness_check"
+      }
+
+      // ──── Extract trace_id uniformly across app and model pods ────
+      stage.regex {
+        expression = "trace_id=(?P<trace_id>[^\\s|]+)"
+      }
+      stage.regex {
+        expression = "chatcmpl-(?P<trace_id>[A-Za-z0-9-]+)"
+      }
+      stage.structured_metadata {
+        values = {
+          trace_id = "",
+        }
+      }
+
+      forward_to = [loki.write.grafana_cloud.receiver]
+    }
+
+    // ──── Push logs to Grafana Cloud Loki ────
+    loki.write "grafana_cloud" {
+      endpoint {
+        url = sys.env("LOKI_URL")
+
+        basic_auth {
+          username = sys.env("LOKI_USER")
+          password = sys.env("GRAFANA_API_KEY")
+        }
+      }
+      external_labels = {
+        cluster = sys.env("CLUSTER_NAME"),
+      }
+    }
+
+    // ──── Node Metrics: embedded node_exporter ────
+    prometheus.exporter.unix "node" {
+      rootfs_path = "/host/root"
+      procfs_path = "/host/proc"
+      sysfs_path  = "/host/sys"
+    }
+
+    prometheus.scrape "node_metrics" {
+      targets         = prometheus.exporter.unix.node.targets
+      forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
+      scrape_interval = "60s"
+    }
+
+    // ──── Model Metrics: annotation-driven pod scraping ────
+    discovery.relabel "model_metrics" {
+      targets = discovery.kubernetes.pods.targets
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        regex         = sys.env("NODE_NAME")
+        action        = "keep"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_scrape"]
+        regex         = "true"
+        action        = "keep"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_phase"]
+        regex         = "Running"
+        action        = "keep"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_path"]
+        regex         = "(.+)"
+        target_label  = "__metrics_path__"
+      }
+      rule {
+        source_labels = ["__address__", "__meta_kubernetes_pod_annotation_prometheus_io_port"]
+        regex         = "([^:]+)(?::\\d+)?;(\\d+)"
+        replacement   = "$1:$2"
+        target_label  = "__address__"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app"]
+        target_label  = "app"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label  = "node"
+      }
+    }
+
+    prometheus.scrape "model_metrics" {
+      targets         = discovery.relabel.model_metrics.output
+      forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
+      scrape_interval = "30s"
+      scrape_timeout  = "10s"
+    }
+
+    // ──── Push metrics to Grafana Cloud Prometheus ────
+    prometheus.remote_write "grafana_cloud" {
+      endpoint {
+        url = sys.env("PROM_URL")
+
+        basic_auth {
+          username = sys.env("PROM_USER")
+          password = sys.env("GRAFANA_API_KEY")
+        }
+      }
+      external_labels = {
+        cluster = sys.env("CLUSTER_NAME"),
+      }
+    }

--- a/build/kubernetes/monitoring/daemonset.yaml
+++ b/build/kubernetes/monitoring/daemonset.yaml
@@ -1,0 +1,108 @@
+# Grafana Alloy DaemonSet — runs one collector pod on every node (including
+# GPU / tainted nodes) to gather logs and node metrics for Grafana Cloud.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: alloy
+  namespace: monitoring
+  labels:
+    app: alloy
+    component: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: alloy
+  template:
+    metadata:
+      labels:
+        app: alloy
+        component: monitoring
+    spec:
+      serviceAccountName: alloy
+      # Run on every node, tolerating all taints (GPU/system nodes included).
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: alloy
+          image: grafana/alloy:v1.5.1
+          args:
+            - run
+            - /etc/alloy/config.alloy
+            - --storage.path=/var/lib/alloy/data
+            - --server.http.listen-addr=0.0.0.0:12345
+          securityContext:
+            runAsUser: 0
+            privileged: false
+          ports:
+            - name: http
+              containerPort: 12345
+          env:
+            - name: CLUSTER_NAME
+              value: "${CLUSTER_NAME}"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: LOKI_URL
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-cloud-credentials
+                  key: loki-url
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-cloud-credentials
+                  key: loki-user
+            - name: PROM_URL
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-cloud-credentials
+                  key: prom-url
+            - name: PROM_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-cloud-credentials
+                  key: prom-user
+            - name: GRAFANA_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-cloud-credentials
+                  key: api-key
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+            - name: data
+              mountPath: /var/lib/alloy/data
+            # Host filesystem for node_exporter metrics (always present on EKS).
+            - name: rootfs
+              mountPath: /host/root
+              readOnly: true
+              mountPropagation: HostToContainer
+            - name: procfs
+              mountPath: /host/proc
+              readOnly: true
+            - name: sysfs
+              mountPath: /host/sys
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: alloy-config
+        - name: data
+          emptyDir: {}
+        - name: rootfs
+          hostPath:
+            path: /
+        - name: procfs
+          hostPath:
+            path: /proc
+        - name: sysfs
+          hostPath:
+            path: /sys

--- a/build/kubernetes/monitoring/namespace.yaml
+++ b/build/kubernetes/monitoring/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+  labels:
+    name: monitoring

--- a/build/kubernetes/monitoring/rbac.yaml
+++ b/build/kubernetes/monitoring/rbac.yaml
@@ -1,0 +1,44 @@
+# RBAC for Grafana Alloy.
+# Alloy uses the Kubernetes API to discover pods and stream their logs
+# (loki.source.kubernetes) and to read node metadata, so it needs cluster-wide
+# read access to pods, pods/log and nodes.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alloy
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: alloy
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+      - pods/log
+      - events
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: alloy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alloy
+subjects:
+  - kind: ServiceAccount
+    name: alloy
+    namespace: monitoring

--- a/build/kubernetes/render-monitoring.sh
+++ b/build/kubernetes/render-monitoring.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Render the shared monitoring/ templates for ONE cluster.
+# Monitoring is per-cluster and env-agnostic — its only variable is CLUSTER_NAME,
+# so this renderer needs no app env file.
+#
+#   ./build/kubernetes/render-monitoring.sh <cluster-name> [out-dir]
+#
+# Example:
+#   ./build/kubernetes/render-monitoring.sh tonedo-doks
+#     -> build/kubernetes/.rendered/monitoring-tonedo-doks/
+#
+set -euo pipefail
+
+CLUSTER_NAME="${1:?usage: render-monitoring.sh <cluster-name> [out-dir]}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$SCRIPT_DIR/monitoring"
+OUT_DIR="${2:-$SCRIPT_DIR/.rendered/monitoring-$CLUSTER_NAME}"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+for f in "$SRC"/*.yaml; do
+  sed "s|\${CLUSTER_NAME}|${CLUSTER_NAME}|g" "$f" > "$OUT_DIR/$(basename "$f")"
+done
+
+echo "Rendered monitoring (cluster=$CLUSTER_NAME) -> $OUT_DIR"

--- a/build/kubernetes/render.sh
+++ b/build/kubernetes/render.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Render a manifest template set for one environment.
+#
+#   ./build/kubernetes/render.sh <env-file> [out-dir] [template-dir]
+#
+# Examples:
+#   # App manifests (default template dir = _base)
+#   ./build/kubernetes/render.sh build/kubernetes/envs/staging-do.env
+#     -> build/kubernetes/.rendered/staging-do/
+#
+#   # Monitoring manifests (separate, per-cluster unit)
+#   ./build/kubernetes/render.sh build/kubernetes/envs/staging-do.env \
+#       build/kubernetes/.rendered/staging-do-monitoring \
+#       build/kubernetes/monitoring
+#
+# Every ${VAR} placeholder in the templates is substituted from the env file.
+# Two tokens are deliberately LEFT untouched for downstream steps:
+#   ${IMAGE_TAG}  -> substituted by CI (the built image sha)
+#   $(POD_NAME)   -> a Kubernetes downward-API fieldRef, not a template var
+#
+set -euo pipefail
+
+ENV_FILE="${1:?usage: render.sh <env-file> [out-dir] [template-dir]}"
+NAME="$(basename "$ENV_FILE" .env)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_DIR="${2:-$SCRIPT_DIR/.rendered/$NAME}"
+BASE="${3:-$SCRIPT_DIR/_base}"
+
+# Load env vars
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+# Required for every render
+: "${NAMESPACE:?}" "${RESOURCE_PREFIX:?}" "${ENVIRONMENT:?}" "${APP_ENV:?}"
+: "${API_DOMAIN:?}" "${CALL_DOMAIN:?}" "${IMAGE_REPO:?}" "${INFISICAL_HOST:?}"
+# Capacity / behaviour
+: "${API_REPLICAS:?}" "${CALL_REPLICAS:?}" "${OUTBOUND_REPLICAS:?}"
+: "${INBOUND_MAX_CONCURRENT_CALLS:?}" "${OUTBOUND_MAX_CONCURRENT_CALLS:?}"
+: "${API_CPU_REQUEST:?}" "${API_MEM_REQUEST:?}" "${API_CPU_LIMIT:?}" "${API_MEM_LIMIT:?}"
+: "${CALL_CPU_REQUEST:?}" "${CALL_MEM_REQUEST:?}" "${CALL_CPU_LIMIT:?}" "${CALL_MEM_LIMIT:?}"
+: "${OUTBOUND_CPU_REQUEST:?}" "${OUTBOUND_MEM_REQUEST:?}" "${OUTBOUND_CPU_LIMIT:?}" "${OUTBOUND_MEM_LIMIT:?}"
+: "${DOCWORKER_CPU_REQUEST:?}" "${DOCWORKER_MEM_REQUEST:?}" "${DOCWORKER_CPU_LIMIT:?}" "${DOCWORKER_MEM_LIMIT:?}"
+: "${ORCH_CPU_REQUEST:?}" "${ORCH_MEM_REQUEST:?}" "${ORCH_CPU_LIMIT:?}" "${ORCH_MEM_LIMIT:?}"
+: "${DOC_MIN_REPLICAS:?}" "${DOC_MAX_REPLICAS:?}" "${OUTBOUND_MIN_REPLICAS:?}" "${OUTBOUND_MAX_REPLICAS:?}"
+: "${LETSENCRYPT_EMAIL:?}"
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+# One sed -e per template variable. Order-independent (each token is unique).
+subst=(
+  NAMESPACE RESOURCE_PREFIX ENVIRONMENT APP_ENV API_DOMAIN CALL_DOMAIN
+  IMAGE_REPO INFISICAL_HOST LETSENCRYPT_EMAIL
+  API_REPLICAS CALL_REPLICAS OUTBOUND_REPLICAS
+  INBOUND_MAX_CONCURRENT_CALLS OUTBOUND_MAX_CONCURRENT_CALLS
+  API_CPU_REQUEST API_MEM_REQUEST API_CPU_LIMIT API_MEM_LIMIT
+  CALL_CPU_REQUEST CALL_MEM_REQUEST CALL_CPU_LIMIT CALL_MEM_LIMIT
+  OUTBOUND_CPU_REQUEST OUTBOUND_MEM_REQUEST OUTBOUND_CPU_LIMIT OUTBOUND_MEM_LIMIT
+  DOCWORKER_CPU_REQUEST DOCWORKER_MEM_REQUEST DOCWORKER_CPU_LIMIT DOCWORKER_MEM_LIMIT
+  ORCH_CPU_REQUEST ORCH_MEM_REQUEST ORCH_CPU_LIMIT ORCH_MEM_LIMIT
+  DOC_MIN_REPLICAS DOC_MAX_REPLICAS OUTBOUND_MIN_REPLICAS OUTBOUND_MAX_REPLICAS
+)
+sed_args=()
+for v in "${subst[@]}"; do
+  sed_args+=(-e "s|\${$v}|${!v}|g")
+done
+
+while IFS= read -r -d '' f; do
+  rel="${f#"$BASE"/}"
+  mkdir -p "$OUT_DIR/$(dirname "$rel")"
+  sed "${sed_args[@]}" "$f" > "$OUT_DIR/$rel"
+done < <(find "$BASE" -type f -name '*.yaml' -print0)
+
+echo "Rendered $ENV_FILE ($BASE) -> $OUT_DIR"


### PR DESCRIPTION
Follow-up to #985. Adds the one-time, per-cluster **cluster-bootstrap** workflow and the env-file secret-name mapping that #985 didn't include (committed after that PR merged).

`workflow_dispatch` workflows are only runnable once they're on the default branch (`dev`) — this lands `cluster-bootstrap.yaml` there so it can be triggered from Actions, exactly like `monitoring.yaml`.

- `.github/workflows/cluster-bootstrap.yaml` — installs cert-manager / KEDA / ingress-nginx, then creates the app namespace + secrets (all values resolved from the GitHub secrets NAMED in `envs/<target>.env` via `toJSON(secrets)`).
- `envs/staging-do.env` — `*_SECRET` name mappings (reuses shared `INFISICAL_TOKEN` / `INFISICAL_PROJECT_ID`; `GHCR_PULL_TOKEN` + `DO_KEDA_POSTGRES`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)