### PR TITLE
feat(hooks): PRD + test generation from ClickUp, gitnexus in pre-commit

### DIFF
--- a/.githooks/hooklib.py
+++ b/.githooks/hooklib.py
@@ -1,0 +1,159 @@
+import json
+import os
+import re
+import subprocess
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+ENV_KEYS = ("CLICKUP_TOKEN", "CLICKUP_LIST_ID", "CLICKUP_BRANCH_FIELD_ID")
+
+
+def repo_root():
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return out.stdout.strip()
+    except Exception:
+        return ""
+
+
+def load_env(root):
+    values = {k: os.environ.get(k, "") for k in ENV_KEYS}
+    for rel in (".env", "backend/.env", "frontend/.env"):
+        path = os.path.join(root, rel)
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path, errors="ignore") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    key, _, val = line.partition("=")
+                    key = key.strip()
+                    if key in ENV_KEYS and not values.get(key):
+                        values[key] = val.strip().strip('"').strip("'")
+        except Exception:
+            continue
+    return values
+
+
+def current_branch():
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return out.stdout.strip()
+    except Exception:
+        return ""
+
+
+def changed_paths(limit=400):
+    for args in (
+        ["git", "diff", "--name-only", "HEAD~1", "HEAD"],
+        ["git", "show", "--name-only", "--format=", "HEAD"],
+    ):
+        try:
+            out = subprocess.run(args, capture_output=True, text=True, timeout=15)
+            paths = [p for p in out.stdout.splitlines() if p.strip()]
+            if paths:
+                return paths[:limit]
+        except Exception:
+            continue
+    return []
+
+
+def clickup_get(path, token, params=None):
+    url = "https://api.clickup.com/api/v2" + path
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(url, headers={"Authorization": token})
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        try:
+            return json.loads(exc.read().decode())
+        except Exception:
+            return {"err": "HTTP " + str(exc.code)}
+    except Exception as exc:
+        return {"err": str(exc)}
+
+
+def resolve_task(env, branch):
+    token = env.get("CLICKUP_TOKEN")
+    list_id = env.get("CLICKUP_LIST_ID")
+    field_id = env.get("CLICKUP_BRANCH_FIELD_ID")
+    if not (token and list_id and field_id):
+        return None
+    flt = json.dumps([{"field_id": field_id, "operator": "=", "value": branch}])
+    data = clickup_get(
+        "/list/" + list_id + "/task",
+        token,
+        {"archived": "false", "include_closed": "true", "custom_fields": flt},
+    )
+    if not isinstance(data, dict) or data.get("err"):
+        return None
+    tasks = data.get("tasks") or []
+    return tasks[0] if tasks else None
+
+
+def slugify(name):
+    slug = re.sub(r"[^a-z0-9]+", "-", (name or "").lower()).strip("-")
+    return slug[:60] or "untitled-feature"
+
+
+def acquire_lock(root, name):
+    lock = os.path.join(root, ".git", name + ".lock")
+    if os.path.exists(lock):
+        return None
+    try:
+        os.makedirs(os.path.dirname(lock), exist_ok=True)
+        with open(lock, "w") as fh:
+            fh.write(str(os.getpid()))
+        return lock
+    except Exception:
+        return None
+
+
+def run_claude(root, prompt, log_name, label, expect_paths, timeout=1800):
+    log_path = os.path.join(root, ".git", log_name)
+    started = time.strftime("%Y-%m-%d %H:%M:%S")
+    code = -1
+    try:
+        with open(log_path, "a") as log:
+            log.write("\n=== " + started + " " + label + " ===\n")
+            log.flush()
+            proc = subprocess.run(
+                ["claude", "-p", "--output-format", "text", "--permission-mode", "acceptEdits"],
+                input=prompt,
+                stdout=log,
+                stderr=log,
+                text=True,
+                timeout=timeout,
+            )
+            code = proc.returncode
+    except Exception as exc:
+        try:
+            with open(log_path, "a") as log:
+                log.write("ERROR: " + str(exc) + "\n")
+        except Exception:
+            pass
+
+    produced = [p for p in expect_paths if os.path.exists(os.path.join(root, p))]
+    ok = bool(produced)
+    try:
+        with open(log_path, "a") as log:
+            log.write(
+                ("OK " if ok else "FAILED ")
+                + label
+                + " (exit=" + str(code) + ", produced=" + str(len(produced)) + ")\n"
+            )
+    except Exception:
+        pass
+    return ok, produced

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -14,4 +14,33 @@ if command -v gitnexus >/dev/null 2>&1; then
   gitnexus analyze >/dev/null 2>&1
 fi
 
+for marker in prd tests; do
+  if [ -f "$REPO_ROOT/.git/${marker}-FAILED" ]; then
+    printf '%s: last run failed — %s' "$marker" "$(cat "$REPO_ROOT/.git/${marker}-FAILED")"
+    printf '%s: see .git/%s-generate.log\n' "$marker" "$marker"
+    rm -f "$REPO_ROOT/.git/${marker}-FAILED"
+  fi
+done
+
+if ! command -v claude >/dev/null 2>&1; then
+  exit 0
+fi
+
+if [ "${TONE_PRD_DISABLE:-0}" != "1" ] && [ -x "$REPO_ROOT/.githooks/prd-generate" ]; then
+  TARGET=$("$REPO_ROOT/.githooks/prd-generate" --plan 2>/dev/null)
+  if [ -n "$TARGET" ]; then
+    printf 'prd: generating %s in the background (several minutes)\n' "$TARGET"
+    nohup "$REPO_ROOT/.githooks/prd-generate" >/dev/null 2>&1 &
+    exit 0
+  fi
+fi
+
+if [ "${TONE_TESTS_DISABLE:-0}" != "1" ] && [ -x "$REPO_ROOT/.githooks/test-generate" ]; then
+  TARGET=$("$REPO_ROOT/.githooks/test-generate" --plan 2>/dev/null)
+  if [ -n "$TARGET" ]; then
+    printf 'tests: generating %s in the background (several minutes)\n' "$TARGET"
+    nohup "$REPO_ROOT/.githooks/test-generate" >/dev/null 2>&1 &
+  fi
+fi
+
 exit 0

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -10,10 +10,6 @@ if [ "${TONE_HOOKS_DISABLE:-0}" = "1" ]; then
   exit 0
 fi
 
-if command -v gitnexus >/dev/null 2>&1; then
-  gitnexus analyze >/dev/null 2>&1
-fi
-
 for marker in prd tests; do
   if [ -f "$REPO_ROOT/.git/${marker}-FAILED" ]; then
     printf '%s: last run failed — %s' "$marker" "$(cat "$REPO_ROOT/.git/${marker}-FAILED")"

