### PR TITLE
feat(stt): expose nvidia riva endpointing params

### DIFF
--- a/core/services/pipeline/service_factory.py
+++ b/core/services/pipeline/service_factory.py
@@ -574,6 +574,19 @@ def build_stt(spec: dict) -> Optional[Any]:
                 }
             if metadata.get("sample_rate") is not None:
                 nvidia_kwargs["sample_rate"] = metadata["sample_rate"]
+            for _endpointing_key in (
+                "start_history",
+                "start_threshold",
+                "stop_history",
+                "stop_threshold",
+                "stop_history_eou",
+                "stop_threshold_eou",
+            ):
+                _endpointing_value = model_meta.get(_endpointing_key)
+                if _endpointing_value is None:
+                    _endpointing_value = metadata.get(_endpointing_key)
+                if _endpointing_value is not None:
+                    nvidia_kwargs[_endpointing_key] = _endpointing_value
             nvidia_metadata = metadata
             raw_language = (metadata or {}).get("language")
             if raw_language:

--- a/dev/dev-data.json
+++ b/dev/dev-data.json
@@ -14584,6 +14584,69 @@
               "validator": null,
               "required": 0,
               "description": "NVCF model name, used as the reported label"
+            },
+            {
+              "name": "start_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva VAD start history in frames. -1 uses the server default"
+            },
+            {
+              "name": "start_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD start threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva end-of-utterance silence window in frames (pipecat default 320). Lower cuts STT latency, raises the risk of clipping"
+            },
+            {
+              "name": "stop_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD stop threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history_eou",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "End-of-utterance stop history in frames. -1 uses the server default"
+            },
+            {
+              "name": "stop_threshold_eou",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "End-of-utterance stop threshold. -1 uses the server default"
             }
           ]
         },
@@ -14622,6 +14685,69 @@
               "validator": null,
               "required": 0,
               "description": "NVCF model name, used as the reported label"
+            },
+            {
+              "name": "start_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva VAD start history in frames. -1 uses the server default"
+            },
+            {
+              "name": "start_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD start threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva end-of-utterance silence window in frames (pipecat default 320). Lower cuts STT latency, raises the risk of clipping"
+            },
+            {
+              "name": "stop_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD stop threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history_eou",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "End-of-utterance stop history in frames. -1 uses the server default"
+            },
+            {
+              "name": "stop_threshold_eou",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "End-of-utterance stop threshold. -1 uses the server default"
             }
           ]
         },
@@ -14660,6 +14786,69 @@
               "validator": null,
               "required": 0,
               "description": "NVCF model name, used as the reported label"
+            },
+            {
+              "name": "start_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva VAD start history in frames. -1 uses the server default"
+            },
+            {
+              "name": "start_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD start threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva end-of-utterance silence window in frames (pipecat default 320). Lower cuts STT latency, raises the risk of clipping"
+            },
+            {
+              "name": "stop_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD stop threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history_eou",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "End-of-utterance stop history in frames. -1 uses the server default"
+            },
+            {
+              "name": "stop_threshold_eou",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "End-of-utterance stop threshold. -1 uses the server default"
             }
           ]
         },
@@ -14698,6 +14887,69 @@
               "validator": null,
               "required": 0,
               "description": "NVCF model name, used as the reported label"
+            },
+            {
+              "name": "start_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva VAD start history in frames. -1 uses the server default"
+            },
+            {
+              "name": "start_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD start threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva end-of-utterance silence window in frames (pipecat default 320). Lower cuts STT latency, raises the risk of clipping"
+            },
+            {
+              "name": "stop_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD stop threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history_eou",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "End-of-utterance stop history in frames. -1 uses the server default"
+            },
+            {
+              "name": "stop_threshold_eou",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "End-of-utterance stop threshold. -1 uses the server default"
             }
           ]
         },
@@ -14736,6 +14988,69 @@
               "validator": null,
               "required": 0,
               "description": "NVCF model name, used as the reported label"
+            },
+            {
+              "name": "start_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva VAD start history in frames. -1 uses the server default"
+            },
+            {
+              "name": "start_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD start threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva end-of-utterance silence window in frames (pipecat default 320). Lower cuts STT latency, raises the risk of clipping"
+            },
+            {
+              "name": "stop_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD stop threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history_eou",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "End-of-utterance stop history in frames. -1 uses the server default"
+            },
+            {
+              "name": "stop_threshold_eou",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "End-of-utterance stop threshold. -1 uses the server default"
             }
           ]
         },
@@ -14774,6 +15089,69 @@
               "validator": null,
               "required": 0,
               "description": "NVCF model name, used as the reported label"
+            },
+            {
+              "name": "start_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva VAD start history in frames. -1 uses the server default"
+            },
+            {
+              "name": "start_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD start threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva end-of-utterance silence window in frames (pipecat default 320). Lower cuts STT latency, raises the risk of clipping"
+            },
+            {
+              "name": "stop_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD stop threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history_eou",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "End-of-utterance stop history in frames. -1 uses the server default"
+            },
+            {
+              "name": "stop_threshold_eou",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "End-of-utterance stop threshold. -1 uses the server default"
             }
           ]
         },
@@ -14812,6 +15190,69 @@
               "validator": null,
               "required": 0,
               "description": "NVCF model name, used as the reported label"
+            },
+            {
+              "name": "start_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva VAD start history in frames. -1 uses the server default"
+            },
+            {
+              "name": "start_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD start threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva end-of-utterance silence window in frames (pipecat default 320). Lower cuts STT latency, raises the risk of clipping"
+            },
+            {
+              "name": "stop_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD stop threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history_eou",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "End-of-utterance stop history in frames. -1 uses the server default"
+            },
+            {
+              "name": "stop_threshold_eou",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "End-of-utterance stop threshold. -1 uses the server default"
             }
           ]
         },
