### PR TITLE
staging-do: manual-only deploy + longer rollout timeouts

### DIFF
--- a/.github/workflows/staging-do.yaml
+++ b/.github/workflows/staging-do.yaml
@@ -101,10 +101,12 @@ jobs:
           kubectl rollout restart deployment/${RESOURCE_PREFIX}worker -n "$NAMESPACE"
           kubectl rollout restart deployment/${RESOURCE_PREFIX}orchestrator -n "$NAMESPACE"
 
+      # Generous timeouts: the app image is large and the FIRST pull onto a fresh
+      # node can exceed a few minutes. Later deploys reuse the cached layers.
       - name: Wait for rollouts
         run: |
-          kubectl rollout status deployment/${RESOURCE_PREFIX}api-deployment -n "$NAMESPACE" --timeout=180s
-          kubectl rollout status statefulset/${RESOURCE_PREFIX}call-worker -n "$NAMESPACE" --timeout=180s
-          kubectl rollout status statefulset/${RESOURCE_PREFIX}outbound-call-worker -n "$NAMESPACE" --timeout=420s
-          kubectl rollout status deployment/${RESOURCE_PREFIX}worker -n "$NAMESPACE" --timeout=180s
-          kubectl rollout status deployment/${RESOURCE_PREFIX}orchestrator -n "$NAMESPACE" --timeout=180s
+          kubectl rollout status deployment/${RESOURCE_PREFIX}api-deployment -n "$NAMESPACE" --timeout=600s
+          kubectl rollout status statefulset/${RESOURCE_PREFIX}call-worker -n "$NAMESPACE" --timeout=600s
+          kubectl rollout status statefulset/${RESOURCE_PREFIX}outbound-call-worker -n "$NAMESPACE" --timeout=600s
+          kubectl rollout status deployment/${RESOURCE_PREFIX}worker -n "$NAMESPACE" --timeout=600s
+          kubectl rollout status deployment/${RESOURCE_PREFIX}orchestrator -n "$NAMESPACE" --timeout=600s

--- a/.github/workflows/staging-do.yaml
+++ b/.github/workflows/staging-do.yaml
@@ -1,8 +1,8 @@
 name: Staging DO (DigitalOcean DOKS) CI/CD
 
 on:
-  push:
-    branches: ["staging-do"]
+  # Manual-only: commits/pushes to staging-do do NOT auto-deploy.
+  # Run it from Actions -> "Staging DO ... CI/CD" -> Run workflow when ready.
   workflow_dispatch:
 
 # Deploys by rendering build/kubernetes/_base with build/kubernetes/envs/staging-do.env.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **havana** (14280 symbols, 36818 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **havana** (15188 symbols, 39160 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ New behavior needs tests; bug fixes need a regression test.
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **havana** (14280 symbols, 36818 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **havana** (15188 symbols, 39160 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 


### PR DESCRIPTION
Small follow-ups to the DO deployment (#985, #990), cherry-picked onto `dev` so the diff is only the real delta.

- **Manual-only deploy** — drop the `push` trigger from `staging-do.yaml`; deploys now run via `workflow_dispatch` only (no auto-deploy on every commit while the cluster is being sorted).
- **Longer rollout timeouts** — `Wait for rollouts` bumped 180s→600s so a cold pull of the large app image onto a fresh DOKS node doesn't fail the job.
- Refresh GitNexus index stats in `CLAUDE.md`/`AGENTS.md`.

No app/manifest logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)