--- a/.githooks/prd-generate
+++ b/.githooks/prd-generate
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import hooklib
+
+
+def build_prompt(task, branch, out_path):
+    return (
+        "Use the generate_feature_prd_and_implementation skill to write a Feature PRD.\n\n"
+        "Run non-interactively: do NOT ask questions. Where information is missing, write\n"
+        "'TBD - needs product input' rather than inventing requirements.\n\n"
+        "Write the PRD to: " + out_path + "\n\n"
+        "Source ClickUp task\n"
+        "-------------------\n"
+        "id: " + str(task.get("id")) + "\n"
+        "name: " + (task.get("name") or "") + "\n"
+        "status: " + ((task.get("status") or {}).get("status") or "-") + "\n"
+        "url: " + (task.get("url") or "") + "\n"
+        "branch: " + branch + "\n\n"
+        "description:\n" + (task.get("description") or "(empty)") + "\n\n"
+        "Ground every technical section in this repository's actual code and conventions.\n"
+        "Do not modify any file other than the PRD.\n"
+    )
+
+
+def main():
+    root = hooklib.repo_root()
+    if not root:
+        return 0
+    os.chdir(root)
+
+    branch = hooklib.current_branch()
+    if not branch or branch == "HEAD":
+        return 0
+
+    env = hooklib.load_env(root)
+    task = hooklib.resolve_task(env, branch)
+    if not task:
+        return 0
+
+    slug = hooklib.slugify(task.get("name"))
+    rel_path = os.path.join("docs", "features", slug + ".md")
+    if os.path.exists(os.path.join(root, rel_path)):
+        return 0
+
+    if "--plan" in sys.argv:
+        print(rel_path)
+        return 0
+
+    lock = hooklib.acquire_lock(root, "prd-" + slug)
+    if not lock:
+        return 0
+
+    os.makedirs(os.path.dirname(os.path.join(root, rel_path)), exist_ok=True)
+
+    try:
+        ok, _ = hooklib.run_claude(
+            root,
+            build_prompt(task, branch, rel_path),
+            "prd-generate.log",
+            branch + " -> " + rel_path,
+            [rel_path],
+        )
+    finally:
+        try:
+            os.remove(lock)
+        except Exception:
+            pass
+
+    if not ok:
+        try:
+            with open(os.path.join(root, ".git", "prd-FAILED"), "w") as fh:
+                fh.write(branch + " -> " + rel_path + "\n")
+        except Exception:
+            pass
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,46 +9,56 @@ if [ "${TONE_HOOKS_DISABLE:-0}" = "1" ]; then
   exit 0
 fi
 
-if [ ! -d "$REPO_ROOT/frontend" ]; then
+STAGED_ALL=$(git diff --cached --name-only --diff-filter=ACMR 2>/dev/null)
+if [ -z "$STAGED_ALL" ]; then
   exit 0
 fi
 
-STAGED=$(git diff --cached --name-only --diff-filter=ACMR -- 'frontend/*' 2>/dev/null | grep -E '\.(ts|tsx|js|jsx)$')
-if [ -z "$STAGED" ]; then
+if [ -d "$REPO_ROOT/frontend" ]; then
+  STAGED_FE=$(printf '%s\n' "$STAGED_ALL" | grep -E '^frontend/.*\.(ts|tsx|js|jsx)$')
+  if [ -n "$STAGED_FE" ] && [ -d "$REPO_ROOT/frontend/node_modules" ]; then
+    cd "$REPO_ROOT/frontend" || exit 0
+    HAS_LINT_STAGED=$(node -e "try{const p=require('./package.json');process.stdout.write(p['lint-staged']?'1':'')}catch(e){}" 2>/dev/null)
+    if [ -n "$HAS_LINT_STAGED" ]; then
+      npx lint-staged || exit $?
+    else
+      REL=$(printf '%s\n' "$STAGED_FE" | sed 's#^frontend/##')
+      # shellcheck disable=SC2086
+      npx eslint --fix $REL
+      STATUS=$?
+      if [ "$STATUS" -eq 1 ]; then
+        exit 1
+      fi
+      if [ "$STATUS" -ge 2 ]; then
+        printf 'pre-commit: eslint could not run (exit %s) — skipping lint\n' "$STATUS"
+      fi
+      cd "$REPO_ROOT" || exit 0
+      printf '%s\n' "$STAGED_FE" | while IFS= read -r f; do
+        if [ -n "$f" ] && [ -f "$f" ]; then
+          git add -- "$f"
+        fi
+      done
+    fi
+    cd "$REPO_ROOT" || exit 0
+  fi
+fi
+
+if [ "${TONE_GITNEXUS_DISABLE:-0}" = "1" ] || ! command -v gitnexus >/dev/null 2>&1; then
   exit 0
 fi
 
-cd "$REPO_ROOT/frontend" 2>/dev/null || exit 0
-
-if [ ! -d node_modules ]; then
+CODE_STAGED=$(printf '%s\n' "$STAGED_ALL" | grep -E '\.(py|ts|tsx|js|jsx|go|rs|java|rb|sql)$')
+if [ -z "$CODE_STAGED" ]; then
   exit 0
 fi
 
-HAS_LINT_STAGED=$(node -e "try{const p=require('./package.json');process.stdout.write(p['lint-staged']?'1':'')}catch(e){}" 2>/dev/null)
+printf 'gitnexus: re-indexing staged code…\n'
+gitnexus analyze --force >/dev/null 2>&1
 
-if [ -n "$HAS_LINT_STAGED" ]; then
-  exec npx lint-staged
-fi
-
-REL=$(printf '%s\n' "$STAGED" | sed 's#^frontend/##')
-
-# shellcheck disable=SC2086
-npx eslint --fix $REL
-STATUS=$?
-
-if [ "$STATUS" -ge 2 ]; then
-  printf 'pre-commit: eslint could not run (exit %s) — skipping lint for this commit\n' "$STATUS"
-  exit 0
-fi
-
-if [ "$STATUS" -ne 0 ]; then
-  exit "$STATUS"
-fi
-
-cd "$REPO_ROOT" || exit 0
-printf '%s\n' "$STAGED" | while IFS= read -r f; do
-  if [ -n "$f" ] && [ -f "$f" ]; then
+for f in AGENTS.md CLAUDE.md; do
+  if [ -f "$REPO_ROOT/$f" ] && ! git diff --quiet -- "$f" 2>/dev/null; then
     git add -- "$f"
+    printf 'gitnexus: %s refreshed and staged\n' "$f"
   fi
 done
 

--- a/.githooks/test-generate
+++ b/.githooks/test-generate
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import hooklib
+
+BACKEND_DIRS = ("test-cases", "backend/tests", "tests")
+FRONTEND_E2E = ("frontend/e2e",)
+
+
+def backend_root(root):
+    for d in BACKEND_DIRS:
+        if os.path.isdir(os.path.join(root, d)):
+            return d
+    return None
+
+
+def frontend_root(root):
+    for d in FRONTEND_E2E:
+        if os.path.isdir(os.path.join(root, d)):
+            return d
+    return None
+
+
+def touched(paths, prefixes):
+    return any(p.startswith(prefixes) for p in paths)
+
+
+def build_prompt(task, branch, prd_rel, targets):
+    lines = [
+        "Generate automated tests for the feature described in the PRD at " + prd_rel + ".",
+        "",
+        "Use section 5 (Test cases) of that PRD as the specification. Ground every test in the",
+        "repository's real modules, fixtures and conventions - read the existing tests first and",
+        "match their style, imports and fixtures exactly.",
+        "",
+        "Run non-interactively: do NOT ask questions. Do NOT start any dev server and do NOT",
+        "modify application code. Only create or edit test files.",
+        "",
+        "Before writing any mock or patch target, VERIFY the symbol exists and is reachable at",
+        "that path: grep the module for the name and confirm it is imported into that module's",
+        "namespace, not merely defined elsewhere. patch() resolves names in the module under",
+        "test, so patching a symbol the module does not import raises AttributeError at runtime.",
+        "Do not copy patch targets from neighbouring test files without re-verifying them - an",
+        "existing test may itself be stale.",
+        "",
+        "When you have written the tests, run them once with pytest (backend) and fix any",
+        "failures caused by the tests themselves. Do not change application code to make a test",
+        "pass - if a test fails because of a real defect, leave it failing and say so at the top",
+        "of the file.",
+        "",
+        "Write tests to:",
+    ]
+    for kind, path in targets:
+        lines.append("  " + kind + ": " + path)
+    lines += [
+        "",
+        "If a case in the PRD cannot be tested without new application code or fixtures, skip it",
+        "and note why in a comment at the top of the file rather than inventing scaffolding.",
+        "",
+        "ClickUp task: " + str(task.get("id")) + " - " + (task.get("name") or ""),
+        "Branch: " + branch,
+    ]
+    return "\n".join(lines)
+
+
+def plan(root):
+    branch = hooklib.current_branch()
+    if not branch or branch == "HEAD":
+        return None
+
+    env = hooklib.load_env(root)
+    task = hooklib.resolve_task(env, branch)
+    if not task:
+        return None
+
+    slug = hooklib.slugify(task.get("name"))
+    prd_rel = os.path.join("docs", "features", slug + ".md")
+    if not os.path.exists(os.path.join(root, prd_rel)):
+        return None
+
+    paths = hooklib.changed_paths()
+    targets = []
+
+    be_dir = backend_root(root)
+    if be_dir and touched(paths, ("core/", "ee/", "backend/", "alembic/", "main.py")):
+        rel = os.path.join(be_dir, "test_" + slug.replace("-", "_") + ".py")
+        if not os.path.exists(os.path.join(root, rel)):
+            targets.append(("backend", rel))
+
+    fe_dir = frontend_root(root)
+    if fe_dir and touched(paths, ("frontend/",)):
+        rel = os.path.join(fe_dir, slug + ".spec.ts")
+        if not os.path.exists(os.path.join(root, rel)):
+            targets.append(("frontend", rel))
+
+    if not targets:
+        return None
+    return {"task": task, "branch": branch, "slug": slug, "prd": prd_rel, "targets": targets}
+
+
+def main():
+    root = hooklib.repo_root()
+    if not root:
+        return 0
+    os.chdir(root)
+
+    job = plan(root)
+    if not job:
+        return 0
+
+    if "--plan" in sys.argv:
+        print(" ".join(p for _, p in job["targets"]))
+        return 0
+
+    lock = hooklib.acquire_lock(root, "tests-" + job["slug"])
+    if not lock:
+        return 0
+
+    for _, rel in job["targets"]:
+        os.makedirs(os.path.dirname(os.path.join(root, rel)), exist_ok=True)
+
+    try:
+        ok, produced = hooklib.run_claude(
+            root,
+            build_prompt(job["task"], job["branch"], job["prd"], job["targets"]),
+            "test-generate.log",
+            job["branch"] + " -> " + ", ".join(p for _, p in job["targets"]),
+            [p for _, p in job["targets"]],
+        )
+    finally:
+        try:
+            os.remove(lock)
+        except Exception:
+            pass
+
+    if not ok:
+        try:
+            with open(os.path.join(root, ".git", "tests-FAILED"), "w") as fh:
+                fh.write(job["branch"] + " -> " + ", ".join(p for _, p in job["targets"]) + "\n")
+        except Exception:
+            pass
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.gitignore
+++ b/.gitignore
@@ -152,7 +152,8 @@ Thumbs.db
 
 .claude/settings.local.json
 
