### PR TITLE
fix(ws-bridge): stream continuous silence so the remote STT finalizes

### DIFF
--- a/core/services/transport/ws_bridge.py
+++ b/core/services/transport/ws_bridge.py
@@ -12,6 +12,8 @@ source (server-accepted vs client-dialed) and the serializer; everything downstr
 place that assembles the outbound media transport.
 """
 
+from pipecat.audio.mixers.base_audio_mixer import BaseAudioMixer
+from pipecat.frames.frames import MixerControlFrame
 from pipecat.transports.base_transport import BaseTransport
 from pipecat.transports.websocket.client import (WebsocketClientParams,
                                                  WebsocketClientTransport)
@@ -24,6 +26,23 @@ from core.serializers.raw_pcm import RawPCMSerializer
 # but degrades audio enough that Deepgram transcribes NOTHING. The bridge also declares
 # this rate in the /ws/test URL so the two sides can never disagree.
 BRIDGE_SAMPLE_RATE = 24000
+
+
+class _ContinuousSilenceMixer(BaseAudioMixer):
+    """Pass-through mixer: selects pipecat's ``with_mixer`` path so the bridge streams
+    continuous silence while idle, keeping the remote STT's endpointing alive."""
+
+    async def start(self, sample_rate: int) -> None:
+        return
+
+    async def stop(self) -> None:
+        return
+
+    async def process_frame(self, frame: MixerControlFrame) -> None:
+        return
+
+    async def mix(self, audio: bytes) -> bytes:
+        return audio
 
 
 def build_ws_bridge_transport(
@@ -40,6 +59,7 @@ def build_ws_bridge_transport(
         audio_in_sample_rate=sample_rate,
         audio_out_sample_rate=sample_rate,
         add_wav_header=False,
+        audio_out_mixer=_ContinuousSilenceMixer(),
         serializer=RawPCMSerializer(sample_rate=sample_rate, num_channels=1),
     )
     return WebsocketClientTransport(uri=remote_uri, params=params)

--- a/requirements.txt
+++ b/requirements.txt
@@ -280,7 +280,7 @@ tldextract==3.1.0
 tokenizers==0.22.2
 tomli==2.0.1
 tomlkit==0.11.6
-tone-pipecat==0.0.76.dev7
+tone-pipecat==0.0.76.dev8
 tornado==6.3.3
 tqdm==4.67.3
 transformers==4.57.6


### PR DESCRIPTION
## Problem
Outbound **WebSocket test-bridge** calls (tone → tone-test `/ws/test`) connected and both agents greeted, but the conversation deadlocked in silence — the remote side reported `turns=0`, only interim transcripts, then disconnect.

**Root cause:** the bridge uses a `WebsocketClientTransport` with no telephony carrier. pipecat's output loop only emits idle silence when an `audio_out_mixer` is set (`with_mixer` pads an empty queue with silence; `without_mixer` sends nothing). With no mixer, the bridge went dead-air the instant our agent stopped talking, so the remote Deepgram never detected end-of-speech, never committed a **final** transcript, the caller persona's turn never closed, and neither side responded.

## Fix
- Attach a no-op pass-through `_ContinuousSilenceMixer` to the bridge's `WebsocketClientParams` (`audio_out_mixer=`). It does no actual mixing — its only effect is to select the `with_mixer` path so the stream stays continuous (silence when idle), mirroring a real call and keeping the far-side endpointing alive. Real speech is unchanged.
- Align `tone-pipecat` `0.0.76.dev7 → dev8` to match tone-test and guarantee `audio_out_mixer` is available.

Paired with tone-test PR (`fix/ws-bridge-audio-deadlock`) which adds an interim→final fallback on the receiving side.

## Risk / testing
The dev8 bump is a framework upgrade I could not diff against dev7 (private package). Treat as a real dependency change — regression-test on staging before prod:
- real Twilio inbound + outbound call (STT/LLM/TTS/recording)
- the ws-bridge to tone-test (expect `turns > 0`, persona replies, origin logs `[raw-pcm] first IN chunk`)
- scheduled outbound + concurrency

🤖 Generated with [Claude Code](https://claude.com/claude-code)