### PR TITLE
fix(stt): coerce nvidia endpointing values from agent settings

### DIFF
--- a/core/services/pipeline/service_factory.py
+++ b/core/services/pipeline/service_factory.py
@@ -211,6 +211,36 @@ def _coerce_cartesia_speed(value):
     return None
 
 
+_NVIDIA_ENDPOINTING_FIELDS = (
+    "start_history",
+    "start_threshold",
+    "stop_history",
+    "stop_threshold",
+    "stop_history_eou",
+    "stop_threshold_eou",
+)
+_NVIDIA_ENDPOINTING_INT_FIELDS = frozenset(
+    {"start_history", "stop_history", "stop_history_eou"}
+)
+
+
+def _coerce_nvidia_endpointing(key: str, value):
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = value.strip()
+        if not value or value == "None":
+            return None
+    try:
+        return int(value) if key in _NVIDIA_ENDPOINTING_INT_FIELDS else float(value)
+    except (TypeError, ValueError):
+        logger.warning(
+            "[service-factory][STT] nvidia: endpointing {}={!r} is not numeric — ignoring it",
+            key, value,
+        )
+        return None
+
+
 def build_llm(spec: dict) -> Optional[Any]:
     """Build an LLM service instance from a resolved spec dict.
 
@@ -574,17 +604,13 @@ def build_stt(spec: dict) -> Optional[Any]:
                 }
             if metadata.get("sample_rate") is not None:
                 nvidia_kwargs["sample_rate"] = metadata["sample_rate"]
-            for _endpointing_key in (
-                "start_history",
-                "start_threshold",
-                "stop_history",
-                "stop_threshold",
-                "stop_history_eou",
-                "stop_threshold_eou",
-            ):
+            for _endpointing_key in _NVIDIA_ENDPOINTING_FIELDS:
                 _endpointing_value = model_meta.get(_endpointing_key)
                 if _endpointing_value is None:
                     _endpointing_value = metadata.get(_endpointing_key)
+                _endpointing_value = _coerce_nvidia_endpointing(
+                    _endpointing_key, _endpointing_value
+                )
                 if _endpointing_value is not None:
                     nvidia_kwargs[_endpointing_key] = _endpointing_value
             nvidia_metadata = metadata

--- a/test-cases/pipeline/test_service_factory_metadata_wiring.py
+++ b/test-cases/pipeline/test_service_factory_metadata_wiring.py
@@ -543,3 +543,26 @@ def test_nvidia_stt_omits_endpointing_when_unset():
         svc = build_stt(_spec("nvidia", "x", model_meta={"function_id": "f", "model_name": "m"}))
     for key in ("start_history", "stop_history", "stop_threshold_eou"):
         assert key not in svc.kwargs
+
+
+def test_nvidia_stt_coerces_endpointing_strings_from_ui():
+    with _patched_modules():
+        svc = build_stt(_spec(
+            "nvidia", "nvidia/Parakeet 0.6b CTC",
+            model_meta={"function_id": "f", "model_name": "m"},
+            metadata={"stop_history": "160", "stop_threshold": "0.5"},
+        ))
+    assert svc.kwargs["stop_history"] == 160
+    assert isinstance(svc.kwargs["stop_history"], int)
+    assert svc.kwargs["stop_threshold"] == 0.5
+
+
+def test_nvidia_stt_drops_blank_and_invalid_endpointing():
+    with _patched_modules():
+        svc = build_stt(_spec(
+            "nvidia", "nvidia/Parakeet 0.6b CTC",
+            model_meta={"function_id": "f", "model_name": "m"},
+            metadata={"stop_history_eou": "", "start_history": "abc"},
+        ))
+    assert "stop_history_eou" not in svc.kwargs
+    assert "start_history" not in svc.kwargs


### PR DESCRIPTION
Agent settings arrive as strings, so the endpointing forwarding added in #1194 passed `stop_history="160"` and `stop_history_eou=""` straight into the Riva config. STT then returned no transcripts at all.

- coerce int/float per field, skip blanks and unparseable values with a warning
- 2 regression tests for the exact UI shape that broke it; 29 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsKQFxnGuWeb5zYqBaPtFi
