### PR TITLE
feat(hooks): generate feature PRD from the linked ClickUp task on commit

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -14,4 +14,18 @@ if command -v gitnexus >/dev/null 2>&1; then
   gitnexus analyze >/dev/null 2>&1
 fi
 
+if [ -f "$REPO_ROOT/.git/prd-FAILED" ]; then
+  printf 'prd: last run failed — %s' "$(cat "$REPO_ROOT/.git/prd-FAILED")"
+  printf 'prd: see .git/prd-generate.log\n'
+  rm -f "$REPO_ROOT/.git/prd-FAILED"
+fi
+
+if [ "${TONE_PRD_DISABLE:-0}" != "1" ] && [ -x "$REPO_ROOT/.githooks/prd-generate" ] && command -v claude >/dev/null 2>&1; then
+  TARGET=$("$REPO_ROOT/.githooks/prd-generate" --plan 2>/dev/null)
+  if [ -n "$TARGET" ]; then
+    printf 'prd: generating %s in the background (several minutes)\n' "$TARGET"
+    nohup "$REPO_ROOT/.githooks/prd-generate" >/dev/null 2>&1 &
+  fi
+fi
+
 exit 0

--- a/.githooks/prd-generate
+++ b/.githooks/prd-generate
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+ENV_KEYS = ("CLICKUP_TOKEN", "CLICKUP_LIST_ID", "CLICKUP_BRANCH_FIELD_ID")
+
+
+def repo_root():
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return out.stdout.strip()
+    except Exception:
+        return ""
+
+
+def load_env(root):
+    values = {k: os.environ.get(k, "") for k in ENV_KEYS}
+    for rel in (".env", "backend/.env", "frontend/.env"):
+        path = os.path.join(root, rel)
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path, errors="ignore") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    key, _, val = line.partition("=")
+                    key = key.strip()
+                    if key in ENV_KEYS and not values.get(key):
+                        values[key] = val.strip().strip('"').strip("'")
+        except Exception:
+            continue
+    return values
+
+
+def current_branch():
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return out.stdout.strip()
+    except Exception:
+        return ""
+
+
+def clickup_get(path, token, params=None):
+    url = "https://api.clickup.com/api/v2" + path
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(url, headers={"Authorization": token})
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        try:
+            return json.loads(exc.read().decode())
+        except Exception:
+            return {"err": "HTTP " + str(exc.code)}
+    except Exception as exc:
+        return {"err": str(exc)}
+
+
+def resolve_task(env, branch):
+    token = env.get("CLICKUP_TOKEN")
+    list_id = env.get("CLICKUP_LIST_ID")
+    field_id = env.get("CLICKUP_BRANCH_FIELD_ID")
+    if not (token and list_id and field_id):
+        return None
+    flt = json.dumps([{"field_id": field_id, "operator": "=", "value": branch}])
+    data = clickup_get(
+        "/list/" + list_id + "/task",
+        token,
+        {"archived": "false", "include_closed": "true", "custom_fields": flt},
+    )
+    if not isinstance(data, dict) or data.get("err"):
+        return None
+    tasks = data.get("tasks") or []
+    return tasks[0] if tasks else None
+
+
+def slugify(name):
+    slug = re.sub(r"[^a-z0-9]+", "-", (name or "").lower()).strip("-")
+    return slug[:60] or "untitled-feature"
+
+
+def build_prompt(task, branch, out_path):
+    return (
+        "Use the generate_feature_prd_and_implementation skill to write a Feature PRD.\n\n"
+        "Run non-interactively: do NOT ask questions. Where information is missing, write\n"
+        "'TBD - needs product input' rather than inventing requirements.\n\n"
+        "Write the PRD to: " + out_path + "\n\n"
+        "Source ClickUp task\n"
+        "-------------------\n"
+        "id: " + str(task.get("id")) + "\n"
+        "name: " + (task.get("name") or "") + "\n"
+        "status: " + ((task.get("status") or {}).get("status") or "-") + "\n"
+        "url: " + (task.get("url") or "") + "\n"
+        "branch: " + branch + "\n\n"
+        "description:\n" + (task.get("description") or "(empty)") + "\n\n"
+        "Ground every technical section in this repository's actual code and conventions.\n"
+        "Do not modify any file other than the PRD.\n"
+    )
+
+
+def main():
+    root = repo_root()
+    if not root:
+        return 0
+    os.chdir(root)
+
+    branch = current_branch()
+    if not branch or branch == "HEAD":
+        return 0
+
+    env = load_env(root)
+    task = resolve_task(env, branch)
+    if not task:
+        return 0
+
+    slug = slugify(task.get("name"))
+    rel_path = os.path.join("docs", "features", slug + ".md")
+    abs_path = os.path.join(root, rel_path)
+
+    if os.path.exists(abs_path):
+        return 0
+
+    if "--plan" in sys.argv:
+        print(rel_path)
+        return 0
+
+    lock = os.path.join(root, ".git", "prd-" + slug + ".lock")
+    if os.path.exists(lock):
+        return 0
+    try:
+        os.makedirs(os.path.dirname(lock), exist_ok=True)
+        with open(lock, "w") as fh:
+            fh.write(str(os.getpid()))
+    except Exception:
+        return 0
+
+    os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+    log_path = os.path.join(root, ".git", "prd-generate.log")
+
+    started = time.strftime("%Y-%m-%d %H:%M:%S")
+    try:
+        with open(log_path, "a") as log:
+            log.write("\n=== " + started + " " + branch + " -> " + rel_path + " ===\n")
+            log.flush()
+            proc = subprocess.run(
+                ["claude", "-p", "--output-format", "text", "--permission-mode", "acceptEdits"],
+                input=build_prompt(task, branch, rel_path),
+                stdout=log,
+                stderr=log,
+                text=True,
+                timeout=1800,
+            )
+            code = proc.returncode
+    except Exception as exc:
+        code = -1
+        try:
+            with open(log_path, "a") as log:
+                log.write("ERROR: " + str(exc) + "\n")
+        except Exception:
+            pass
+    finally:
+        try:
+            os.remove(lock)
+        except Exception:
+            pass
+
+    ok = os.path.exists(abs_path)
+    try:
+        with open(log_path, "a") as log:
+            log.write(
+                ("OK " if ok else "FAILED ")
+                + rel_path
+                + " (exit=" + str(code) + ")\n"
+            )
+    except Exception:
+        pass
+
+    if not ok:
+        try:
+            with open(os.path.join(root, ".git", "prd-FAILED"), "w") as fh:
+                fh.write(branch + " -> " + rel_path + " (exit=" + str(code) + ")\n")
+        except Exception:
+            pass
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/clickup-task.yaml
+++ b/.github/workflows/clickup-task.yaml
@@ -22,108 +22,128 @@ jobs:
   resolve:
     runs-on: ubuntu-latest
     steps:
