### PR TITLE
refactor(agent-ui): rename "Schedule" surface to "Outbound Calls"

### DIFF
--- a/frontend/src/components/agents/agent-form/sectionNav.ts
+++ b/frontend/src/components/agents/agent-form/sectionNav.ts
@@ -51,7 +51,7 @@ export const AGENT_SECTIONS: AgentSection[] = [
   { key: 'llm-evals', label: 'LLM Evals', icon: Gauge },
   { key: 'channels', label: 'Channels', icon: Radio },
   { key: 'contacts', label: 'Contacts', icon: Users },
-  { key: 'schedule', label: 'Schedule', icon: CalendarClock },
+  { key: 'schedule', label: 'Outbound Calls', icon: CalendarClock },
   { key: 'call-history', label: 'Call History', icon: Clock },
 ];
 

--- a/frontend/src/components/agents/agent-form/steps/ScheduleStep.tsx
+++ b/frontend/src/components/agents/agent-form/steps/ScheduleStep.tsx
@@ -2,7 +2,7 @@
 
 import ScheduledCallsPage from '@/components/scheduled-calls/ScheduledCallsPage';
 
-// Agent-scoped Schedule tab inside the editor. Renders the same scheduled-calls table +
+// Agent-scoped Outbound Calls tab inside the editor. Renders the same scheduled-calls table +
 // create modal as the (removed) global page, but scoped to this agent via `agentId` — the
 // list filters on it and the create modal locks the agent. Edit-only + outbound-gated: a
 // not-yet-created or inbound-only agent renders nothing (also hidden in the rail).

--- a/frontend/src/components/outbound-calls/NewOutboundCallModal.tsx
+++ b/frontend/src/components/outbound-calls/NewOutboundCallModal.tsx
@@ -348,10 +348,10 @@ export default function NewOutboundCallModal({
         } else {
           showToast.success(
             res?.mode === 'bulk' ? `${res.count} calls queued` : 'Call scheduled',
-            'Track them on the agent’s Schedule tab.',
+            'Track them on the agent’s Outbound Calls tab.',
           );
         }
-        // Honor the caller's contract: when onScheduled is provided (the agent Schedule tab),
+        // Honor the caller's contract: when onScheduled is provided (the agent Outbound Calls tab),
         // refresh in place and STAY on the page — for every mode, immediate included. Only when
         // it's omitted (standalone use) do we navigate to Call History.
         if (onScheduled) {
@@ -561,7 +561,7 @@ export default function NewOutboundCallModal({
               />
               <p className="text-xs text-muted-foreground">
                 {numberCount > 0
-                  ? `${numberCount} number${numberCount > 1 ? 's' : ''} — E.164 format (e.g. +14155550123). Multiple comma- or line-separated numbers are queued and shown on Scheduled Calls.`
+                  ? `${numberCount} number${numberCount > 1 ? 's' : ''} — E.164 format (e.g. +14155550123). Multiple comma- or line-separated numbers are queued and shown on Outbound Calls.`
                   : 'Enter E.164 numbers (e.g. +14155550123), separated by commas or new lines, or upload a CSV/Excel file.'}
               </p>
             </>

--- a/frontend/src/components/scheduled-calls/ScheduledCallsPage.tsx
+++ b/frontend/src/components/scheduled-calls/ScheduledCallsPage.tsx
@@ -36,7 +36,7 @@ function formatDateTime(iso: string | null): string {
 }
 
 interface ScheduledCallsPageProps {
-  /** When set, scopes the list + locks the create modal to this agent (Agent → Schedule tab). */
+  /** When set, scopes the list + locks the create modal to this agent (Agent → Outbound Calls tab). */
   agentId?: string;
 }
 
@@ -186,7 +186,7 @@ export default function ScheduledCallsPage({ agentId }: ScheduledCallsPageProps 
         <span className="font-medium tabular-nums">{(value as string) ?? '—'}</span>
       ),
     },
-    // The Agent column is redundant inside a single agent's Schedule tab, so it's dropped
+    // The Agent column is redundant inside a single agent's Outbound Calls tab, so it's dropped
     // when the view is agent-scoped (see `visibleColumns` below).
     {
       key: 'agent_name',
@@ -247,16 +247,17 @@ export default function ScheduledCallsPage({ agentId }: ScheduledCallsPageProps 
 
   const selectedCount = selectedIds.size;
 
-  // Agent-scoped view (agent Schedule tab) hides the repeating Agent column.
+  // Agent-scoped view (agent Outbound Calls tab) hides the repeating Agent column.
   const visibleColumns = agentId ? columns.filter((c) => c.key !== 'agent_name') : columns;
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-6">
       <div className="flex items-center justify-between">
         <div className="space-y-1">
-          <h1 className="text-xl font-semibold tracking-tight">Scheduled Calls</h1>
+          <h1 className="text-xl font-semibold tracking-tight">Outbound Calls</h1>
           <p className="text-sm text-muted-foreground">
-            Outbound calls queued to dial at a future time. Connected calls appear in Call History.
+            Place outbound calls now or schedule them for later. Connected calls appear in Call
+            History.
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -265,7 +266,7 @@ export default function ScheduledCallsPage({ agentId }: ScheduledCallsPageProps 
             icon={<PhoneOutgoing className="size-4" />}
             onClick={() => setCreateOpen(true)}
           >
-            Schedule Call
+            New Outbound Call
           </CustomButton>
         </div>
       </div>
@@ -299,13 +300,13 @@ export default function ScheduledCallsPage({ agentId }: ScheduledCallsPageProps 
           <div className="flex flex-col items-center gap-3 py-12 text-center">
             <PhoneOutgoing className="size-8 text-muted-foreground/60" aria-hidden />
             <div>
-              <p className="font-medium">No scheduled calls</p>
+              <p className="font-medium">No outbound calls yet</p>
               <p className="text-sm text-muted-foreground">
-                Queue a call to dial at a future time.
+                Place a call now or schedule one for later.
               </p>
             </div>
             <CustomButton type="primary" onClick={() => setCreateOpen(true)}>
-              Schedule Call
+              New Outbound Call
             </CustomButton>
           </div>
         }


### PR DESCRIPTION
## What

Renames the user-facing "Schedule" surface to **"Outbound Calls"** across the agent editor and the scheduled-calls page.

Changed strings:
- Agent nav label: `Schedule` → `Outbound Calls` (`sectionNav.ts`)
- Page heading + subtext, empty-state text, and buttons (`Schedule Call` → `New Outbound Call`) in `ScheduledCallsPage.tsx`
- Success toast copy in `NewOutboundCallModal.tsx`
- Multi-number helper text ("shown on Scheduled Calls" → "shown on Outbound Calls")
- Doc comments referencing the tab

## Why

Consistent product terminology — the surface now supports placing calls immediately as well as scheduling, so "Outbound Calls" better describes it than "Schedule".

## Scope / safety

Cosmetic only. No logic, control flow, routing, or data handling changed. The navigation `key: 'schedule'` is preserved, so section gating and the `agentId`-scoped list/create-modal wiring are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)