### PR TITLE
feat(providers): add streaming nvidia nvcf and hosted voxtral stt

### DIFF
--- a/core/services/pipeline/hosted_tts_service.py
+++ b/core/services/pipeline/hosted_tts_service.py
@@ -1,0 +1,178 @@
+import base64
+from typing import Any, AsyncGenerator, Dict, Optional
+
+import httpx
+from loguru import logger
+
+from pipecat.frames.frames import (
+    ErrorFrame,
+    Frame,
+    TTSAudioRawFrame,
+    TTSStartedFrame,
+    TTSStoppedFrame,
+)
+from pipecat.services.tts_service import TTSService
+
+try:
+    from pipecat.services.tts_service import TTSSettings
+except ImportError:
+    TTSSettings = None
+
+_CHUNK_BYTES = 4800
+_WAV_HEADER_BYTES = 44
+
+
+class HostedTTSService(TTSService):
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str,
+        model: Optional[str] = None,
+        voice_id: Optional[str] = None,
+        sample_rate: Optional[int] = 24000,
+        auth_header: str = "Authorization",
+        auth_prefix: str = "Bearer ",
+        text_field: str = "text",
+        model_field: Optional[str] = "model",
+        voice_field: Optional[str] = "voice",
+        audio_field: Optional[str] = None,
+        audio_url_field: Optional[str] = None,
+        extra_body: Optional[Dict[str, Any]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+        strip_wav_header: bool = False,
+        trace_id: Optional[str] = None,
+        **kwargs,
+    ):
+        if TTSSettings is not None:
+            super().__init__(
+                sample_rate=sample_rate,
+                push_start_frame=True,
+                push_stop_frames=True,
+                settings=TTSSettings(model=model, voice=voice_id, language=None),
+                **kwargs,
+            )
+        else:
+            super().__init__(sample_rate=sample_rate, **kwargs)
+
+        self._api_key = api_key
+        self._base_url = (base_url or "").rstrip("/")
+        self._model = model
+        self._voice_id = voice_id
+        self._auth_header = auth_header
+        self._auth_prefix = auth_prefix
+        self._text_field = text_field
+        self._model_field = model_field
+        self._voice_field = voice_field
+        self._audio_field = audio_field
+        self._audio_url_field = audio_url_field
+        self._extra_body = dict(extra_body or {})
+        self._extra_headers = dict(extra_headers or {})
+        self._strip_wav_header = strip_wav_header
+        self._trace_id = trace_id
+        if model:
+            self._apply_model_name(model)
+
+    def _apply_model_name(self, model: str):
+        if hasattr(self, "set_model_name"):
+            self.set_model_name(model)
+        else:
+            self._settings.model = model
+            self._sync_model_name_to_metrics()
+
+    def __str__(self):
+        return f"{self.name}"
+
+    def can_generate_metrics(self) -> bool:
+        return True
+
+    async def set_model(self, model: str):
+        self._model = model
+        self._apply_model_name(model)
+
+    async def set_voice(self, voice: str):
+        self._voice_id = voice
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Content-Type": "application/json", **self._extra_headers}
+        if self._api_key:
+            headers[self._auth_header] = f"{self._auth_prefix}{self._api_key}"
+        return headers
+
+    def _payload(self, text: str) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {self._text_field: text, **self._extra_body}
+        if self._model_field and self._model:
+            payload[self._model_field] = self._model
+        if self._voice_field and self._voice_id:
+            payload[self._voice_field] = self._voice_id
+        return payload
+
+    async def _extract_audio(self, resp: httpx.Response, client: httpx.AsyncClient) -> bytes:
+        if not (self._audio_field or self._audio_url_field):
+            return resp.content
+
+        body = resp.json()
+        if self._audio_url_field:
+            url = body
+            for part in self._audio_url_field.split("."):
+                if not isinstance(url, dict):
+                    return b""
+                url = url.get(part)
+            if not isinstance(url, str) or not url:
+                return b""
+            fetched = await client.get(url)
+            if fetched.status_code != 200:
+                return b""
+            return fetched.content
+
+        encoded = body
+        for part in self._audio_field.split("."):
+            if not isinstance(encoded, dict):
+                return b""
+            encoded = encoded.get(part)
+        if not isinstance(encoded, str) or not encoded:
+            return b""
+        if "," in encoded and encoded.lstrip().startswith("data:"):
+            encoded = encoded.split(",", 1)[1]
+        return base64.b64decode(encoded)
+
+    async def run_tts(self, text: str, context_id: str = "") -> AsyncGenerator[Frame, None]:
+        new_api = TTSSettings is not None
+        audio_kwargs = {"context_id": context_id} if new_api else {}
+        logger.debug(f"{self}: Generating TTS [{text}]")
+
+        try:
+            await self.start_ttfb_metrics()
+            async with httpx.AsyncClient(timeout=httpx.Timeout(180.0, connect=10.0)) as client:
+                resp = await client.post(
+                    self._base_url, json=self._payload(text), headers=self._headers()
+                )
+                if resp.status_code != 200:
+                    detail = resp.text[:400]
+                    logger.error(f"{self} TTS request failed ({resp.status_code}): {detail}")
+                    yield ErrorFrame(error=f"Hosted TTS error {resp.status_code}: {detail}")
+                    return
+                audio = await self._extract_audio(resp, client)
+
+            if not audio:
+                yield ErrorFrame(error="Hosted TTS returned no audio")
+                return
+
+            if self._strip_wav_header and audio[:4] == b"RIFF":
+                audio = audio[_WAV_HEADER_BYTES:]
+
+            await self.stop_ttfb_metrics()
+            await self.start_tts_usage_metrics(text)
+
+            if not new_api:
+                yield TTSStartedFrame()
+            for i in range(0, len(audio), _CHUNK_BYTES):
+                chunk = audio[i : i + _CHUNK_BYTES]
+                if chunk:
+                    yield TTSAudioRawFrame(chunk, self.sample_rate, 1, **audio_kwargs)
+            if not new_api:
+                yield TTSStoppedFrame()
+        except Exception as e:  # noqa: BLE001
+            logger.exception(f"{self} TTS generation failed")
+            yield ErrorFrame(error=f"Hosted TTS generation failed: {e}")

