### PR TITLE
fix(pipeline): fail fast when a service cannot be built

### DIFF
--- a/core/services/pipeline/builder/pipecat.py
+++ b/core/services/pipeline/builder/pipecat.py
@@ -136,6 +136,15 @@ def _build_service(kind: str, factory, spec: Any) -> Any:
             kind, provider, model,
         )
         raise
+    if service is None:
+        logger.bind(service_kind=kind, provider=provider, model=model).error(
+            "[pipeline-builder] service build returned None kind={} provider={} model={}",
+            kind, provider, model,
+        )
+        raise ValueError(
+            f"{kind} service could not be built for provider={provider} model={model} — "
+            f"check the provider config and credentials"
+        )
     logger.bind(
         service_kind=kind,
         provider=provider,


### PR DESCRIPTION
`_build_service` put `None` in the pipeline when a service failed to build, so a misconfigured provider surfaced later as `NoneType` errors mid-call instead of at build time.

- raise with provider/model context instead of returning `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsKQFxnGuWeb5zYqBaPtFi