-docs/
+docs/*
+!docs/features/
 /scripts
 files/
 .claude/skills/code-review

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **tone** (17612 symbols, 40364 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tone** (17994 symbols, 40802 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ New behavior needs tests; bug fixes need a regression test.
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **tone** (17612 symbols, 40364 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tone** (17994 symbols, 40802 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/docs/features/schedule-a-call.md
+++ b/docs/features/schedule-a-call.md
@@ -1,0 +1,440 @@
+# Schedule a Call — PRD & Implementation Spec
+
+> Authored 2026-08-28. Update via `/generate_feature_prd_and_implementation` whenever the feature changes.
+>
+> **Source:** ClickUp [86d44t3xg — "Schedule a Call"](https://app.clickup.com/t/86d44t3xg) (status: `to do`) · branch `feature/schedule-a-call`
+>
+> **Authoring mode:** non-interactive. The source ticket is a *product question*, not a spec. Every
+> requirement that the ticket does not answer is written as **`TBD - needs product input`** rather than
+> invented. Sections that describe current behaviour are grounded in the code and cite `file:line`.
+
+---
+
+## 1. Overview
+
+Today, one user-facing action ("Schedule Call" → modal "New outbound call") covers two behaviours that
+are conceptually different:
+
+1. **Call now** — dial the destination immediately.
+2. **Schedule for later** — queue the call to dial at a future instant.
+
+The distinction is currently a checkbox inside the modal (`Schedule for later`,
+`frontend/src/components/outbound-calls/NewOutboundCallModal.tsx:597`) and an optional field on the API
+(`scheduled_at`, `core/api/v1/outbound_calls.py:30`). The ticket raises that labelling the *entry point*
+"Schedule a Call" is wrong for the immediate case, and proposes splitting the concept:
+
+- **Outbound Call** → immediate dialing
+- **Schedule a Call** → calls queued for a later time
+
+**Target user:** any org member (`require_org_member`) who places outbound calls from the agent editor's
+**Schedule** tab.
+
+**Problem statement:** the naming does not match the behaviour, in three concrete places in the code:
+
+| Where | Current copy / behaviour | Why it misleads |
+|---|---|---|
+| `ScheduledCallsPage.tsx:268`, `:307` | Primary button reads **"Schedule Call"** | It is the only way to place an *immediate* call too. |
+| `NewOutboundCallModal.tsx:416` | Modal title reads **"New outbound call"** | Opened from a button labelled "Schedule Call" — the two names disagree. |
+| `ScheduledCallsPage.tsx:257–260` | List titled **"Scheduled Calls"**, described as "queued to dial at a future time" | Multi-number *immediate* batches land in this same list (see below). |
+
+**The behavioural inconsistency behind the naming problem** (this is not just copy): whether a request
+dials now or is queued is decided by *two* inputs, not one.
+
+- A **single** number with no `scheduled_at` dials inline and returns `mode: "immediate"`
+  (`core/services/outbound_call_service.py:463`, response at `:574`). It surfaces in **Call History**.
+- **Multiple** numbers with no `scheduled_at` are routed through `_schedule_via_contacts` and persisted as
+  `scheduled_calls` rows with `mode: "bulk"` (`outbound_call_service.py:466–473`, `:544`). They dial ASAP —
+  `_resolve_contact_when` falls back to `now` (`:766`) — but they **appear in the "Scheduled Calls" list**.
+- A request with `scheduled_at` returns `mode: "scheduled"` (`:544`).
+- `provider="websocket"` with no `scheduled_at` fans out immediately as `mode: "parallel_websocket"`
+  (`:459–460`, `:698`).
+
+So "Scheduled Calls" today means "rows in the `scheduled_calls` table", which includes immediate bulk
+dials. That is the root of the confusion the ticket describes.
+
+---
+
+## 2. User stories & use cases
+
+Derived from the ticket. Acceptance detail for each is deferred to product.
+
+- **US-1** — As an org member, I want a clearly labelled **Outbound Call** action, so that I understand the
+  call will be placed immediately when I confirm.
+- **US-2** — As an org member, I want a separate **Schedule a Call** action, so that I can queue a call for
+  a later time without wondering whether it will dial right now.
+- **US-3** — As an org member, I want the **Scheduled Calls** list to contain only calls that are actually
+  waiting for a future time, so that the list matches its name.
+  - ⚠ Conflicts with current behaviour: immediate `bulk` batches are written to `scheduled_calls`
+    (`outbound_call_service.py:469–473`). Resolving this needs a product decision — see FR-4.
+- **US-4** — As an org member placing a bulk/CSV batch, I want to know before submitting whether rows will
+  dial now or later. *(Partially implemented already: `immediateNotice`, `NewOutboundCallModal.tsx:388–394`;
+  submit-button label switches between "Call … now" / "Schedule call", `:400–410`.)*
+
+**Use cases not covered by the ticket:** `TBD - needs product input` — specifically whether the split
+applies to the CSV/Excel upload path, the per-row `schedule_column` path, and
+`POST /api/v1/contact/schedule-calls` (`core/api/v1/contacts.py:186`), which also dials ASAP when
+`scheduled_at` is omitted.
+
+---
+
+## 3. Functional requirements
+
+The ticket asks a question and does not state requirements. The items below are the *decisions that must be
+made*, each with the code that would change. **None are approved yet.**
+
+- **FR-1 — Two distinct entry points in the UI.** Replace the single "Schedule Call" button
+  (`ScheduledCallsPage.tsx:263–269` and the empty-state button at `:307–309`) with two actions:
+  "Outbound Call" (immediate) and "Schedule a Call" (future).
+  - Exact labels, button order, primary/secondary emphasis, and icons: `TBD - needs product input`.
+  - Whether they open two modals or one modal in two modes: `TBD - needs product input`.
+    (Recommended: **one** `NewOutboundCallModal` with a `mode: 'immediate' | 'scheduled'` prop — it already
+    holds agent/from-number/provider/concurrency/upload/directory logic that both flows need; forking it
+    would duplicate ~650 lines and violate the single-source-of-truth rule in `CLAUDE.md`.)
+- **FR-2 — Mode-specific form.** In `immediate` mode the "Schedule for later" checkbox
+  (`NewOutboundCallModal.tsx:597`) and the `DateTimePicker` block (`:598–635`) are hidden; in `scheduled`
+  mode the scheduled time is **required** rather than opt-in.
+- **FR-3 — Copy alignment.** Modal title (`:416`), submit label (`:400–410`), and success toasts
+  (`:347–353`) must state which behaviour was chosen. Final strings: `TBD - needs product input`.
+- **FR-4 — Where immediate bulk calls are listed.** Decide one of:
+  - **(a)** Keep writing immediate bulk batches to `scheduled_calls` and rename the list to something
+    behaviour-accurate (e.g. "Outbound queue"), or
+  - **(b)** Keep the list name and filter immediate rows out of the default view, or
+  - **(c)** Change the backend so immediate bulk no longer persists `scheduled_calls` rows.
+  - **Decision: `TBD - needs product input`.** Note (c) is the largest change — it would remove the
+    per-batch concurrency mechanism for immediate batches, which is enforced only at dispatch over
+    `scheduled_calls` rows (`outbound_call_service.py:866+`, `resolve_batch_concurrency` in
+    `core/services/outbound_capacity.py`). **Recommended: (a) or (b).**
+- **FR-5 — API surface.** Decide whether the split is UI-only or reaches the API:
+  - **(a)** UI-only — `POST /api/v1/outbound-call/create` keeps deciding from `scheduled_at`
+    (`core/api/v1/outbound_calls.py:81`). No backend change, no migration, no API-consumer breakage.
+  - **(b)** Add explicit sibling routes (e.g. `POST /outbound-call/call-now`, `POST /outbound-call/schedule`)
+    as thin wrappers over `OutboundCallService.create_outbound_call`.
+  - **Decision: `TBD - needs product input`. Recommended: (a)** — the ticket describes a naming/IA problem,
+    and `mode` is already returned in every response (`types/outboundCall.ts:23`), so the client can label
+    outcomes correctly without new endpoints.
+- **FR-6 — Navigation / IA.** There is no global `/scheduled-calls` route; the list is the agent editor's
+  edit-only, outbound-gated **Schedule** tab (`frontend/src/components/agents/agent-form/sectionNav.ts:54`,
+  `:65`, `:72` → `steps/ScheduleStep.tsx`). Whether the tab is renamed or split into two tabs:
+  `TBD - needs product input`.
+
+### Edge cases & failure modes
+
+Existing behaviour that any redesign must preserve — each already has code:
+
+- **Past / near-now time.** `scheduled_at` in the past is rejected with 400, with a 60s grace window
+  (`outbound_call_service.py:447–453`, mirrored client-side at `NewOutboundCallModal.tsx:602–608`).
+- **Empty destination list.** 400 "Provide at least one destination number." (`:423–424`); all-invalid
+  numbers → 400 (`:444–445`).
+- **Partial validity.** Per-number E.164 failures are collected into `invalid` instead of failing the batch
+  (`:429–442`); the modal renders them (`NewOutboundCallModal.tsx:569–586`).
+- **Duplicates.** De-duplicated both client-side (`parseNumbers`, `:81–96`) and server-side (`seen` set, `:439`).
+- **Org isolation.** Every route uses `require_org_member`; the service is constructed with the caller's
+  `org_id` (`core/api/v1/outbound_calls.py:71–74`) and all queries are org-scoped
+  (e.g. contact load at `outbound_call_service.py:809–813`).
+- **Permission boundary.** The `websocket` trigger is restricted — `assert_ws_trigger_allowed`
+  (`:1066`) is called on both create routes (`outbound_calls.py:91`, `:138`), and the UI only shows the
+  "Trigger via" selector when `ws_trigger_allowed` is true (`NewOutboundCallModal.tsx:456`).
+- **Concurrency.** Per-batch limit is stamped on `scheduled_calls.batch_id` / `.max_concurrency`
+  (`core/models/scheduled_call.py:41–45`) and enforced at dispatch. **If FR-4(c) is chosen, immediate bulk
+  loses this — call out explicitly before implementing.**
+- **Cancel race.** Only `scheduled` rows are cancelable; a row already `processing` is rejected
+  (`CANCELABLE`, `ScheduledCallsPage.tsx:27`; selection is pruned on poll at `:91–98`).
+- **Per-row CSV schedule times.** `schedule_column` cells that are unparseable or in the past are reported
+  as invalid rather than dialed now (`outbound_calls.py:165–187`,
+  `ContactSchemaService.apply_scheduled_at_from_column`). Empty cells fall back to the request-level time.
+- **Telephony failure.** Immediate dial errors surface as 502 (`outbound_call_service.py:565–567`);
+  enqueue failures are isolated per row and mark that row `failed` (`:734–738`).
+- Pagination limits, rate limits/quotas, and any new empty states for a split view: `TBD - needs product input`.
+
+---
+
+## 4. Non-functional requirements
+
+- **Backward compatibility (blocker-level).** `POST /api/v1/outbound-call/create` and
+  `POST /api/v1/contact/schedule-calls` are public API surface. Under FR-5(a) nothing breaks. Under FR-5(b),
+  the existing route must remain and keep its current semantics.
+- **Multi-tenancy.** Unchanged — `require_org_member` on every route; org-scoped queries throughout.
+  No new tenancy seam is introduced by a naming change.
+- **Observability.** Existing `[outbound]`-tagged loguru lines (`outbound_call_service.py:552`, `:569`,
+  `:853`) already distinguish immediate from scheduled. No new logging required for a UI-only change.
+- **Performance.** No new budget. The modal already gates its schema/directory list queries on
+  `open && uploadMode` (`NewOutboundCallModal.tsx:143–147`); a mode split must not un-gate them.
+- **Security/compliance:** unchanged. **Accessibility:** two adjacent primary actions need distinct
+  accessible names — covered by FR-3 copy.
+
+---
+
+## 5. Test cases (requirements-as-tests)
+
+Backend tests live in `test-cases/core/test_outbound_calls.py` and
+`test-cases/test_outbound_status_machine.py`; frontend e2e specs live in `frontend/e2e/`.
+
+Regression tests locking today's behaviour (must keep passing whichever option is chosen):
+
+```
+TEST: single immediate number dials inline
+  GIVEN an outbound agent and one valid E.164 number
+  WHEN  POST /api/v1/outbound-call/create with no scheduled_at
+  THEN  response mode == "immediate" and no scheduled_calls row is created
+
+TEST: future time queues instead of dialing
+  GIVEN an outbound agent and a scheduled_at 1 hour ahead
+  WHEN  POST /api/v1/outbound-call/create
+  THEN  response mode == "scheduled" and a scheduled_calls row exists with status "scheduled"
+
+TEST: past time is rejected
+  GIVEN a scheduled_at 10 minutes in the past
+  WHEN  POST /api/v1/outbound-call/create
+  THEN  400 "scheduled_at must be in the future."
+
+TEST: near-now time is accepted (60s grace)
+  GIVEN a scheduled_at 30 seconds in the past
+  WHEN  POST /api/v1/outbound-call/create
+  THEN  the request succeeds and the call is queued to dial ASAP
+
+TEST: cross-org scheduled call is not visible
+  GIVEN a scheduled call owned by org B
+  WHEN  a member of org A calls GET /api/v1/outbound-call/scheduled/{id}
+  THEN  404
+```
+
+New tests required by this feature:
+
+```
+TEST: multi-number immediate batch is labelled correctly
+  GIVEN two valid numbers and no scheduled_at
+  WHEN  POST /api/v1/outbound-call/create
+  THEN  response mode == "bulk"
+  AND   the UI reports it as an immediate call, not a scheduled one
+  # Expected list placement of these rows: TBD - needs product input (see FR-4)
+
+TEST: Schedule a Call requires a time
+  GIVEN the "Schedule a Call" entry point is open
+  WHEN  the user submits without picking a date & time
+  THEN  the form blocks submission with a validation error
+  # Exact message: TBD - needs product input
+
+TEST: Outbound Call hides scheduling controls
+  GIVEN the "Outbound Call" entry point is open
+  WHEN  the form renders
+  THEN  the "Schedule for later" checkbox and the date/time picker are not present
+```
+
+Acceptance criteria beyond the above: `TBD - needs product input`.
+
+---
+
+## 6. Data model / DB schema
+
+**No schema change is required for the UI-only option (FR-5a), which is the recommended path.**
+
+Existing table — `scheduled_calls` (`core/models/scheduled_call.py`, extends `OrgScopedModel`):
+
+| Column | Type | Null | Notes |
+|---|---|---|---|
+| `agent_id` | UUID FK `agents.id` (RESTRICT) | no | |
+| `channel_id` | UUID FK `channels.id` (SET NULL) | yes | |
+| `contact_id` | UUID FK `contacts.id` (SET NULL) | yes | indexed |
+| `from_number` / `to_number` | `String(20)` | no | E.164 |
+| `scheduled_at` | `DateTime(timezone=True)` | no | indexed |
+| `status` | `String(20)` | no | `scheduled\|processing\|dispatched\|completed\|busy\|no_answer\|failed\|canceled` (`:32–33`) |
+| `provider` | `String(20)` | no | default `twilio` |
+| `provider_call_sid` | `String(120)` | yes | |
+| `call_id` | UUID FK `calls.id` (SET NULL) | yes | set once the call connects |
+| `queue_job_id` | `Integer` | yes | Procrastinate job |
+| `error` | `String(500)` | yes | |
+| `created_by_user_id` | UUID | yes | |
+| `batch_id` / `max_concurrency` | UUID / Integer | yes | per-batch concurrency; NULL = unlimited |
+| `metadata_` (`metadata`) | JSONB | yes | |
+
+Index: `ix_scheduled_calls_batch_status` on `(batch_id, status)` for the dispatch-time in-flight count
+(`:20–22`). Org scoping + soft-delete columns come from `OrgScopedModel` — the convention holds.
+
+**Only if FR-4(c) or an explicit-kind model is chosen** would a change be needed — e.g. a
+`kind` / `is_immediate` discriminator column on `scheduled_calls` plus an Alembic migration and a backfill
+(`UPDATE ... SET kind = 'immediate' WHERE …`). Whether to add it: `TBD - needs product input`.
+Migration head to branch from: the latest of `d4f1b7c8e35a`, `6ab783e9080f`, `b7d4e9c2f1a8` — confirm with
+`alembic heads` at implementation time.
+
+---
+
+## 7. API design
+
+All routes are mounted at `/api/v1/outbound-call` (`main.py:176`, `:234`) and guarded by
+`require_org_member` (`core/api/v1/outbound_calls.py`). Responses are plain dicts built by
+`OutboundCallService._to_response` (`:1341`) — this repo does **not** use a `.to_dict()` ORM convention.
+
+### Existing (unchanged under the recommended option)
+
+| Method + path | Handler | Purpose |
+|---|---|---|
+| `POST /outbound-call/create` | `create_outbound_call` (`:81`) | Dial now, or queue when `scheduled_at` is set |
+| `POST /outbound-call/create-from-file` | `create_outbound_call_from_file` (`:104`) | CSV/Excel batch; optional per-row `schedule_column` |
+| `GET  /outbound-call/concurrency-max` | `get_outbound_concurrency_max` (`:205`) | `{max, ws_trigger_allowed}` for the modal |
+| `POST /outbound-call/scheduled/list` | `list_scheduled_calls` (`:218`) | Paginated list (`page_no`, `page_size`, `filters`, `sort_by`, `sort_order`, date range) |
+| `GET  /outbound-call/scheduled/{id}` | `get_scheduled_call` (`:247`) | Single row |
+| `POST /outbound-call/scheduled/{id}/cancel` | `cancel_scheduled_call` (`:256`) | Cancel one |
+| `POST /outbound-call/scheduled/bulk-cancel` | `bulk_cancel_scheduled_calls` (`:236`) | Cancel up to 500 |
+| `POST /contact/schedule-calls` | `schedule_contact_calls` (`core/api/v1/contacts.py:186`) | Schedule from selected contacts; also dials ASAP when `scheduled_at` is omitted |
+
+`CreateOutboundCallRequest` (`:21–44`): `agent_id` (required), `from_number?`, `to_numbers[]?` /
+`to_number?`, `scheduled_at?`, `directory_id?`, `max_concurrency?`,
+`provider?: "twilio"|"telnyx"|"websocket"`.
+
+Response `mode` values: `immediate` | `bulk` | `scheduled` | `parallel_websocket`
+(`types/outboundCall.ts:23`).
+
+### Proposed additions
+
+`TBD - needs product input` — only if FR-5(b) is chosen. If so, the new routes must be **thin wrappers**
+that call the existing `OutboundCallService` methods (no logic in the router), per `CLAUDE.md`:
+
+```
+POST /api/v1/outbound-call/call-now   → OutboundCallService.create_outbound_call(scheduled_at=None)
+POST /api/v1/outbound-call/schedule   → OutboundCallService.create_outbound_call(scheduled_at=<required>)
+```
+
+No WebSocket events are emitted for this feature; the UI polls (`POLL_MS = 5000`,
+`ScheduledCallsPage.tsx:22`).
+
+---
+
+## 8. Backend implementation
+
+Under the recommended UI-only option (FR-5a), **no backend change is required.** Files that would change
+only if FR-4(c) or FR-5(b) is chosen:
+
+- **Router:** `core/api/v1/outbound_calls.py` — `create_outbound_call`, `create_outbound_call_from_file`,
+  `list_scheduled_calls`, `cancel_scheduled_call`, `bulk_cancel_scheduled_calls`, `get_scheduled_call`.
+- **Service:** `core/services/outbound_call_service.py` (`OutboundCallService`, extends `BaseService`) —
+  `create_outbound_call` (`:407`), `create_outbound_calls_from_rows` (`:475`), `_schedule_via_contacts`
+  (`:506`), `_dial_now` (`:549`), `_dial_parallel_ws` (`:588`), `_persist_and_enqueue_rows` (`:711`),
+  `_resolve_contact_when` (`:746`), `schedule_calls_for_contacts` (`:768`), `dispatch_scheduled_call`
+  (`:866`), `drain_outbound_capacity` (`:1089`), `list_scheduled_calls` (`:1280`), `_to_response` (`:1341`).
+- **Shared helpers already in place (reuse, do not re-implement):**
+  `select_from_number` (`:253`), `resolve_batch_concurrency` / `get_env_outbound_ceiling`
+  (`core/services/outbound_capacity.py`), `get_scheduling_timezone` (`core/services/org_settings.py`),
+  the ingestion pipeline in `core/services/contact_ingestion/`.
+- **Background work:** Procrastinate — one deferred job per row at that row's own `scheduled_at`
+  (`enqueue_outbound_calls_batch`, `core/services/ingestion_queue.py`); periodic `drain_outbound_calls`
+  refills freed per-batch slots. Worker manifest: `build/kubernetes/_base/call/outbound-call-worker.yaml`.
+  This project uses Procrastinate, **not** Celery.
+
+---
+
+## 9. Frontend implementation
+
+- **Route:** none of its own. The list renders inside the agent editor's **Schedule** section —
+  `agent-form/sectionNav.ts:54` (`{ key: 'schedule', label: 'Schedule', icon: CalendarClock }`), gated
+  edit-only (`:65`) and outbound-only (`:72`) → `agent-form/steps/ScheduleStep.tsx` →
+  `components/scheduled-calls/ScheduledCallsPage.tsx` with `agentId` (list filtered, agent locked in the
+  modal, Agent column hidden at `:251`).
+- **Components to modify:**
+  - `components/scheduled-calls/ScheduledCallsPage.tsx` — header + primary action (`:255–271`),
+    empty state (`:298–311`), modal mount (`:314–323`).
+  - `components/outbound-calls/NewOutboundCallModal.tsx` — mode prop, title (`:416`), submit label
+    (`:400–410`), schedule checkbox + picker (`:597–635`), `immediateNotice` (`:388–394`), toasts (`:347–353`).
+  - `components/scheduled-calls/ScheduledCallStatusChip.tsx` — only if statuses change (they should not).
+- **New components:** none expected under the recommended one-modal-two-modes approach.
+- **Form layout mode:** **modal** (existing `CustomModal` via `@/components/shared`). Keep `CustomButton`
+  and the shared `DateTimePicker` — mandated by `CLAUDE.md` / `.cursor/rules/shared-components.mdc`.
+- **State:** this repo uses **Jotai**, not Zustand — `atoms/OutboundCallsAtom.tsx`
+  (`scheduledCallsAtom`, `fetchScheduledCalls`, `createOutboundCallAtom`,
+  `createOutboundCallFromFileAtom`, `cancelScheduledCallAtom`, `cancelScheduledCallsAtom`).
+  Components call atoms; atoms call `services/outboundCallService.ts`; HTTP goes through
+  `utils/axios.ts`. TanStack Query is used only for the contacts schema/directory lists
+  (`lib/api/contactSchemas.ts`, `lib/api/contactDirectories.ts`).
+- **Types:** `types/outboundCall.ts` — add the mode prop type here, not inline in the component.
+- **Listing component:** `CustomTable` (existing), with client-side polling and bulk-select. Unchanged.
+- **Toasts:** `showToast` from `@/utils/toast`; API errors via `handleApiError` from `@/utils/helpers`.
+
+### ⚠ Conventions Check
+
+Flagged for the reader — the PRD skill's generic template assumes a different stack than this repo:
+
+| Skill template assumes | This repo actually uses |
+|---|---|
+| `backend/app/models`, `backend/app/services` | `core/models/`, `core/services/`, `core/api/v1/` |
+| `require_permission(...)` | `require_org_member` / `require_admin_or_owner` (`core/middleware/auth.py`) |
+| `.to_dict()` serialization | hand-built response dicts (`OutboundCallService._to_response`) |
+| Celery tasks | Procrastinate jobs |
+| Zustand + React Query | Jotai (+ TanStack Query for the contacts lists only) |
+| `postman/Tone-Test-API.postman_collection.json` | no `postman/` directory exists in this repo |
+
+No convention violation is introduced by this feature as specified. The one design risk to watch is
+FR-4(c): removing `scheduled_calls` rows for immediate bulk would also remove per-batch concurrency
+enforcement, which lives entirely on those rows.
+
+---
+
+## 10. Postman collection & examples
+
+There is no Postman collection checked into this repo (no `postman/` directory), so there is nothing to
+update. Interactive API docs are served by FastAPI at `/docs`. Current request/response shapes for the two
+behaviours the ticket distinguishes:
+
+**Immediate call**
+
+```http
+POST /api/v1/outbound-call/create
+Content-Type: application/json
+
+{ "agent_id": "0b2f…", "to_number": "+14155550123" }
+```
+```json
+{ "mode": "immediate", "status": "dialing", "agent_id": "0b2f…",
+  "from_number": "+14155550100", "to_number": "+14155550123", "provider": "twilio" }
+```
+```bash
+curl -X POST "$BASE/api/v1/outbound-call/create" -b cookies.txt \
+  -H 'Content-Type: application/json' \
+  -d '{"agent_id":"0b2f…","to_number":"+14155550123"}'
+```
+
+**Scheduled call**
+
+```http
+POST /api/v1/outbound-call/create
+Content-Type: application/json
+
+{ "agent_id": "0b2f…", "to_numbers": ["+14155550123", "+14155550124"],
+  "scheduled_at": "2026-09-01T17:30:00Z", "max_concurrency": 5 }
+```
+```json
+{ "mode": "scheduled", "count": 2, "invalid": [], "assigned": 2, "data": [ /* scheduled_call rows */ ] }
+```
+```bash
+curl -X POST "$BASE/api/v1/outbound-call/create" -b cookies.txt \
+  -H 'Content-Type: application/json' \
+  -d '{"agent_id":"0b2f…","to_numbers":["+14155550123"],"scheduled_at":"2026-09-01T17:30:00Z"}'
+```
+
+Examples for any new endpoints: `TBD - needs product input` (blocked on FR-5).
+
+---
+
+## 11. Next steps (downstream skills)
+
+- [ ] **Resolve the open product decisions first** — FR-1 (labels + one-modal-vs-two), FR-4 (where immediate
+      bulk rows are listed), FR-5 (UI-only vs new endpoints), FR-6 (tab naming). Everything below is blocked
+      on these; running a generator now would scaffold against `TBD`s.
+- [ ] Re-run `/generate_feature_prd_and_implementation schedule-a-call` once decisions land, to replace the
+      `TBD - needs product input` markers.
+- [ ] Then run `/implement_feature_from_prd schedule-a-call`, or the individual generators:
+      - `/form_page` with `layout=modal` — only if FR-1 lands on a new/split modal.
+      - `/backend_form` — only if FR-5(b) adds explicit `call-now` / `schedule` endpoints.
+      - `/table_page` + `/backend_tables` — **not needed**; `POST /outbound-call/scheduled/list` and
+        `ScheduledCallsPage` (CustomTable) already exist. Modify, don't regenerate.
+- [ ] Alembic migration — **only** if FR-4(c) / a `kind` discriminator is approved
+      (`alembic revision --autogenerate -m "outbound call kind"`).
+- [ ] Tests: extend `test-cases/core/test_outbound_calls.py` with the new cases in §5; add/extend a
+      Playwright spec under `frontend/e2e/` for the split entry points.
+- [ ] Postman: N/A — no collection in this repo.
+
+---
+
+## 12. Change Log
+
+- 2026-08-28 — Initial PRD authored from ClickUp task 86d44t3xg, non-interactively. Current
+  immediate-vs-scheduled behaviour documented from code; open product decisions recorded as
+  `TBD - needs product input` rather than invented.

--- a/test-cases/core/test_outbound_calls.py
+++ b/test-cases/core/test_outbound_calls.py
@@ -105,7 +105,7 @@ class TestCreateValidation:
 
 
 @patch("core.services.outbound_call_service.OutboundCallService._prewarm_pipeline", lambda *a, **k: None)
-@patch("core.services.outbound_call_service.get_twilio_credentials",
+@patch("core.services.outbound_call_service.get_provider_credentials",
        return_value={"account_sid": "AC", "auth_token": "tok"})
 class TestCreateSuccess:
     def _db(self):

--- a/test-cases/test_schedule_a_call.py
+++ b/test-cases/test_schedule_a_call.py
@@ -1,0 +1,321 @@
+"""Requirements-as-tests for the "Schedule a Call" feature (docs/features/schedule-a-call.md §5).
+
+Source: core/services/outbound_call_service.py — the immediate-vs-scheduled decision the PRD
+is about lives entirely in ``OutboundCallService.create_outbound_call`` (:407) and the read
+path ``get_scheduled_call`` (:1272). Mocked DB, no live Twilio — same style as
+``test-cases/core/test_outbound_calls.py``.
+
+These lock TODAY's behaviour: whichever of FR-4 / FR-5 product picks, the four response
+``mode`` values and the schedule-time validation below must keep behaving this way (§5,
+"Regression tests locking today's behaviour").
+
+Cases from §5 deliberately NOT implemented here, and why:
+
+* "cross-org scheduled call is not visible" is specified against
+  ``GET /api/v1/outbound-call/scheduled/{id}``. This module's fixtures
+  (``test-cases/conftest.py``) are mock-only — there is no ``TestClient`` here; the real-DB
+  ``TestClient`` fixtures live one level down in ``test-cases/core/conftest.py`` and are not
+  visible to a top-level module. The org boundary is therefore asserted where it is actually
+  enforced — ``BaseService.query``'s org filter, via ``get_scheduled_call`` — with a
+  filter-aware session double. The route adds no scoping of its own
+  (``core/api/v1/outbound_calls.py:247`` constructs the service with the caller's org and
+  forwards), so this covers the same seam one layer down.
+* "multi-number immediate batch … AND the UI reports it as an immediate call" — only the
+  backend half (``mode == "bulk"`` for a no-``scheduled_at`` batch) is asserted. The UI half
+  is a frontend assertion; there is no Playwright/RTL harness for
+  ``NewOutboundCallModal``/``ScheduledCallsPage`` in this repo (``frontend/e2e/`` holds no
+  outbound spec), and the PRD forbids inventing scaffolding.
+* "Schedule a Call requires a time" and "Outbound Call hides scheduling controls" are
+  frontend-only and describe entry points that do not exist yet — the split into
+  "Outbound Call" / "Schedule a Call" is FR-1/FR-2, still ``TBD - needs product input``.
+  Testing them needs the application code the PRD has not approved.
+"""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from core.models.agent import Agent
+from core.models.channel import Channel
+from core.models.contact import Contact
+from core.models.phone_number import PhoneNumber
+from core.models.scheduled_call import ScheduledCall
+from core.services.outbound_call_service import OutboundCallService
+
+
+def make_db(by_model=None):
+    """MagicMock Session that returns a per-model query whose .first() is configurable."""
+    by_model = by_model or {}
+    db = MagicMock()
+
+    def _query(model):
+        qm = MagicMock()
+        qm.filter.return_value = qm
+        qm.order_by.return_value = qm
+        qm.limit.return_value = qm
+        qm.offset.return_value = qm
+        qm.first.return_value = by_model.get(model)
+        qm.update.return_value = by_model.get((model, "update"), 1)
+        qm.all.return_value = by_model.get((model, "all"), [])
+        return qm
+
+    db.query.side_effect = _query
+    return db
+
+
+def _agent(agent_type="outbound", active=True):
+    return SimpleNamespace(id=uuid4(), name="A", agent_type=agent_type, is_active=active)
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+@patch("core.services.outbound_call_service.OutboundCallService._prewarm_pipeline", lambda *a, **k: None)
+@patch("core.services.outbound_call_service.get_provider_credentials",
+       return_value={"account_sid": "AC", "auth_token": "tok"})
+class TestImmediateVsScheduled:
+    """The two behaviours the ticket says one button conflates: dial now vs queue for later."""
+
+    def _db(self):
+        ch = SimpleNamespace(id=uuid4(), channel_type="twilio")
+        pn = SimpleNamespace(id=uuid4(), channel_id=ch.id)
+        return make_db({Agent: _agent(), PhoneNumber: pn, Channel: ch})
+
+    def _db_with_contacts(self, numbers):
+        """A mock DB plus the fake Contact rows the Schedule → Assign → Create path resolves to.
+
+        Bulk/scheduled create routes through ``_schedule_via_contacts``: the numbers become
+        contacts in the default directory, then ``schedule_calls_for_contacts`` loads them
+        back and builds the ``scheduled_calls`` rows."""
+        ch = SimpleNamespace(id=uuid4(), channel_type="twilio")
+        pn = SimpleNamespace(id=uuid4(), channel_id=ch.id)
+        contacts = [
+            SimpleNamespace(id=uuid4(), phone_number=n, name=None, contact_metadata={})
+            for n in numbers
+        ]
+        db = make_db({Agent: _agent(), PhoneNumber: pn, Channel: ch, (Contact, "all"): contacts})
+        return db, contacts
+
+    def _patch_contact_services(self, mock_dir, mock_contacts, contacts):
+        mock_dir.return_value.get_or_create_default_directory.return_value = SimpleNamespace(id=uuid4())
+        mock_contacts.return_value.create_contacts.return_value = {
+            "created": [{"id": str(c.id)} for c in contacts],
+            "assigned": len(contacts),
+        }
+
+    # -- §5: single immediate number dials inline ---------------------------------------
+
+    @patch("core.services.outbound_call_service.get_call_engine")
+    def test_single_immediate_dials_inline_and_writes_no_scheduled_row(
+        self, mock_engine, _creds, monkeypatch
+    ):
+        """One valid number + no scheduled_at → mode 'immediate', dialed inline, and NOTHING
+        lands in scheduled_calls (so it surfaces in Call History, not the Scheduled list)."""
+        monkeypatch.setattr("core.services.outbound_call_service.settings.BASE_CALL_URL", "https://api.x")
+        mock_engine.return_value.initiate_call.return_value = SimpleNamespace(
+            call_id="CA1", provider="twilio"
+        )
+        db = self._db()
+        svc = OutboundCallService(db, org_id=uuid4())
+
+        res = svc.create_outbound_call(
+            agent_id=uuid4(), from_number="+15551110000", to_numbers=["+15552220000"],
+        )
+
+        assert res["mode"] == "immediate" and res["status"] == "dialing"
+        mock_engine.return_value.initiate_call.assert_called_once()
+        assert not db.add_all.called  # no scheduled_calls row for an immediate single dial
+
+    # -- §5: future time queues instead of dialing --------------------------------------
+
+    @patch("core.services.contacts.contact_service.ContactService")
+    @patch("core.services.contacts.contact_directory_service.ContactDirectoryService")
+    @patch("core.services.outbound_call_service.get_call_engine")
+    def test_future_time_queues_scheduled_row_and_dials_nothing(
+        self, mock_engine, mock_dir, mock_contacts, _creds, monkeypatch
+    ):
+        """scheduled_at an hour out → mode 'scheduled', a 'scheduled' row at exactly that
+        instant, and the dial engine is never touched at schedule time."""
+        enq = MagicMock(side_effect=lambda items: [(4242, None) for _ in items])
+        monkeypatch.setattr("core.services.ingestion_queue.enqueue_outbound_calls_batch", enq)
+        db, contacts = self._db_with_contacts(["+15552220000"])
+        self._patch_contact_services(mock_dir, mock_contacts, contacts)
+        svc = OutboundCallService(db, org_id=uuid4())
+        future = _now() + timedelta(hours=1)
+
+        res = svc.create_outbound_call(
+            agent_id=uuid4(), from_number="+15551110000",
+            to_numbers=["+15552220000"], scheduled_at=future,
+        )
+
+        assert res["mode"] == "scheduled" and res["count"] == 1
+        rows = db.add_all.call_args.args[0]
+        assert len(rows) == 1 and isinstance(rows[0], ScheduledCall)
+        assert rows[0].status == "scheduled"
+        assert rows[0].scheduled_at == future
+        enq.assert_called_once()
+        mock_engine.return_value.initiate_call.assert_not_called()
+
+    # -- §5: past time is rejected ------------------------------------------------------
+
+    def test_past_time_is_rejected_400(self, _creds):
+        """10 minutes in the past is outside the 60s grace window → 400 with the exact copy
+        the modal mirrors client-side (NewOutboundCallModal.tsx:602-608)."""
+        svc = OutboundCallService(self._db(), org_id=uuid4())
+        past = _now() - timedelta(minutes=10)
+
+        with pytest.raises(HTTPException) as exc:
+            svc.create_outbound_call(
+                agent_id=uuid4(), from_number="+15551110000",
+                to_numbers=["+15552220000"], scheduled_at=past,
+            )
+
+        assert exc.value.status_code == 400
+        assert exc.value.detail == "scheduled_at must be in the future."
+
+    # -- §5: near-now time is accepted (60s grace) --------------------------------------
+
+    @patch("core.services.contacts.contact_service.ContactService")
+    @patch("core.services.contacts.contact_directory_service.ContactDirectoryService")
+    def test_near_now_time_within_grace_is_accepted_and_dials_asap(
+        self, mock_dir, mock_contacts, _creds, monkeypatch
+    ):
+        """A time the user picked seconds ago (client-clock skew / request latency) must NOT
+        be rejected: 30s in the past is inside the 60s grace, so the row is queued at that
+        already-elapsed instant, i.e. due now → the worker dials ASAP."""
+        enq = MagicMock(side_effect=lambda items: [(11, None) for _ in items])
+        monkeypatch.setattr("core.services.ingestion_queue.enqueue_outbound_calls_batch", enq)
+        db, contacts = self._db_with_contacts(["+15552220000"])
+        self._patch_contact_services(mock_dir, mock_contacts, contacts)
+        svc = OutboundCallService(db, org_id=uuid4())
+        near_now = _now() - timedelta(seconds=30)
+
+        res = svc.create_outbound_call(
+            agent_id=uuid4(), from_number="+15551110000",
+            to_numbers=["+15552220000"], scheduled_at=near_now,
+        )
+
+        assert res["mode"] == "scheduled" and res["count"] == 1
+        rows = db.add_all.call_args.args[0]
+        assert rows[0].scheduled_at == near_now
+        assert rows[0].scheduled_at <= _now()  # already due → dispatched ASAP, not held
+        enq.assert_called_once()
+
+    # -- §5 (new): multi-number immediate batch is labelled correctly -------------------
+
+    @patch("core.services.contacts.contact_service.ContactService")
+    @patch("core.services.contacts.contact_directory_service.ContactDirectoryService")
+    @patch("core.services.outbound_call_service.get_call_engine")
+    def test_multi_number_immediate_batch_is_mode_bulk_not_scheduled(
+        self, mock_engine, mock_dir, mock_contacts, _creds, monkeypatch
+    ):
+        """Two numbers + no scheduled_at → mode 'bulk', NOT 'scheduled'. ``mode`` is the
+        contract the client labels the outcome from (types/outboundCall.ts:23), so the UI can
+        call this an immediate call without a new endpoint (FR-5a).
+
+        This is also the behavioural inconsistency the ticket is about, pinned here so any FR-4
+        decision has to face it explicitly: the batch dials ASAP (every row is due now) yet it
+        IS persisted to scheduled_calls, which is what the "Scheduled Calls" list renders."""
+        enq = MagicMock(side_effect=lambda items: [(99, None) for _ in items])
+        monkeypatch.setattr("core.services.ingestion_queue.enqueue_outbound_calls_batch", enq)
+        db, contacts = self._db_with_contacts(["+15552220001", "+15552220002"])
+        self._patch_contact_services(mock_dir, mock_contacts, contacts)
+        svc = OutboundCallService(db, org_id=uuid4())
+
+        res = svc.create_outbound_call(
+            agent_id=uuid4(), from_number="+15551110000",
+            to_numbers=["+15552220001", "+15552220002"],
+        )
+
+        assert res["mode"] == "bulk" and res["count"] == 2
+        rows = db.add_all.call_args.args[0]
+        assert len(rows) == 2 and all(isinstance(r, ScheduledCall) for r in rows)
+        assert all(r.scheduled_at <= _now() for r in rows)  # due now — an immediate batch
+        assert all(r.status == "scheduled" for r in rows)   # …yet listed as a scheduled row
+        mock_engine.return_value.initiate_call.assert_not_called()  # bulk goes to the queue
+
+
+# ---------------------------------------------------------------------- org isolation
+
+def _row_matches(row, expr) -> bool:
+    """Evaluate a simple ``Column == value`` SQLAlchemy clause against a fake row.
+
+    Only equality on a mapped column is simulated; anything else (IS NULL, IN, …) is treated
+    as non-narrowing, which is enough for the two clauses ``_get_owned`` builds."""
+    column = getattr(expr, "left", None)
+    bind = getattr(expr, "right", None)
+    key = getattr(column, "key", None)
+    if key is None or not hasattr(bind, "value"):
+        return True
+    return getattr(row, key, None) == bind.value
+
+
+class _FilterAwareQuery:
+    """Query double that actually applies ``filter(Column == value)`` — so the org filter
+    ``BaseService.query`` adds is exercised rather than mocked away."""
+
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def filter(self, *criteria):
+        rows = self._rows
+        for expr in criteria:
+            rows = [r for r in rows if _row_matches(r, expr)]
+        return _FilterAwareQuery(rows)
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def all(self):
+        return list(self._rows)
+
+
+def _scoped_db(scheduled_calls):
+    """Session double whose ScheduledCall query honours equality filters; every other model
+    resolves to nothing (get_scheduled_call's agent/contact lookups are incidental here)."""
+    db = MagicMock()
+    db.query.side_effect = lambda model: (
+        _FilterAwareQuery(scheduled_calls) if model is ScheduledCall else _FilterAwareQuery([])
+    )
+    return db
+
+
+class TestScheduledCallOrgIsolation:
+    """§5: a scheduled call owned by another org must not be readable. Asserted at the seam
+    that enforces it — the org filter in ``BaseService.query``, reached via
+    ``get_scheduled_call`` (``GET /outbound-call/scheduled/{id}`` is a thin forward)."""
+
+    def _sc(self, org_id):
+        return SimpleNamespace(
+            id=uuid4(), organization_id=org_id, agent_id=uuid4(), contact_id=None,
+            status="scheduled", from_number="+15551110000", to_number="+15552220000",
+            scheduled_at=_now() + timedelta(hours=1), provider_call_sid=None,
+            call_id=None, error=None, created_at=None,
+        )
+
+    def test_cross_org_scheduled_call_is_404(self):
+        org_a, org_b = uuid4(), uuid4()
+        owned_by_b = self._sc(org_b)
+        svc = OutboundCallService(_scoped_db([owned_by_b]), org_id=org_a)
+
+        with pytest.raises(HTTPException) as exc:
+            svc.get_scheduled_call(owned_by_b.id)
+
+        assert exc.value.status_code == 404  # not 403 — the row is invisible, not forbidden
+
+    def test_same_org_scheduled_call_is_returned(self):
+        """Control for the test above: the same double DOES find an in-org row, so the 404
+        comes from the org filter and not from a lookup that can never match."""
+        org_a = uuid4()
+        owned_by_a = self._sc(org_a)
+        svc = OutboundCallService(_scoped_db([owned_by_a]), org_id=org_a)
+
+        res = svc.get_scheduled_call(owned_by_a.id)
+
+        assert res["id"] == str(owned_by_a.id)
+        assert res["status"] == "scheduled"


### PR DESCRIPTION
- post-commit generates the feature PRD from the linked ClickUp task, then tests from PRD section 5
- gitnexus indexing moved to pre-commit (analyze --force; plain analyze is a no-op before the commit exists) and refreshed AGENTS.md/CLAUDE.md are staged into the same commit
- fix: test_outbound_calls.py patched the stale get_twilio_credentials; outbound_call_service imports get_provider_credentials since the SIP change (11 failed -> 37 passed)
- docs/features un-ignored so generated PRDs are committable