-      - name: Resolve ClickUp task from branch name
+      - name: Resolve ClickUp task for this branch
         id: task
         env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
           CLICKUP_TOKEN: ${{ secrets.CLICKUP_TOKEN }}
           CLICKUP_LIST_ID: ${{ vars.CLICKUP_LIST_ID }}
-          CLICKUP_TEAM_ID: ${{ vars.CLICKUP_TEAM_ID }}
+          CLICKUP_BRANCH_FIELD_ID: ${{ vars.CLICKUP_BRANCH_FIELD_ID }}
+        shell: python
         run: |
-          set -u
+          import json
+          import os
+          import re
+          import urllib.error
+          import urllib.parse
+          import urllib.request
 
-          TASK_ID=$(printf '%s' "$BRANCH" | grep -oE '[Cc][Uu][-_][0-9A-Za-z]{5,}' | head -1 | sed 's/^[Cc][Uu][-_]//')
-          CUSTOM_ID=0
+          BRANCH = os.environ.get("BRANCH", "")
+          TOKEN = os.environ.get("CLICKUP_TOKEN", "")
+          LIST_ID = os.environ.get("CLICKUP_LIST_ID", "")
+          FIELD_ID = os.environ.get("CLICKUP_BRANCH_FIELD_ID", "")
 
