### PR TITLE
ci: resolve ClickUp task by branch name

### DIFF
--- a/.github/workflows/clickup-task.yaml
+++ b/.github/workflows/clickup-task.yaml
@@ -22,108 +22,128 @@ jobs:
   resolve:
     runs-on: ubuntu-latest
     steps:
-      - name: Resolve ClickUp task from branch name
+      - name: Resolve ClickUp task for this branch
         id: task
         env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
           CLICKUP_TOKEN: ${{ secrets.CLICKUP_TOKEN }}
           CLICKUP_LIST_ID: ${{ vars.CLICKUP_LIST_ID }}
-          CLICKUP_TEAM_ID: ${{ vars.CLICKUP_TEAM_ID }}
+          CLICKUP_BRANCH_FIELD_ID: ${{ vars.CLICKUP_BRANCH_FIELD_ID }}
+        shell: python
         run: |
-          set -u
+          import json
+          import os
+          import re
+          import urllib.error
+          import urllib.parse
+          import urllib.request
 
-          TASK_ID=$(printf '%s' "$BRANCH" | grep -oE '[Cc][Uu][-_][0-9A-Za-z]{5,}' | head -1 | sed 's/^[Cc][Uu][-_]//')
-          CUSTOM_ID=0
+          BRANCH = os.environ.get("BRANCH", "")
+          TOKEN = os.environ.get("CLICKUP_TOKEN", "")
+          LIST_ID = os.environ.get("CLICKUP_LIST_ID", "")
+          FIELD_ID = os.environ.get("CLICKUP_BRANCH_FIELD_ID", "")
 
-          if [ -z "$TASK_ID" ]; then
-            TASK_ID=$(printf '%s' "$BRANCH" | grep -oE '[A-Z][A-Z0-9]{1,9}-[0-9]+' | head -1)
-            if [ -n "$TASK_ID" ]; then CUSTOM_ID=1; fi
-          fi
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY", os.devnull)
+          out_path = os.environ.get("GITHUB_OUTPUT", os.devnull)
 
-          if [ -z "$TASK_ID" ]; then
-            TASK_ID=$(printf '%s' "$BRANCH" | grep -oE '(^|[/_-])(86[0-9a-z]{6,10}|9[0-9a-z]{7,10})($|[/_-])' | grep -oE '86[0-9a-z]{6,10}|9[0-9a-z]{7,10}' | head -1)
-          fi
-
-          if [ -z "$TASK_ID" ]; then
-            echo "No ClickUp task id in branch '$BRANCH' — nothing to do." >> "$GITHUB_STEP_SUMMARY"
-            echo "found=0" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ -z "${CLICKUP_TOKEN:-}" ]; then
-            echo "Branch names task \`$TASK_ID\` but the CLICKUP_TOKEN secret is not configured." >> "$GITHUB_STEP_SUMMARY"
-            echo "found=0" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          URL="https://api.clickup.com/api/v2/task/${TASK_ID}"
-          if [ "$CUSTOM_ID" = "1" ]; then
-            if [ -z "${CLICKUP_TEAM_ID:-}" ]; then
-              echo "\`$TASK_ID\` looks like a custom id — set the CLICKUP_TEAM_ID variable." >> "$GITHUB_STEP_SUMMARY"
-              echo "found=0" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            URL="${URL}?custom_task_ids=true&team_id=${CLICKUP_TEAM_ID}"
-          fi
-
-          RESPONSE_FILE="${RUNNER_TEMP:-/tmp}/clickup-task.json"
-          curl -s --max-time 15 -H "Authorization: ${CLICKUP_TOKEN}" "$URL" -o "$RESPONSE_FILE"
-
-          python3 - "$RESPONSE_FILE" "$GITHUB_OUTPUT" "$GITHUB_STEP_SUMMARY" <<'PY'
-          import json, os, sys
-
-          response_path, out_path, summary_path = sys.argv[1], sys.argv[2], sys.argv[3]
-          expected = os.environ.get("CLICKUP_LIST_ID") or ""
-
-          def write(path, text):
-              with open(path, "a") as fh:
+          def emit_summary(text):
+              with open(summary_path, "a") as fh:
                   fh.write(text + "\n")
 
-          try:
-              with open(response_path) as fh:
-                  task = json.load(fh)
-          except Exception:
-              write(summary_path, "ClickUp returned an unreadable response.")
-              write(out_path, "found=0")
+          def emit_output(key, value):
+              with open(out_path, "a") as fh:
+                  if "\n" in value:
+                      fh.write(key + "<<CLICKUP_EOF\n" + value + "\nCLICKUP_EOF\n")
+                  else:
+                      fh.write(key + "=" + value + "\n")
+
+          def finish(found, summary):
+              print(summary)
+              emit_summary(summary)
+              emit_output("found", "1" if found else "0")
               raise SystemExit(0)
 
