### PR TITLE
Add presigned download_url to agent KB documents (shared helper)

### DIFF
--- a/core/api/v1/knowledge_base_routes.py
+++ b/core/api/v1/knowledge_base_routes.py
@@ -120,7 +120,12 @@ from core.services.rag.embedder_factory import EMBEDDERS
 from core.services.rag.factory import VECTOR_STORES
 from core.services.rag.parser_factory import PARSERS
 from core.services.rag.tokeniser_factory import TOKENISERS
-from core.services.r2_storage_service import KB_DOCUMENT, R2StorageService, build_r2_object_key
+from core.services.r2_storage_service import (
+    KB_DOCUMENT,
+    R2StorageService,
+    build_r2_object_key,
+    signed_url_or_none,
+)
 from core.services.upload_service import UploadService
 from core.utils.faceted_query import apply_filters, apply_sort, build_facets, distinct_values
 from core.utils.list_params import resolve_sort
@@ -150,19 +155,9 @@ def _kb_base_query(db: Session, org_id: UUID):
     )
 
 
-def _signed_url(file_path: str | None, r2: R2StorageService | None = None) -> str | None:
-    if not file_path:
-        return None
-    try:
-        return (r2 or R2StorageService()).generate_presigned_url(file_path)
-    except Exception as exc:
-        logger.debug("Failed to generate presigned URL for {}: {}", file_path, exc)
-        return None
-
-
 def _upload_to_payload(upload: Upload, r2: R2StorageService | None = None) -> dict:
     payload = upload.to_dict()
-    payload["url"] = _signed_url(upload.file_path, r2)
+    payload["url"] = signed_url_or_none(upload.file_path, r2)
     return payload
 
 

--- a/core/services/agent_service.py
+++ b/core/services/agent_service.py
@@ -25,6 +25,7 @@ from core.models.model import Model
 from core.services.agent_config_service import AgentConfigService
 from core.services.channel_service import ChannelService
 from core.services.meta_data_schema_validator import MetaDataSchemaValidator
+from core.services.r2_storage_service import R2StorageService, signed_url_or_none
 from core.services.webrtc import supported_providers
 from core.utils.model_settings import SETTINGS_MODEL_KINDS, as_uuid
 from core.models.agent_tool import AgentTool
@@ -2858,10 +2859,22 @@ class AgentService(BaseService):
             )
             .all()
         )
+        # A short-lived presigned GET URL so external consumers (e.g. the ToneHQ
+        # importer in tone-test) can actually download the document — the private
+        # ``file_path`` alone is not fetchable outside this service's R2 account.
+        # Reuse one R2 client across all rows; ``signed_url_or_none`` degrades to
+        # reference-only (returns None, logs at debug) when R2 is unconfigured.
+        try:
+            _r2 = R2StorageService()
+        except Exception as exc:  # R2 not configured — degrade to reference-only
+            logger.debug("[agent] R2 unavailable, documents omit download_url: {}", exc)
+            _r2 = None
+
         result["documents"] = [
             {
                 "id": str(row.Upload.id),
                 "file_path": row.Upload.file_path,
+                "download_url": signed_url_or_none(row.Upload.file_path, _r2) if _r2 else None,
                 "file_name": row.Upload.file_name,
                 "knowledge_base_id": str(row.knowledge_base_id),
                 "active_ingestion_pipeline_run_id": (

--- a/core/services/r2_storage_service.py
+++ b/core/services/r2_storage_service.py
@@ -111,3 +111,23 @@ class R2StorageService:
             Key=object_key,
         )
         logger.info("Deleted from R2: key={}", object_key)
+
+
+def signed_url_or_none(
+    file_path: Optional[str], r2: Optional["R2StorageService"] = None
+) -> Optional[str]:
+    """Best-effort presigned GET URL for an R2 object key.
+
+    Single source of truth for turning a stored ``file_path`` into a downloadable
+    URL in serializers/payloads. Returns ``None`` (logged at debug) when there is
+    no ``file_path`` or R2 is unconfigured/signing fails, so callers can degrade
+    to reference-only without their own try/except. Pass an existing ``r2`` to
+    reuse a client across a batch of rows.
+    """
+    if not file_path:
+        return None
+    try:
+        return (r2 or R2StorageService()).generate_presigned_url(file_path)
+    except Exception as exc:  # R2 unconfigured or signing failed
+        logger.debug("Failed to generate presigned URL for {}: {}", file_path, exc)
+        return None


### PR DESCRIPTION
## What
Agent-detail documents now include a short-lived presigned R2 GET `download_url` alongside `file_path`, so external consumers (e.g. the ToneHQ importer) can actually download the file — the private `file_path` is not fetchable on its own.

## Why this shape (DRY / logging)
The presigned-URL-or-None logic is factored into one shared helper, `signed_url_or_none`, in `core/services/r2_storage_service.py`:
- `core/services/agent_service.py` and `core/api/v1/knowledge_base_routes.py` both call it (the duplicate `_signed_url` in the routes layer is removed).
- Failures are logged at `logger.debug` and degrade to reference-only (`download_url: null`) when R2 is unconfigured — no silent swallow.
- One R2 client is constructed per request and reused across all document rows; when construction fails, rows short-circuit to `null` instead of re-instantiating per row.

## Files
- `core/services/r2_storage_service.py` — new `signed_url_or_none` helper.
- `core/services/agent_service.py` — emit `download_url`; module-level import; log on R2-unavailable.
- `core/api/v1/knowledge_base_routes.py` — reuse shared helper; drop duplicate `_signed_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)