-          if [ -z "$TASK_ID" ]; then
-            TASK_ID=$(printf '%s' "$BRANCH" | grep -oE '[A-Z][A-Z0-9]{1,9}-[0-9]+' | head -1)
-            if [ -n "$TASK_ID" ]; then CUSTOM_ID=1; fi
-          fi
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY", os.devnull)
+          out_path = os.environ.get("GITHUB_OUTPUT", os.devnull)
 
-          if [ -z "$TASK_ID" ]; then
-            TASK_ID=$(printf '%s' "$BRANCH" | grep -oE '(^|[/_-])(86[0-9a-z]{6,10}|9[0-9a-z]{7,10})($|[/_-])' | grep -oE '86[0-9a-z]{6,10}|9[0-9a-z]{7,10}' | head -1)
-          fi
-
-          if [ -z "$TASK_ID" ]; then
-            echo "No ClickUp task id in branch '$BRANCH' — nothing to do." >> "$GITHUB_STEP_SUMMARY"
-            echo "found=0" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ -z "${CLICKUP_TOKEN:-}" ]; then
-            echo "Branch names task \`$TASK_ID\` but the CLICKUP_TOKEN secret is not configured." >> "$GITHUB_STEP_SUMMARY"
-            echo "found=0" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          URL="https://api.clickup.com/api/v2/task/${TASK_ID}"
-          if [ "$CUSTOM_ID" = "1" ]; then
-            if [ -z "${CLICKUP_TEAM_ID:-}" ]; then
-              echo "\`$TASK_ID\` looks like a custom id — set the CLICKUP_TEAM_ID variable." >> "$GITHUB_STEP_SUMMARY"
-              echo "found=0" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            URL="${URL}?custom_task_ids=true&team_id=${CLICKUP_TEAM_ID}"
-          fi
-
-          RESPONSE_FILE="${RUNNER_TEMP:-/tmp}/clickup-task.json"
-          curl -s --max-time 15 -H "Authorization: ${CLICKUP_TOKEN}" "$URL" -o "$RESPONSE_FILE"
-
-          python3 - "$RESPONSE_FILE" "$GITHUB_OUTPUT" "$GITHUB_STEP_SUMMARY" <<'PY'
-          import json, os, sys
-
-          response_path, out_path, summary_path = sys.argv[1], sys.argv[2], sys.argv[3]
-          expected = os.environ.get("CLICKUP_LIST_ID") or ""
-
-          def write(path, text):
-              with open(path, "a") as fh:
+          def emit_summary(text):
+              with open(summary_path, "a") as fh:
                   fh.write(text + "\n")
 
-          try:
-              with open(response_path) as fh:
-                  task = json.load(fh)
-          except Exception:
-              write(summary_path, "ClickUp returned an unreadable response.")
-              write(out_path, "found=0")
+          def emit_output(key, value):
+              with open(out_path, "a") as fh:
+                  if "\n" in value:
+                      fh.write(key + "<<CLICKUP_EOF\n" + value + "\nCLICKUP_EOF\n")
+                  else:
+                      fh.write(key + "=" + value + "\n")
+
+          def finish(found, summary):
+              print(summary)
+              emit_summary(summary)
+              emit_output("found", "1" if found else "0")
               raise SystemExit(0)
 
-          if not isinstance(task, dict) or "id" not in task:
-              err = task.get("err") if isinstance(task, dict) else None
-              write(summary_path, "ClickUp error: " + (err or "unexpected response"))
-              write(out_path, "found=0")
-              raise SystemExit(0)
+          def api(path, params=None):
+              url = "https://api.clickup.com/api/v2" + path
+              if params:
+                  url += "?" + urllib.parse.urlencode(params)
+              req = urllib.request.Request(url, headers={"Authorization": TOKEN})
+              try:
+                  with urllib.request.urlopen(req, timeout=20) as resp:
+                      return json.loads(resp.read().decode())
+              except urllib.error.HTTPError as exc:
+                  try:
+                      return json.loads(exc.read().decode())
+                  except Exception:
+                      return {"err": "HTTP " + str(exc.code)}
+              except Exception as exc:
+                  return {"err": str(exc)}
 