-          if not isinstance(task, dict) or "id" not in task:
-              err = task.get("err") if isinstance(task, dict) else None
-              write(summary_path, "ClickUp error: " + (err or "unexpected response"))
-              write(out_path, "found=0")
-              raise SystemExit(0)
+          def api(path, params=None):
+              url = "https://api.clickup.com/api/v2" + path
+              if params:
+                  url += "?" + urllib.parse.urlencode(params)
+              req = urllib.request.Request(url, headers={"Authorization": TOKEN})
+              try:
+                  with urllib.request.urlopen(req, timeout=20) as resp:
+                      return json.loads(resp.read().decode())
+              except urllib.error.HTTPError as exc:
+                  try:
+                      return json.loads(exc.read().decode())
+                  except Exception:
+                      return {"err": "HTTP " + str(exc.code)}
+              except Exception as exc:
+                  return {"err": str(exc)}
 
-          lst = task.get("list") or {}
-          list_id = str(lst.get("id") or "")
-          list_name = lst.get("name") or "-"
-          status = (task.get("status") or {}).get("status") or "-"
-          people = [a.get("username") or "" for a in (task.get("assignees") or [])]
-          assignees = ", ".join([p for p in people if p]) or "unassigned"
+          if not TOKEN:
+              finish(False, "CLICKUP_TOKEN secret is not configured.")
 
-          lines = [
-              "### ClickUp — [" + (task.get("name") or "") + "](" + (task.get("url") or "") + ")",
-              "",
-              "| | |",
-              "|---|---|",
-              "| Task | `" + str(task.get("id")) + "` |",
-              "| Status | " + status + " |",
-              "| Assignees | " + assignees + " |",
-              "| List | " + list_name + " |",
-          ]
-          if expected and list_id and list_id != expected:
-              lines.append("")
-              lines.append("> This task is in **" + list_name + "**, not the list configured for this repository.")
+          if not LIST_ID or not FIELD_ID:
+              finish(False, "Set the CLICKUP_LIST_ID and CLICKUP_BRANCH_FIELD_ID repository variables.")
 
-          body = "\n".join(lines)
-          write(summary_path, body)
+          tasks = []
 
-          with open(out_path, "a") as fh:
-              fh.write("found=1\n")
-              fh.write("body<<CLICKUP_EOF\n" + body + "\nCLICKUP_EOF\n")
-          PY
+          field_filter = json.dumps([{"field_id": FIELD_ID, "operator": "=", "value": BRANCH}])
+          data = api(
+              "/list/" + LIST_ID + "/task",
+              {
+                  "archived": "false",
+                  "include_closed": "true",
+                  "custom_fields": field_filter,
+              },
+          )
+
+          if isinstance(data, dict) and data.get("err"):
+              finish(False, "ClickUp error: " + str(data.get("err")))
+
+          tasks = data.get("tasks") or []
+
+          if not tasks:
+              m = re.search(r"[Cc][Uu][-_]([0-9A-Za-z]{5,})", BRANCH)
+              if m:
+                  single = api("/task/" + m.group(1))
+                  if isinstance(single, dict) and single.get("id"):
+                      tasks = [single]
+
+          if not tasks:
+              finish(
+                  False,
+                  "No ClickUp task is linked to branch `" + BRANCH + "`.\n\n"
+                  "Set the **Branch Name** field on the task to `" + BRANCH + "`.",
+              )
+
+          blocks = ["## ClickUp"]
+          for task in tasks:
+              lst = task.get("list") or {}
+              status = (task.get("status") or {}).get("status") or "-"
+              people = [a.get("username") or "" for a in (task.get("assignees") or [])]
+              assignees = ", ".join([p for p in people if p]) or "unassigned"
+              blocks.append("")
+              blocks.append("**[" + (task.get("name") or "") + "](" + (task.get("url") or "") + ")**")
+              blocks.append("")
+              blocks.append("| | |")
+              blocks.append("|---|---|")
+              blocks.append("| Task | `" + str(task.get("id")) + "` |")
+              blocks.append("| Status | " + status + " |")
+              blocks.append("| Assignees | " + assignees + " |")
+              blocks.append("| List | " + (lst.get("name") or "-") + " |")
+
+          blocks.append("")
+          blocks.append("_Matched on branch_ `" + BRANCH + "`")
+
+          body = "\n".join(blocks)
+          print(body)
+          emit_summary(body)
+          emit_output("found", "1")
+          emit_output("body", body)
 
       - name: Comment on the pull request
         if: github.event_name == 'pull_request' && steps.task.outputs.found == '1'
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: clickup-task


### PR DESCRIPTION
Resolves the ClickUp task from the branch name via the Branch Name custom field, instead of parsing a task id out of the branch.

Also logs the resolved task to the job log (step summaries are not visible in logs).

Test task: Schedule a Call (86d44t3xg)