@@ -14850,6 +15291,69 @@
               "validator": null,
               "required": 0,
               "description": "NVCF model name, used as the reported label"
+            },
+            {
+              "name": "start_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva VAD start history in frames. -1 uses the server default"
+            },
+            {
+              "name": "start_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD start threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva end-of-utterance silence window in frames (pipecat default 320). Lower cuts STT latency, raises the risk of clipping"
+            },
+            {
+              "name": "stop_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD stop threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history_eou",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "End-of-utterance stop history in frames. -1 uses the server default"
+            },
+            {
+              "name": "stop_threshold_eou",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "End-of-utterance stop threshold. -1 uses the server default"
             }
           ]
         },
@@ -14888,6 +15392,69 @@
               "validator": null,
               "required": 0,
               "description": "NVCF model name, used as the reported label"
+            },
+            {
+              "name": "start_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva VAD start history in frames. -1 uses the server default"
+            },
+            {
+              "name": "start_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD start threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva end-of-utterance silence window in frames (pipecat default 320). Lower cuts STT latency, raises the risk of clipping"
+            },
+            {
+              "name": "stop_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD stop threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history_eou",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "End-of-utterance stop history in frames. -1 uses the server default"
+            },
+            {
+              "name": "stop_threshold_eou",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "End-of-utterance stop threshold. -1 uses the server default"
             }
           ]
         },
@@ -14926,6 +15493,69 @@
               "validator": null,
               "required": 0,
               "description": "NVCF model name, used as the reported label"
+            },
+            {
+              "name": "start_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva VAD start history in frames. -1 uses the server default"
+            },
+            {
+              "name": "start_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD start threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva end-of-utterance silence window in frames (pipecat default 320). Lower cuts STT latency, raises the risk of clipping"
+            },
+            {
+              "name": "stop_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD stop threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history_eou",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "End-of-utterance stop history in frames. -1 uses the server default"
+            },
+            {
+              "name": "stop_threshold_eou",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "End-of-utterance stop threshold. -1 uses the server default"
             }
           ]
         },
@@ -14964,6 +15594,69 @@
               "validator": null,
               "required": 0,
               "description": "NVCF model name, used as the reported label"
+            },
+            {
+              "name": "start_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva VAD start history in frames. -1 uses the server default"
+            },
+            {
+              "name": "start_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD start threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "Riva end-of-utterance silence window in frames (pipecat default 320). Lower cuts STT latency, raises the risk of clipping"
+            },
+            {
+              "name": "stop_threshold",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "Riva VAD stop threshold. -1 uses the server default"
+            },
+            {
+              "name": "stop_history_eou",
+              "data_type": "integer",
+              "type": "input number",
+              "format": "integer",
+              "validator": {
+                "min": -1,
+                "max": 5000
+              },
+              "required": 0,
+              "description": "End-of-utterance stop history in frames. -1 uses the server default"
+            },
+            {
+              "name": "stop_threshold_eou",
+              "data_type": "number",
+              "type": "input number",
+              "format": "number",
+              "validator": null,
+              "required": 0,
+              "description": "End-of-utterance stop threshold. -1 uses the server default"
             }
           ]
         }

--- a/test-cases/pipeline/test_service_factory_metadata_wiring.py
+++ b/test-cases/pipeline/test_service_factory_metadata_wiring.py
@@ -154,7 +154,8 @@ class _FakeNvidia:
         model_fields = {"language": None}
 
     def __init__(self, api_key=None, params=None, model_function_map=None,
-                 sample_rate=None, server=None):
+                 sample_rate=None, server=None, **kwargs):
+        self.kwargs = kwargs
         self.api_key = api_key
         self.params = params
         self.model_function_map = model_function_map
@@ -524,3 +525,21 @@ def test_mistral_stt_omits_streaming_delay_when_unset():
         svc = build_stt(_spec("mistral", "voxtral-mini-transcribe-realtime-2602"))
     assert "target_streaming_delay_ms" not in svc.kwargs
     assert "base_url" not in svc.kwargs
+
+
+def test_nvidia_stt_forwards_endpointing_from_model_meta():
+    with _patched_modules():
+        svc = build_stt(_spec(
+            "nvidia", "nvidia/Nemotron 3.5 ASR Streaming",
+            model_meta={"function_id": "abc-123", "model_name": "nemotron-asr-streaming",
+                        "stop_history": 120, "stop_threshold_eou": 0.5},
+        ))
+    assert svc.kwargs["stop_history"] == 120
+    assert svc.kwargs["stop_threshold_eou"] == 0.5
+
+
+def test_nvidia_stt_omits_endpointing_when_unset():
+    with _patched_modules():
+        svc = build_stt(_spec("nvidia", "x", model_meta={"function_id": "f", "model_name": "m"}))
+    for key in ("start_history", "stop_history", "stop_threshold_eou"):
+        assert key not in svc.kwargs


### PR DESCRIPTION
Riva's end-of-utterance window (`stop_history`, pipecat default 320) is a constructor kwarg, not a `Settings` field, so `build_input_params` could never reach it — every NVIDIA call was pinned to the default with no way to tune it.

- `nvidia` STT branch forwards `start_history`, `start_threshold`, `stop_history`, `stop_threshold`, `stop_history_eou`, `stop_threshold_eou` from `model_meta`/`metadata`
- exposed on all 11 NVIDIA STT models in `dev-data.json` so they are tunable per model
- 27 tests pass

Defaults are unchanged — nothing moves unless a value is set. Measured on live calls: NVIDIA STT TTFB is ~770ms while inference is 4-110ms; ~320ms of the gap is this endpointing window and the rest is NVCF round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsKQFxnGuWeb5zYqBaPtFi