-          lst = task.get("list") or {}
-          list_id = str(lst.get("id") or "")
-          list_name = lst.get("name") or "-"
-          status = (task.get("status") or {}).get("status") or "-"
-          people = [a.get("username") or "" for a in (task.get("assignees") or [])]
-          assignees = ", ".join([p for p in people if p]) or "unassigned"
+          if not TOKEN:
+              finish(False, "CLICKUP_TOKEN secret is not configured.")
 
-          lines = [
-              "### ClickUp — [" + (task.get("name") or "") + "](" + (task.get("url") or "") + ")",
-              "",
-              "| | |",
-              "|---|---|",
-              "| Task | `" + str(task.get("id")) + "` |",
-              "| Status | " + status + " |",
-              "| Assignees | " + assignees + " |",
-              "| List | " + list_name + " |",
-          ]
-          if expected and list_id and list_id != expected:
-              lines.append("")
-              lines.append("> This task is in **" + list_name + "**, not the list configured for this repository.")
+          if not LIST_ID or not FIELD_ID:
+              finish(False, "Set the CLICKUP_LIST_ID and CLICKUP_BRANCH_FIELD_ID repository variables.")
 
-          body = "\n".join(lines)
-          write(summary_path, body)
+          tasks = []
 
-          with open(out_path, "a") as fh:
-              fh.write("found=1\n")
-              fh.write("body<<CLICKUP_EOF\n" + body + "\nCLICKUP_EOF\n")
-          PY
+          field_filter = json.dumps([{"field_id": FIELD_ID, "operator": "=", "value": BRANCH}])
+          data = api(
+              "/list/" + LIST_ID + "/task",
+              {
+                  "archived": "false",
+                  "include_closed": "true",
+                  "custom_fields": field_filter,
+              },
+          )
+
+          if isinstance(data, dict) and data.get("err"):
+              finish(False, "ClickUp error: " + str(data.get("err")))
+
+          tasks = data.get("tasks") or []
+
+          if not tasks:
+              m = re.search(r"[Cc][Uu][-_]([0-9A-Za-z]{5,})", BRANCH)
+              if m:
+                  single = api("/task/" + m.group(1))
+                  if isinstance(single, dict) and single.get("id"):
+                      tasks = [single]
+
+          if not tasks:
+              finish(
+                  False,
+                  "No ClickUp task is linked to branch `" + BRANCH + "`.\n\n"
+                  "Set the **Branch Name** field on the task to `" + BRANCH + "`.",
+              )
+
+          blocks = ["## ClickUp"]
+          for task in tasks:
+              lst = task.get("list") or {}
+              status = (task.get("status") or {}).get("status") or "-"
+              people = [a.get("username") or "" for a in (task.get("assignees") or [])]
+              assignees = ", ".join([p for p in people if p]) or "unassigned"
+              blocks.append("")
+              blocks.append("**[" + (task.get("name") or "") + "](" + (task.get("url") or "") + ")**")
+              blocks.append("")
+              blocks.append("| | |")
+              blocks.append("|---|---|")
+              blocks.append("| Task | `" + str(task.get("id")) + "` |")
+              blocks.append("| Status | " + status + " |")
+              blocks.append("| Assignees | " + assignees + " |")
+              blocks.append("| List | " + (lst.get("name") or "-") + " |")
+
+          blocks.append("")
+          blocks.append("_Matched on branch_ `" + BRANCH + "`")
+
+          body = "\n".join(blocks)
+          print(body)
+          emit_summary(body)
+          emit_output("found", "1")
+          emit_output("body", body)
 
       - name: Comment on the pull request
         if: github.event_name == 'pull_request' && steps.task.outputs.found == '1'
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: clickup-task


### PR DESCRIPTION
post-commit resolves the ClickUp task linked to the current branch (Branch Name custom field) and generates `docs/features/<slug>.md` via the claude CLI, detached so commits are not blocked.

- skips if the PRD already exists, so it runs once per feature not once per commit
- lock file prevents concurrent runs
- announces at commit time and reports failures on the next commit (`.git/prd-generate.log`)
- `TONE_PRD_DISABLE=1` opts out

Also switches the ClickUp workflow to resolve tasks by branch name instead of parsing a task id out of the branch.