### PR TITLE
feat(providers): add test-stt-selfhosting STT provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **phoenix** (19047 symbols, 47763 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tone** (19525 symbols, 43300 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -17,7 +17,7 @@ This project is indexed by GitNexus as **phoenix** (19047 symbols, 47763 relatio
 
 1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
 2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
-3. `READ gitnexus://repo/phoenix/process/{processName}` — trace the full execution flow step by step
+3. `READ gitnexus://repo/tone/process/{processName}` — trace the full execution flow step by step
 4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
 
 ## When Refactoring
@@ -56,10 +56,10 @@ This project is indexed by GitNexus as **phoenix** (19047 symbols, 47763 relatio
 
 | Resource | Use for |
 |----------|---------|
-| `gitnexus://repo/phoenix/context` | Codebase overview, check index freshness |
-| `gitnexus://repo/phoenix/clusters` | All functional areas |
-| `gitnexus://repo/phoenix/processes` | All execution flows |
-| `gitnexus://repo/phoenix/process/{name}` | Step-by-step execution trace |
+| `gitnexus://repo/tone/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/tone/clusters` | All functional areas |
+| `gitnexus://repo/tone/processes` | All execution flows |
+| `gitnexus://repo/tone/process/{name}` | Step-by-step execution trace |
 
 ## Self-Check Before Finishing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ New behavior needs tests; bug fixes need a regression test.
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **phoenix** (19047 symbols, 47763 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tone** (19525 symbols, 43300 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -202,7 +202,7 @@ This project is indexed by GitNexus as **phoenix** (19047 symbols, 47763 relatio
 
 1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
 2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
-3. `READ gitnexus://repo/phoenix/process/{processName}` — trace the full execution flow step by step
+3. `READ gitnexus://repo/tone/process/{processName}` — trace the full execution flow step by step
 4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
 
 ## When Refactoring
@@ -241,10 +241,10 @@ This project is indexed by GitNexus as **phoenix** (19047 symbols, 47763 relatio
 
 | Resource | Use for |
 |----------|---------|
-| `gitnexus://repo/phoenix/context` | Codebase overview, check index freshness |
-| `gitnexus://repo/phoenix/clusters` | All functional areas |
-| `gitnexus://repo/phoenix/processes` | All execution flows |
-| `gitnexus://repo/phoenix/process/{name}` | Step-by-step execution trace |
+| `gitnexus://repo/tone/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/tone/clusters` | All functional areas |
+| `gitnexus://repo/tone/processes` | All execution flows |
+| `gitnexus://repo/tone/process/{name}` | Step-by-step execution trace |
 
 ## Self-Check Before Finishing
 

--- a/core/services/pipeline/service_factory.py
+++ b/core/services/pipeline/service_factory.py
@@ -348,6 +348,20 @@ def build_stt(spec: dict) -> Optional[Any]:
             if model:
                 granite_kwargs["model"] = model
             return GraniteWebSocketSTTService(url=ws_url, trace_id=get_trace_id(), **granite_kwargs)
+        if provider_name == "test-stt-selfhosting":
+            # Self-hosted test ASR server. It speaks the same partial/final JSON
+            # protocol as granite, so reuse GraniteWebSocketSTTService: unlike
+            # NvidiaWebSocketService it accepts `model`, so the seeded model id
+            # actually reaches the server instead of collapsing to the default.
+            from core.services.pipeline.granite_stt_service import GraniteWebSocketSTTService
+            from core.logging import get_trace_id
+            ws_url = metadata.get("base_url") or "wss://testselfhosting.com/ws"
+            selfhosted_kwargs = {}
+            if metadata.get("sample_rate") is not None:
+                selfhosted_kwargs["sample_rate"] = metadata["sample_rate"]
+            if model:
+                selfhosted_kwargs["model"] = model
+            return GraniteWebSocketSTTService(url=ws_url, trace_id=get_trace_id(), **selfhosted_kwargs)
         if provider_name == "groq":
             from pipecat.services.groq.stt import GroqSTTService
             return GroqSTTService(

--- a/dev/dev-data.json
+++ b/dev/dev-data.json
@@ -19505,6 +19505,51 @@
         }
       ],
       "status": "inactive"
+    },
+    {
+      "name": "test-stt-selfhosting",
+      "provider_type": "stt",
+      "display_name": "Test STT Selfhosting",
+      "description": "Self-hosted test STT server (streaming WebSocket ASR)",
+      "api_key_env": "TEST_STT_SELFHOSTING_API_KEY",
+      "models": [
+        {
+          "name": "test-stt-selfhosting",
+          "base_url": "wss://testselfhosting.com/ws",
+          "meta_data": {
+            "model": "test-stt-selfhosting"
+          },
+          "meta_data_schema": [
+            {
+              "name": "sample_rate",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": 8000,
+                "max": 48000
+              },
+              "required": 0,
+              "description": "Audio sample rate in Hz sent to the server (e.g. 8000, 16000). Default: 16000"
+            }
+          ]
+        }
+      ],
+      "meta_data_schema": [
+        {
+          "name": "sample_rate",
+          "data_type": "integer",
+          "type": "input number",
+          "format": "integer",
+          "validator": {
+            "min": 8000,
+            "max": 48000
+          },
+          "required": 0,
+          "description": "Audio sample rate in Hz sent to the server (e.g. 8000, 16000). Default: 16000"
+        }
+      ],
+      "status": "active"
     }
   ],
   "tts_providers": [

--- a/test-cases/test_stt_selfhosting_provider.py
+++ b/test-cases/test_stt_selfhosting_provider.py
@@ -1,0 +1,112 @@
+"""Regression tests for the `test-stt-selfhosting` STT provider branch.
+
+`build_stt` is a long `if provider_name == ...` chain whose failure modes are all
+*silent*: a wrong slug, a dropped model id or a falsy API key produce no error —
+the agent simply starts with no STT and the call goes deaf. These tests pin the
+four values that have to agree for this provider to work.
+
+No network: `GraniteWebSocketSTTService` opens its websocket in `start()`, not in
+`__init__`, so construction alone contacts nothing and the tests stay deterministic.
+"""
+
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from core.services.pipeline.service_factory import build_stt
+from core.services.pipeline.service_resolver import _make_service_spec
+
+PROVIDER_SLUG = "test-stt-selfhosting"
+MODEL_NAME = "test-stt-selfhosting"
+SEEDED_URL = "wss://testselfhosting.com/ws"
+
+
+def _spec(**overrides) -> dict:
+    """A resolved spec as `_make_service_spec` would produce it for this provider."""
+    spec = {
+        "provider_name": PROVIDER_SLUG,
+        "api_key": "selfhosted-placeholder",
+        "model_name": MODEL_NAME,
+        "metadata": {"base_url": SEEDED_URL, "sample_rate": 16000},
+        "model_meta_data": {},
+    }
+    spec.update(overrides)
+    return spec
+
+
+def test_builds_the_granite_websocket_service():
+    """The branch resolves to a real service rather than falling through to None."""
+    svc = build_stt(_spec())
+    assert svc is not None, "provider fell through build_stt and would leave the agent deaf"
+    assert type(svc).__name__ == "GraniteWebSocketSTTService"
+
+
+def test_seeded_base_url_is_used_verbatim():
+    """`Model.base_url` reaches the service; it is not replaced by a class default."""
+    svc = build_stt(_spec())
+    assert svc._url == SEEDED_URL
+
+
+def test_model_id_reaches_the_service():
+    """Regression for the reason this branch uses Granite over NvidiaWebSocketService.
+
+    `NvidiaWebSocketService` takes no `model=` argument, so every seeded model id
+    would silently collapse to the class default (the live `nvidia` STT bug). If
+    this branch is ever repointed at that class, this assertion fails.
+    """
+    svc = build_stt(_spec(model_name="some-other-weights"))
+    assert svc._settings.model == "some-other-weights"
+
+
+def test_sample_rate_is_forwarded():
+    svc = build_stt(_spec(metadata={"base_url": SEEDED_URL, "sample_rate": 8000}))
+    assert svc._init_sample_rate == 8000
+
+
+def test_falls_back_to_default_url_when_base_url_absent():
+    """A model row with no base_url must still build, not raise."""
+    svc = build_stt(_spec(metadata={}))
+    assert svc is not None
+    assert svc._url.startswith("wss://")
+
+
+@pytest.mark.parametrize(
+    "wrong_slug",
+    [
+        "test_stt_selfhosting",   # underscores: what _slugify can never produce
+        "Test STT Selfhosting",   # the display name, not the slug
+        "test-stt-selfhosted",    # near miss
+    ],
+)
+def test_only_the_exact_slug_matches(wrong_slug):
+    """The factory keys off `provider.slug` with no normalization.
+
+    `_slugify` maps `_` -> `-`, so an underscore slug is unreachable; the resolver
+    passes the slug through verbatim. A mismatch returns None — no exception, no
+    log line the caller sees — which is exactly the trap this pins.
+    """
+    assert build_stt(_spec(provider_name=wrong_slug)) is None
+
+
+@pytest.mark.parametrize("falsy_key", [None, "", 0])
+def test_missing_api_key_yields_no_spec(falsy_key):
+    """A self-hosted provider still needs a non-empty key.
+
+    `_make_service_spec` returns None on a falsy api_key, so the service is never
+    built and the agent runs without STT. This is why the branch is seeded with a
+    placeholder credential even though the server is unauthenticated.
+    """
+    provider = SimpleNamespace(slug=PROVIDER_SLUG, display_name="Test STT Selfhosting")
+    assert _make_service_spec(provider, MODEL_NAME, falsy_key, {}) is None
+
+
+def test_spec_is_built_when_key_present():
+    provider = SimpleNamespace(slug=PROVIDER_SLUG, display_name="Test STT Selfhosting")
+    spec = _make_service_spec(provider, MODEL_NAME, "placeholder", {"base_url": SEEDED_URL})
+    assert spec is not None
+    assert spec["provider_name"] == PROVIDER_SLUG
+    assert build_stt(spec) is not None


### PR DESCRIPTION
## What

Adds `test-stt-selfhosting` — a self-hosted streaming-WebSocket ASR server — as an STT provider, wired across all four layers that have to agree or the provider fails silently.

| Layer | Change |
|---|---|
| Code | `build_stt` branch keyed on slug `test-stt-selfhosting` |
| Data | `dev/dev-data.json` entry, `base_url` on the model row |
| Credential | `TEST_STT_SELFHOSTING_API_KEY` in `.env` (gitignored, not in this diff) |
| Tests | `test-cases/test_stt_selfhosting_provider.py` |

## Why these specific choices

**`GraniteWebSocketSTTService`, not `NvidiaWebSocketService`.** Both speak the same `{"type":"partial"|"final","text":...}` framing, but the Nvidia class takes no `model=` argument — every seeded model id would silently collapse to the class default. That is the live `nvidia` STT bug (11 seeded models, one actual model). Granite accepts `model=`, so the seeded id reaches the server.

**Hyphens, not underscores, in the slug.** `dev/seed.py:463` derives the slug from `display_name` via `_slugify`, which maps `_` → `-`, and `service_resolver.py:139` passes `provider.slug` to the factory verbatim with no normalization. An underscore slug is unreachable. `name`, slug and branch key are all `test-stt-selfhosting`.

**A placeholder credential for an unauthenticated server.** `_make_service_spec` returns `None` on a falsy `api_key` and `seed_org.py` skips the `ApiKey` row when the env var is unset. Neither logs an error the caller sees — the provider still appears in the UI (the listing query has no `ApiKey` join), stays selectable, and then produces no STT at call time. The agent runs deaf.

## Verified

- Provider, model and API-key rows created through the API (`create_provider` → `models/create` → `POST /services`), all `201`, read back clean.
- Those real rows resolved end to end: `_make_service_spec` → `build_stt` returns `GraniteWebSocketSTTService` with `url=wss://testselfhosting.com/ws` and `model=test-stt-selfhosting`.
- 12 tests pass under the repo's pytest config (`-n auto`). No network — the websocket opens in `start()`, not `__init__`.

## NOT verified — reviewer please confirm

**No live call has been placed.** The vendor URL and the assumption that the server speaks granite's framing are unproven by anything static. If the protocol differs, this fails on the first audio frame with everything above still green.

## Review findings

Reviewed against `docs/code-review/` over two passes; the second produced no new blockers.

- `[blocker]` No tests for the new branch — **fixed**. The tests pin the silent failure modes specifically: only the exact slug matches (one case asserts the underscore form does *not*), a falsy key yields no spec, and the model id reaches the service — that last one fails if anyone repoints this branch at `NvidiaWebSocketService`.
- `[should]` This is the **sixth** near-duplicate of the self-hosted-WebSocket branch shape (`granite`, `voxtral`, `gemma`, `nvidia_websocket`, `parakeet`, this one), differing only in class and default URL. The DRY doctrine says extract at the third. **Not fixed here** — it means rewriting five working branches in the live voice path, which belongs in its own PR rather than riding along with a new provider. Happy to follow up.
- `[should]` Tests assert private attributes (`_url`, `_settings.model`, `_init_sample_rate`). Forced by the class surface: no public `model_name`, no url accessor, and the public `sample_rate` property returns `0` until a `StartFrame`.
- `[nit]` The seed entry carries `meta_data: {"model": ...}` that the resolver never reads — dead data, kept for consistency with the other 47 entries.
- `[nit]` The branch's hardcoded fallback URL is a deployment guess, but `base_url` is seeded explicitly so it should never fire.

## Note for whoever maintains the provider skill

The skill's Step 6 warns that a model created via the API "reaches the vendor with no model id" because `meta_data` isn't settable through `create_provider_model`. That is **not** the case: the resolver never reads `Model.meta_data`, and `spec["model_name"]` comes from `Model.name` (`_mname`, `service_resolver.py:200`/`308`), which the API does set. Confirmed live — the built service carried the right model id while the DB row's `meta_data` was `null`. Likewise `CreateModelProviderRequest.meta_data_schema` being `Dict[str, Any]` is correct: seed writes `{kind: [...]}` to `ModelProvider.meta_data_schema`; the list is the pre-merge per-bucket shape in `dev-data.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGUhFG5MuVPQGidGWTRbQD