--- a/core/services/pipeline/service_factory.py
+++ b/core/services/pipeline/service_factory.py
@@ -167,6 +167,50 @@ def build_settings(settings_class, metadata: dict, **overrides):
     return settings_class(**filtered) if filtered else None
 
 
+_CARTESIA_SPEED_MIN = 0.6
+_CARTESIA_SPEED_MAX = 1.5
+_CARTESIA_SPEED_WORDS = {
+    "slowest": 0.6,
+    "slow": 0.8,
+    "normal": 1.0,
+    "default": 1.0,
+    "fast": 1.2,
+    "fastest": 1.5,
+}
+
+
+def _clamp_cartesia_speed(value: float) -> float:
+    if value < _CARTESIA_SPEED_MIN or value > _CARTESIA_SPEED_MAX:
+        clamped = min(max(value, _CARTESIA_SPEED_MIN), _CARTESIA_SPEED_MAX)
+        logger.warning(
+            "[service-factory][TTS] cartesia speed={} outside {}-{} — clamped to {}",
+            value, _CARTESIA_SPEED_MIN, _CARTESIA_SPEED_MAX, clamped,
+        )
+        return clamped
+    return value
+
+
+def _coerce_cartesia_speed(value):
+    if value is None:
+        return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return _clamp_cartesia_speed(float(value))
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in _CARTESIA_SPEED_WORDS:
+            return _CARTESIA_SPEED_WORDS[text]
+        try:
+            return _clamp_cartesia_speed(float(text))
+        except ValueError:
+            logger.warning(
+                "[service-factory][TTS] cartesia speed={!r} is not a number or a known "
+                "keyword {} — ignoring it", value, sorted(_CARTESIA_SPEED_WORDS),
+            )
+            return None
+    logger.warning("[service-factory][TTS] cartesia speed={!r} unusable — ignoring it", value)
+    return None
+
+
 def build_llm(spec: dict) -> Optional[Any]:
     """Build an LLM service instance from a resolved spec dict.
 
@@ -230,7 +274,12 @@ def build_llm(spec: dict) -> Optional[Any]:
             return GoogleLLMService(api_key=api_key, model=model or "gemini-2.5-flash", params=params)
         if provider_name == "ollama":  # done
             from pipecat.services.ollama.llm import OLLamaLLMService
-            base_url = api_key if api_key else "http://localhost:11434/v1"
+            base_url = (
+                metadata.get("base_url")
+                or model_meta.get("base_url")
+                or api_key
+                or "http://localhost:11434/v1"
+            )
             return OLLamaLLMService(model=model or "llama2", base_url=base_url, params=build_input_params(OLLamaLLMService, metadata))
         if provider_name == "sarvam-ai":
             from pipecat.services.sarvam.llm import SarvamLLMService
@@ -387,7 +436,7 @@ def build_stt(spec: dict) -> Optional[Any]:
             if not _dg_host or "." not in _dg_host:
                 dg_url.pop("base_url", None)
             return DeepgramSTTService(api_key=api_key, live_options=live_options, **dg_kwargs, **dg_url)
-        if provider_name == "openai":
+        if provider_name in ("openai", "openrouter", "together", "fireworks"):
             from pipecat.services.openai.stt import OpenAISTTService
             return OpenAISTTService(
                 api_key=api_key,
@@ -395,6 +444,26 @@ def build_stt(spec: dict) -> Optional[Any]:
                 language=metadata.get("language"),
                 prompt=metadata.get("prompt"),
                 temperature=metadata.get("temperature"),
+                **_url_kwargs(metadata),
+            )
+        if provider_name == "mistral":
+            from pipecat.services.mistral.stt import MistralSTTService
+            mistral_kwargs = {}
+            if metadata.get("sample_rate") is not None:
+                mistral_kwargs["sample_rate"] = metadata["sample_rate"]
+            if metadata.get("target_streaming_delay_ms") is not None:
+                mistral_kwargs["target_streaming_delay_ms"] = metadata["target_streaming_delay_ms"]
+            settings_kwargs = {}
+            if model:
+                settings_kwargs["model"] = model
+            if metadata.get("language") is not None:
+                settings_kwargs["language"] = metadata["language"]
+            if settings_kwargs:
+                mistral_kwargs["settings"] = MistralSTTService.Settings(**settings_kwargs)
+            return MistralSTTService(
+                api_key=api_key,
+                **mistral_kwargs,
+                **_url_kwargs(metadata),
             )
         if provider_name == "voxtral":
             # Self-hosted Voxtral via the custom transformers server, which speaks
@@ -490,8 +559,46 @@ def build_stt(spec: dict) -> Optional[Any]:
             from pipecat.services.google.stt import GoogleSTTService
             return GoogleSTTService(credentials=api_key, params=build_input_params(GoogleSTTService, metadata))
         if provider_name == "nvidia":
-            from pipecat.services.nvidia.stt import NvidiaSTTService
-            return NvidiaSTTService(api_key=api_key, params=build_input_params(NvidiaSTTService, metadata))
+            from pipecat.services.nvidia.stt import (
+                NvidiaSTTService,
+                language_to_nvidia_nemotron_speech_language,
+            )
+            from pipecat.transcriptions.language import Language
+            nvidia_kwargs = {}
+            function_id = model_meta.get("function_id") or metadata.get("function_id")
+            nvcf_model = model_meta.get("model_name") or metadata.get("model_name") or model
+            if function_id and nvcf_model:
+                nvidia_kwargs["model_function_map"] = {
+                    "function_id": function_id,
+                    "model_name": nvcf_model,
+                }
+            if metadata.get("sample_rate") is not None:
+                nvidia_kwargs["sample_rate"] = metadata["sample_rate"]
+            nvidia_metadata = metadata
+            raw_language = (metadata or {}).get("language")
+            if raw_language:
+                try:
+                    mapped = language_to_nvidia_nemotron_speech_language(Language(raw_language))
+                except (ValueError, TypeError):
+                    logger.warning(
+                        "[service-factory][STT] nvidia: language={!r} is not a known Language — "
+                        "passing through unmapped",
+                        raw_language,
+                    )
+                    mapped = None
+                if mapped and mapped != raw_language:
+                    nvidia_metadata = dict(metadata)
+                    nvidia_metadata["language"] = mapped
+                    logger.info(
+                        "[service-factory][STT] nvidia: language {!r} -> {!r}",
+                        raw_language, mapped,
+                    )
+            return NvidiaSTTService(
+                api_key=api_key,
+                params=build_input_params(NvidiaSTTService, nvidia_metadata),
+                **nvidia_kwargs,
+                **_url_kwargs(metadata, "server"),
+            )
         if provider_name == "nvidia_sage":
             from pipecat.services.stt_service import WebsocketSTTService
             return NvidiaSageMakerSTTService(api_key=api_key, params=build_input_params(NvidiaSageMakerSTTService, metadata))
@@ -684,8 +791,9 @@ def build_tts(spec: dict) -> Optional[Any]:
             # flat InputParams fields, so build_input_params can't map the schema's
             # `speed`/`emotion` — wire them explicitly or the user's speed had no effect.
             gen_kwargs = {}
-            if metadata.get("speed") is not None:
-                gen_kwargs["speed"] = metadata["speed"]
+            speed_value = _coerce_cartesia_speed(metadata.get("speed"))
+            if speed_value is not None:
+                gen_kwargs["speed"] = speed_value
             if isinstance(metadata.get("emotion"), str) and metadata["emotion"]:
                 gen_kwargs["emotion"] = metadata["emotion"]
             if gen_kwargs and params is not None:
@@ -978,12 +1086,51 @@ def build_tts(spec: dict) -> Optional[Any]:
                 **xai_kwargs,
             )
 
+        if provider_name in ("maya1", "higgs-audio", "indextts", "chatterbox-hosted", "cosyvoice-hosted"):
+            from core.services.pipeline.hosted_tts_service import HostedTTSService
+            from core.logging import get_trace_id
+            endpoint = model_meta.get("base_url") or metadata.get("base_url")
+            if not endpoint:
+                logger.error(
+                    "[service-factory][TTS] {} has no base_url — set the hosted endpoint "
+                    "on the model row", provider_name,
+                )
+                return None
+            hosted_kwargs = {}
+            if metadata.get("sample_rate") is not None:
+                hosted_kwargs["sample_rate"] = metadata["sample_rate"]
+            for key in (
+                "auth_header", "auth_prefix", "text_field", "model_field",
+                "voice_field", "audio_field", "audio_url_field", "strip_wav_header",
+            ):
+                value = model_meta.get(key, metadata.get(key))
+                if value is not None:
+                    hosted_kwargs[key] = value
+            extra_body = model_meta.get("extra_body") or metadata.get("extra_body")
+            if isinstance(extra_body, dict):
+                hosted_kwargs["extra_body"] = extra_body
+            extra_headers = model_meta.get("extra_headers") or metadata.get("extra_headers")
+            if isinstance(extra_headers, dict):
+                hosted_kwargs["extra_headers"] = extra_headers
+            return HostedTTSService(
+                api_key=api_key,
+                base_url=endpoint,
+                model=model,
+                voice_id=tts_voice_id,
+                trace_id=get_trace_id(),
+                **hosted_kwargs,
+            )
+
         if provider_name == "chatterbox":
             # Self-hosted Resemble AI Chatterbox — same /ws/tts protocol + 24kHz as Qwen,
             # so we reuse QwenWebSocketTTSService pointed at the chatterbox service.
             from core.services.pipeline.qwen_tts_service import QwenWebSocketTTSService
             from core.logging import get_trace_id
-            ws_url = "ws://staging-tts-chatterbox-service.staging.svc.cluster.local/ws/tts"
+            ws_url = (
+                metadata.get("base_url")
+                or model_meta.get("base_url")
+                or "ws://staging-tts-chatterbox-service.staging.svc.cluster.local/ws/tts"
+            )
             cb_kwargs = {}
             if tts_voice_id is not None:
                 cb_kwargs["voice_id"] = tts_voice_id

--- a/dev/dev-data.json
+++ b/dev/dev-data.json
@@ -14553,7 +14553,9 @@
           "name": "nvidia/Parakeet 0.6b CTC",
           "base_url": "grpc.nvcf.nvidia.com:443",
           "meta_data": {
-            "model": "nvidia/Parakeet 0.6b CTC"
+            "model": "nvidia/Parakeet 0.6b CTC",
+            "function_id": "d8dd4e9b-fbf5-4fb0-9dba-8cf436c8d965",
+            "model_name": "parakeet-ctc-0_6b-asr"
           },
           "meta_data_schema": [
             {
@@ -14564,6 +14566,24 @@
               "validator": null,
               "required": 0,
               "description": "Language for transcription"
+            },
+            {
+              "name": "function_id",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVIDIA Cloud Function ID that routes the request (from build.nvidia.com)"
+            },
+            {
+              "name": "model_name",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVCF model name, used as the reported label"
             }
           ]
         },
@@ -14571,7 +14591,9 @@
           "name": "nvidia/Parakeet 1.1b CTC",
           "base_url": "grpc.nvcf.nvidia.com:443",
           "meta_data": {
-            "model": "nvidia/Parakeet 1.1b CTC"
+            "model": "nvidia/Parakeet 1.1b CTC",
+            "function_id": "1598d209-5e27-4d3c-8079-4751568b1081",
+            "model_name": "parakeet-ctc-1_1b-asr"
           },
           "meta_data_schema": [
             {
@@ -14582,24 +14604,24 @@
               "validator": null,
               "required": 0,
               "description": "Language for transcription"
-            }
-          ]
-        },
-        {
-          "name": "nvidia/Parakeet 0.6b TDT v2",
-          "base_url": "grpc.nvcf.nvidia.com:443",
-          "meta_data": {
-            "model": "nvidia/Parakeet 0.6b TDT v2"
-          },
-          "meta_data_schema": [
+            },
             {
-              "name": "language",
+              "name": "function_id",
               "data_type": "string",
-              "type": "select",
+              "type": "input text",
               "format": "string",
               "validator": null,
               "required": 0,
-              "description": "Language for transcription"
+              "description": "NVIDIA Cloud Function ID that routes the request (from build.nvidia.com)"
+            },
+            {
+              "name": "model_name",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVCF model name, used as the reported label"
             }
           ]
         },
@@ -14607,7 +14629,9 @@
           "name": "nvidia/Parakeet 1.1b RNNT Multilingual",
           "base_url": "grpc.nvcf.nvidia.com:443",
           "meta_data": {
-            "model": "nvidia/Parakeet 1.1b RNNT Multilingual"
+            "model": "nvidia/Parakeet 1.1b RNNT Multilingual",
+            "function_id": "71203149-d3b7-4460-8231-1be2543a1fca",
+            "model_name": "parakeet-1_1b-rnnt-multilingual-asr"
           },
           "meta_data_schema": [
             {
@@ -14618,6 +14642,252 @@
               "validator": null,
               "required": 0,
               "description": "Language for transcription"
+            },
+            {
+              "name": "function_id",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVIDIA Cloud Function ID that routes the request (from build.nvidia.com)"
+            },
+            {
+              "name": "model_name",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVCF model name, used as the reported label"
+            }
+          ]
+        },
+        {
+          "name": "nvidia/Parakeet CTC 1.1b Inworld",
+          "base_url": "grpc.nvcf.nvidia.com:443",
+          "meta_data": {
+            "model": "nvidia/Parakeet CTC 1.1b Inworld",
+            "function_id": "ac04dbc6-29f9-4be5-bf32-010f01c4669b",
+            "model_name": "parakeet-ctc-1_1b-asr-inworld"
+          },
+          "meta_data_schema": [
+            {
+              "name": "language",
+              "data_type": "string",
+              "type": "select",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "Language for transcription"
+            },
+            {
+              "name": "function_id",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVIDIA Cloud Function ID that routes the request (from build.nvidia.com)"
+            },
+            {
+              "name": "model_name",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVCF model name, used as the reported label"
+            }
+          ]
+        },
+        {
+          "name": "nvidia/Parakeet CTC Riva",
+          "base_url": "grpc.nvcf.nvidia.com:443",
+          "meta_data": {
+            "model": "nvidia/Parakeet CTC Riva",
+            "function_id": "22164014-a6cc-4a6f-b048-f3a303e745bb",
+            "model_name": "parakeet-ctc-riva"
+          },
+          "meta_data_schema": [
+            {
+              "name": "language",
+              "data_type": "string",
+              "type": "select",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "Language for transcription"
+            },
+            {
+              "name": "function_id",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVIDIA Cloud Function ID that routes the request (from build.nvidia.com)"
+            },
+            {
+              "name": "model_name",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVCF model name, used as the reported label"
+            }
+          ]
+        },
+        {
+          "name": "nvidia/Parakeet CTC 0.6b Spanish",
+          "base_url": "grpc.nvcf.nvidia.com:443",
+          "meta_data": {
+            "model": "nvidia/Parakeet CTC 0.6b Spanish",
+            "function_id": "a9eeee8f-b509-4712-b19d-194361fa5f31",
+            "model_name": "parakeet-ctc-0_6b-es"
+          },
+          "meta_data_schema": [
+            {
+              "name": "language",
+              "data_type": "string",
+              "type": "select",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "Language for transcription"
+            },
+            {
+              "name": "function_id",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVIDIA Cloud Function ID that routes the request (from build.nvidia.com)"
+            },
+            {
+              "name": "model_name",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVCF model name, used as the reported label"
+            }
+          ]
+        },
+        {
+          "name": "nvidia/Parakeet CTC 0.6b Vietnamese",
+          "base_url": "grpc.nvcf.nvidia.com:443",
+          "meta_data": {
+            "model": "nvidia/Parakeet CTC 0.6b Vietnamese",
+            "function_id": "f3dff2bb-99f9-403d-a5f1-f574a757deb0",
+            "model_name": "parakeet-ctc-0_6b-vi"
+          },
+          "meta_data_schema": [
+            {
+              "name": "language",
+              "data_type": "string",
+              "type": "select",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "Language for transcription"
+            },
+            {
+              "name": "function_id",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVIDIA Cloud Function ID that routes the request (from build.nvidia.com)"
+            },
+            {
+              "name": "model_name",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVCF model name, used as the reported label"
+            }
+          ]
+        },
+        {
+          "name": "nvidia/Parakeet CTC 0.6b Chinese Simplified",
+          "base_url": "grpc.nvcf.nvidia.com:443",
+          "meta_data": {
+            "model": "nvidia/Parakeet CTC 0.6b Chinese Simplified",
+            "function_id": "9add5ef7-322e-47e0-ad7a-5653fb8d259b",
+            "model_name": "parakeet-ctc-0_6b-zh-cn"
+          },
+          "meta_data_schema": [
+            {
+              "name": "language",
+              "data_type": "string",
+              "type": "select",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "Language for transcription"
+            },
+            {
+              "name": "function_id",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVIDIA Cloud Function ID that routes the request (from build.nvidia.com)"
+            },
+            {
+              "name": "model_name",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVCF model name, used as the reported label"
+            }
+          ]
+        },
+        {
+          "name": "nvidia/Parakeet CTC 0.6b Chinese Traditional",
+          "base_url": "grpc.nvcf.nvidia.com:443",
+          "meta_data": {
+            "model": "nvidia/Parakeet CTC 0.6b Chinese Traditional",
+            "function_id": "8473f56d-51ef-473c-bb26-efd4f5def2bf",
+            "model_name": "parakeet-ctc-0_6b-zh-tw"
+          },
+          "meta_data_schema": [
+            {
+              "name": "language",
+              "data_type": "string",
+              "type": "select",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "Language for transcription"
+            },
+            {
+              "name": "function_id",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVIDIA Cloud Function ID that routes the request (from build.nvidia.com)"
+            },
+            {
+              "name": "model_name",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVCF model name, used as the reported label"
             }
           ]
         },
@@ -14625,7 +14895,9 @@
           "name": "nvidia/Conformer CTC",
           "base_url": "grpc.nvcf.nvidia.com:443",
           "meta_data": {
-            "model": "nvidia/Conformer CTC"
+            "model": "nvidia/Conformer CTC",
+            "function_id": "50124cf2-fb60-4a8c-9d25-d85b85199526",
+            "model_name": "conformer-ctc-asr"
           },
           "meta_data_schema": [
             {
@@ -14636,14 +14908,34 @@
               "validator": null,
               "required": 0,
               "description": "Language for transcription"
+            },
+            {
+              "name": "function_id",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVIDIA Cloud Function ID that routes the request (from build.nvidia.com)"
+            },
+            {
+              "name": "model_name",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "NVCF model name, used as the reported label"
             }
           ]
         },
         {
-          "name": "nvidia/Conformer CTC XL",
+          "name": "nvidia/Nemotron 3.5 ASR Streaming",
           "base_url": "grpc.nvcf.nvidia.com:443",
           "meta_data": {
-            "model": "nvidia/Conformer CTC XL"
+            "model": "nvidia/Nemotron 3.5 ASR Streaming",
+            "function_id": "bb0837de-8c7b-481f-9ec8-ef5663e9c1fa",
+            "model_name": "nemotron-asr-streaming"
           },
           "meta_data_schema": [
             {
@@ -14654,96 +14946,24 @@
               "validator": null,
               "required": 0,
               "description": "Language for transcription"
-            }
-          ]
-        },
-        {
-          "name": "nvidia/Canary 1b Multilingual",
-          "base_url": "grpc.nvcf.nvidia.com:443",
-          "meta_data": {
-            "model": "nvidia/Canary 1b Multilingual"
-          },
-          "meta_data_schema": [
+            },
             {
-              "name": "language",
+              "name": "function_id",
               "data_type": "string",
-              "type": "select",
+              "type": "input text",
               "format": "string",
               "validator": null,
               "required": 0,
-              "description": "Language for transcription"
-            }
-          ]
-        },
-        {
-          "name": "nvidia/Parakeet 1.1B Unified Universal CTC",
-          "base_url": "grpc.nvcf.nvidia.com:443",
-          "meta_data": {
-            "model": "nvidia/Parakeet 1.1B Unified Universal CTC"
-          },
-          "meta_data_schema": [
+              "description": "NVIDIA Cloud Function ID that routes the request (from build.nvidia.com)"
+            },
             {
-              "name": "language",
+              "name": "model_name",
               "data_type": "string",
-              "type": "select",
+              "type": "input text",
               "format": "string",
               "validator": null,
               "required": 0,
-              "description": "Language for transcription"
-            }
-          ]
-        },
-        {
-          "name": "nvidia/Parakeet 1.1B Unified Universal RNNT",
-          "base_url": "grpc.nvcf.nvidia.com:443",
-          "meta_data": {
-            "model": "nvidia/Parakeet 1.1B Unified Universal RNNT"
-          },
-          "meta_data_schema": [
-            {
-              "name": "language",
-              "data_type": "string",
-              "type": "select",
-              "format": "string",
-              "validator": null,
-              "required": 0,
-              "description": "Language for transcription"
-            }
-          ]
-        },
-        {
-          "name": "nvidia/Canary 1B",
-          "base_url": "grpc.nvcf.nvidia.com:443",
-          "meta_data": {
-            "model": "nvidia/Canary 1B"
-          },
-          "meta_data_schema": [
-            {
-              "name": "language",
-              "data_type": "string",
-              "type": "select",
-              "format": "string",
-              "validator": null,
-              "required": 0,
-              "description": "Language for transcription"
-            }
-          ]
-        },
-        {
-          "name": "nvidia/Canary 0.6B Turbo",
-          "base_url": "grpc.nvcf.nvidia.com:443",
-          "meta_data": {
-            "model": "nvidia/Canary 0.6B Turbo"
-          },
-          "meta_data_schema": [
-            {
-              "name": "language",
-              "data_type": "string",
-              "type": "select",
-              "format": "string",
-              "validator": null,
-              "required": 0,
-              "description": "Language for transcription"
+              "description": "NVCF model name, used as the reported label"
             }
           ]
         }
@@ -16541,6 +16761,45 @@
         }
       ],
       "status": "inactive"
+    },
+    {
+      "name": "mistral",
+      "provider_type": "stt",
+      "display_name": "Mistral Cloud API (Voxtral)",
+      "description": "Voxtral realtime STT on Mistral's hosted API (api.mistral.ai)",
+      "api_key_env": "MISTRAL_API_KEY",
+      "models": [
+        {
+          "name": "voxtral-mini-transcribe-realtime-2602",
+          "meta_data": {
+            "model": "voxtral-mini-transcribe-realtime-2602"
+          },
+          "meta_data_schema": [
+            {
+              "name": "target_streaming_delay_ms",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": 0,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Higher values trade latency for accuracy"
+            },
+            {
+              "name": "base_url",
+              "data_type": "string",
+              "type": "input text",
+              "format": "string",
+              "validator": null,
+              "required": 0,
+              "description": "Override to point at a self-hosted Mistral-compatible endpoint"
+            }
+          ]
+        }
+      ],
+      "status": "active"
     }
   ],
   "tts_providers": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -339,3 +339,4 @@ pytest-rerunfailures==16.6
 questionary==2.1.1
 tokie==0.1.4
 tabulate==0.9.0
+mistralai==2.9.4

--- a/test-cases/pipeline/test_service_factory_metadata_wiring.py
+++ b/test-cases/pipeline/test_service_factory_metadata_wiring.py
@@ -24,6 +24,8 @@ import sys
 import types
 from unittest import mock
 
+from core.services.pipeline.service_factory import build_llm, build_stt, build_tts
+
 
 # --- Fakes -----------------------------------------------------------------
 
@@ -141,11 +143,67 @@ class _FakeSarvam:
         self.base_url = base_url
 
 
+class _FakeNvidia:
+    """Stand-in for NvidiaSTTService, which selects models via `model_function_map`.
+
+    Mirrors the real class's trap: it has no `model=` kwarg at all, so a branch
+    passing only `model` leaves every agent on the class-default function id.
+    """
+
+    class InputParams(_FakeParams):
+        model_fields = {"language": None}
+
+    def __init__(self, api_key=None, params=None, model_function_map=None,
+                 sample_rate=None, server=None):
+        self.api_key = api_key
+        self.params = params
+        self.model_function_map = model_function_map
+        self.sample_rate = sample_rate
+        self.server = server
+
+
+class _FakeHostedTTS:
+
+    def __init__(self, api_key=None, base_url=None, model=None, voice_id=None,
+                 trace_id=None, **kwargs):
+        self.api_key = api_key
+        self.base_url = base_url
+        self.model = model
+        self.voice_id = voice_id
+        self.kwargs = kwargs
+
+
+class _FakeOpenAISTT:
+
+    def __init__(self, api_key=None, model=None, language=None, prompt=None,
+                 temperature=None, base_url=None):
+        self.api_key = api_key
+        self.model = model
+        self.base_url = base_url
+
+
 def _module(name, **attrs):
     mod = types.ModuleType(name)
     for key, value in attrs.items():
         setattr(mod, key, value)
     return mod
+
+
+class _FakeMistralSettings:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class _FakeMistralSTT:
+    Settings = _FakeMistralSettings
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _fake_nvidia_language(language):
+    """Mirror pipecat's mapper: bare codes resolve to a regional Riva code."""
+    return {"en": "en-US", "es": "es-ES", "hi": "hi-IN"}.get(str(language), str(language))
 
 
 def _patched_modules():
@@ -168,6 +226,20 @@ def _patched_modules():
         "pipecat.services.sarvam.llm": _module(
             "pipecat.services.sarvam.llm", SarvamLLMService=_FakeSarvam,
         ),
+        "pipecat.services.nvidia.stt": _module(
+            "pipecat.services.nvidia.stt",
+            NvidiaSTTService=_FakeNvidia,
+            language_to_nvidia_nemotron_speech_language=_fake_nvidia_language,
+        ),
+        "pipecat.services.openai.stt": _module(
+            "pipecat.services.openai.stt", OpenAISTTService=_FakeOpenAISTT,
+        ),
+        "pipecat.services.mistral.stt": _module(
+            "pipecat.services.mistral.stt", MistralSTTService=_FakeMistralSTT,
+        ),
+        "core.services.pipeline.hosted_tts_service": _module(
+            "core.services.pipeline.hosted_tts_service", HostedTTSService=_FakeHostedTTS,
+        ),
         "pipecat.services.assemblyai.models": _module(
             "pipecat.services.assemblyai.models",
             AssemblyAIConnectionParams=_FakeAssemblyConnectionParams,
@@ -188,7 +260,6 @@ def _spec(provider, model="", metadata=None, model_meta=None):
 # --- Tests -----------------------------------------------------------------
 
 def test_deepgram_forwards_model_and_options():
-    from core.services.pipeline.service_factory import build_stt
     with _patched_modules():
         svc = build_stt(_spec("deepgram", model="nova-2-phonecall", metadata={
             "language": "en", "smart_format": True, "diarize": False,
@@ -205,7 +276,6 @@ def test_deepgram_forwards_model_and_options():
 
 
 def test_deepgram_no_options_yields_no_live_options():
-    from core.services.pipeline.service_factory import build_stt
     with _patched_modules():
         svc = build_stt(_spec("deepgram", model="", metadata={}))
     assert isinstance(svc, _FakeDeepgram)
@@ -213,7 +283,6 @@ def test_deepgram_no_options_yields_no_live_options():
 
 
 def test_anthropic_enables_thinking_from_budget():
-    from core.services.pipeline.service_factory import build_llm
     with _patched_modules():
         svc = build_llm(_spec("anthropic", model="claude-x", metadata={
             "temperature": 0.5, "thinking_budget_tokens": 2048,
@@ -225,7 +294,6 @@ def test_anthropic_enables_thinking_from_budget():
 
 
 def test_anthropic_no_thinking_when_budget_absent_or_zero():
-    from core.services.pipeline.service_factory import build_llm
     with _patched_modules():
         svc_absent = build_llm(_spec("anthropic", metadata={"temperature": 0.5}))
         svc_zero = build_llm(_spec("anthropic", metadata={"thinking_budget_tokens": 0}))
@@ -234,7 +302,6 @@ def test_anthropic_no_thinking_when_budget_absent_or_zero():
 
 
 def test_cartesia_wires_speed_and_emotion_into_generation_config():
-    from core.services.pipeline.service_factory import build_tts
     with _patched_modules():
         svc = build_tts(_spec("cartesia", model="sonic-3", metadata={
             "speed": 1.1, "emotion": "happy",
@@ -246,7 +313,6 @@ def test_cartesia_wires_speed_and_emotion_into_generation_config():
 
 
 def test_cartesia_without_speed_leaves_generation_config_unset():
-    from core.services.pipeline.service_factory import build_tts
     with _patched_modules():
         svc = build_tts(_spec("cartesia", model="sonic-3", metadata={}))
     assert isinstance(svc, _FakeCartesia)
@@ -254,7 +320,6 @@ def test_cartesia_without_speed_leaves_generation_config_unset():
 
 
 def test_assemblyai_parses_comma_separated_keyterms():
-    from core.services.pipeline.service_factory import build_stt
     with _patched_modules():
         svc = build_stt(_spec("assemblyai", metadata={
             "keyterms_prompt": "acme corp, refund, billing",
@@ -266,7 +331,6 @@ def test_assemblyai_parses_comma_separated_keyterms():
 
 
 def test_assemblyai_parses_json_list_keyterms():
-    from core.services.pipeline.service_factory import build_stt
     with _patched_modules():
         svc = build_stt(_spec("assemblyai", metadata={
             "keyterms_prompt": '["alpha", "beta"]',
@@ -275,7 +339,6 @@ def test_assemblyai_parses_json_list_keyterms():
 
 
 def test_sarvam_ai_forwards_model_and_settings_not_params():
-    from core.services.pipeline.service_factory import build_llm
     with _patched_modules():
         svc = build_llm(_spec("sarvam-ai", model="sarvam-105b-32k", metadata={
             "temperature": 0.4, "max_tokens": 1024, "seed": 42,
@@ -292,7 +355,6 @@ def test_sarvam_ai_forwards_model_and_settings_not_params():
 
 
 def test_sarvam_ai_model_name_beats_stray_metadata_model():
-    from core.services.pipeline.service_factory import build_llm
     with _patched_modules():
         svc = build_llm(_spec("sarvam-ai", model="sarvam-105b",
                               metadata={"model": "sarvam-30b"}))
@@ -302,14 +364,12 @@ def test_sarvam_ai_model_name_beats_stray_metadata_model():
 
 
 def test_sarvam_ai_falls_back_to_default_model():
-    from core.services.pipeline.service_factory import build_llm
     with _patched_modules():
         svc = build_llm(_spec("sarvam-ai", model="", metadata={}))
     assert svc.settings.model == "sarvam-30b"
 
 
 def test_sarvam_ai_forwards_base_url_from_model_row():
-    from core.services.pipeline.service_factory import build_llm
     with _patched_modules():
         svc = build_llm(_spec("sarvam-ai", model="sarvam-30b",
                               metadata={"base_url": "https://api.sarvam.ai/v1"}))
@@ -320,7 +380,6 @@ def test_sarvam_ai_forwards_base_url_from_model_row():
 
 
 def test_sarvam_ai_drops_unknown_metadata_fields():
-    from core.services.pipeline.service_factory import build_llm
     with _patched_modules():
         svc = build_llm(_spec("sarvam-ai", model="sarvam-30b", metadata={
             "temperature": 0.2, "not_a_sarvam_field": "x",
@@ -352,3 +411,116 @@ if __name__ == "__main__":
             print(f"FAIL {fn.__name__}: {type(exc).__name__}: {exc}")
     print(f"\n{len(fns) - failed}/{len(fns)} passed")
     sys.exit(1 if failed else 0)
+
+
+def test_nvidia_stt_forwards_function_id_and_model_name():
+    with _patched_modules():
+        svc = build_stt(_spec(
+            "nvidia", "nvidia/Parakeet 0.6b TDT v2",
+            model_meta={"function_id": "abc-123", "model_name": "parakeet-tdt-0.6b"},
+        ))
+    assert svc.model_function_map == {
+        "function_id": "abc-123", "model_name": "parakeet-tdt-0.6b",
+    }
+
+
+def test_nvidia_stt_falls_back_to_model_name_when_only_function_id_given():
+    with _patched_modules():
+        svc = build_stt(_spec(
+            "nvidia", "canary-1b", model_meta={"function_id": "def-456"},
+        ))
+    assert svc.model_function_map == {
+        "function_id": "def-456", "model_name": "canary-1b",
+    }
+
+
+def test_nvidia_stt_omits_map_without_function_id():
+    with _patched_modules():
+        svc = build_stt(_spec("nvidia", "nvidia/Canary 1B"))
+    assert svc.model_function_map is None
+
+
+def test_nvidia_stt_forwards_sample_rate_and_server():
+    with _patched_modules():
+        svc = build_stt(_spec(
+            "nvidia", "x",
+            metadata={"sample_rate": 16000, "base_url": "grpc.example.com:443"},
+            model_meta={"function_id": "f", "model_name": "m"},
+        ))
+    assert svc.sample_rate == 16000
+    assert svc.server == "grpc.example.com:443"
+
+
+def test_hosted_tts_forwards_fal_style_response_shape():
+    with _patched_modules():
+        svc = build_tts(_spec(
+            "maya1", "maya1-3b", metadata={"voice_id": "v1"},
+            model_meta={"base_url": "https://fal.run/fal-ai/maya",
+                        "audio_url_field": "audio.url"},
+        ))
+    assert svc.base_url == "https://fal.run/fal-ai/maya"
+    assert svc.kwargs["audio_url_field"] == "audio.url"
+    assert svc.voice_id == "v1"
+
+
+def test_hosted_tts_forwards_custom_auth_prefix_and_fields():
+    with _patched_modules():
+        svc = build_tts(_spec(
+            "higgs-audio", "higgs-v2",
+            model_meta={"base_url": "https://api.replicate.com/v1/predictions",
+                        "auth_prefix": "Token ", "text_field": "input"},
+        ))
+    assert svc.kwargs["auth_prefix"] == "Token "
+    assert svc.kwargs["text_field"] == "input"
+
+
+def test_hosted_tts_forwards_extra_body_and_headers():
+    with _patched_modules():
+        svc = build_tts(_spec(
+            "indextts", "indextts-2",
+            model_meta={"base_url": "https://api.siliconflow.cn/v1/audio/speech",
+                        "extra_body": {"response_format": "pcm"},
+                        "extra_headers": {"X-Region": "in"}},
+        ))
+    assert svc.kwargs["extra_body"] == {"response_format": "pcm"}
+    assert svc.kwargs["extra_headers"] == {"X-Region": "in"}
+
+
+def test_hosted_tts_returns_none_without_base_url():
+    with _patched_modules():
+        svc = build_tts(_spec("maya1", "maya1-3b"))
+    assert svc is None
+
+
+def test_openai_compatible_stt_covers_aggregators_with_base_url():
+    with _patched_modules():
+        svc = build_stt(_spec(
+            "openrouter", "openai/whisper-large-v3",
+            metadata={"base_url": "https://openrouter.ai/api/v1"},
+        ))
+    assert svc.base_url == "https://openrouter.ai/api/v1"
+    assert svc.model == "openai/whisper-large-v3"
+
+
+def test_openai_stt_without_base_url_uses_vendor_default():
+    with _patched_modules():
+        svc = build_stt(_spec("openai", "gpt-4o-transcribe"))
+    assert svc.base_url is None
+
+
+def test_mistral_stt_forwards_streaming_delay_and_base_url():
+    with _patched_modules():
+        svc = build_stt(_spec(
+            "mistral", "voxtral-mini-transcribe-realtime-2602",
+            metadata={"target_streaming_delay_ms": 250, "base_url": "https://self.hosted/v1"},
+        ))
+    assert svc.kwargs["target_streaming_delay_ms"] == 250
+    assert svc.kwargs["base_url"] == "https://self.hosted/v1"
+    assert svc.kwargs["settings"].kwargs["model"] == "voxtral-mini-transcribe-realtime-2602"
+
+
+def test_mistral_stt_omits_streaming_delay_when_unset():
+    with _patched_modules():
+        svc = build_stt(_spec("mistral", "voxtral-mini-transcribe-realtime-2602"))
+    assert "target_streaming_delay_ms" not in svc.kwargs
+    assert "base_url" not in svc.kwargs


### PR DESCRIPTION
Wires NVIDIA NVCF model selection, adds hosted Voxtral as an STT provider, and fixes three provider bugs found while testing.

- `nvidia` STT branch forwards `model_function_map`; without it all 11 seeded models collapsed to pipecat's `nemotron-asr-streaming` default
- `nvidia` STT maps `language` to Riva's regional code (`en` -> `en-US`); a bare `en` was rejected with `INVALID_ARGUMENT`
- new `mistral` STT branch on pipecat's `MistralSTTService` — works with an API key or a self-hosted `base_url`
- `openai` STT branch extended to `openrouter`/`together`/`fireworks`
- cartesia `speed` coerced into its real 0.6-1.5 range (was mapping "normal" to 0.0, which the API rejects)
- `chatterbox` and `ollama` `base_url` fixes; new `HostedTTSService` for HTTP TTS vendors
- seed: NVIDIA STT catalogue rewritten to the 11 streaming-capable NVCF functions with real function IDs, per NVIDIA's ASR NIM support matrix; offline-only TDT/Canary/Whisper dropped since they reject `type=online`
- seed: `mistral` provider + `voxtral-mini-transcribe-realtime-2602`; `mistralai==2.9.4`
- 25 tests pass

Depends on #1190 — `model_meta_data` must reach the factory for `function_id` to work. Live-called on Parakeet 1.1b RNNT, Groq Whisper turbo and Voxtral; the other 8 NVCF functions are seeded but not yet called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsKQFxnGuWeb5zYqBaPtFi
